### PR TITLE
cleanup project and routes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ __pycache__/
 *.so
 .Python
 env/
+.venv/
 build/
 develop-eggs/
 dist/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+## 2026-02-21
+
+- removed duplicate `medJournalRoutes` mount in `server.js` — it was registered twice and the second one skipped auth
+- cleaned logs in `server.js`
+- `routes/nba.js` — `/teams` and `/players` were still using a hardcoded season string, swapped to `getCurrentSeason()`
+- fixed wrong arg order in `constructor-points/:year/:round`
+- standardised all F1 routes to go through `runPythonScriptQueued`, pulled repeated timeout handling into `handleQueuedRoute`
+- removed the `/debug-python` enpoint from f1 routes, shouldn't be exposed in prod
+- renamed `GET /clear-cache` to `DELETE /cache` and added `checkJwt`
+- added `checkJwt` to the schema inspection routes in `db.js` (`/tables`, `/table/:tableName`)
+- removed deprecated `calculateSprintPoints` function in `fantasy.js`, also moved the inline python script to its own file
+- added `.venv/` to `.gitignore`
+- updated readme and this changelog

--- a/README.md
+++ b/README.md
@@ -1,111 +1,183 @@
-# F1 API
+# Portfolio API
 
-Trial F1 used for implementing/testing Portfolio site. (located currently at paulsumido.com)
+Backend REST API for [paulsumido.com](https://paulsumido.com). Built with Node.js/Express, PostgreSQL, and Python (FastF1). Deployed on Railway.
+
+## Tech Stack
+
+- **Runtime**: Node.js 18+
+- **Framework**: Express
+- **Database**: PostgreSQL (via `pg`)
+- **Auth**: Auth0 (JWT via `express-oauth2-jwt-bearer`)
+- **Storage**: AWS S3 (image uploads)
+- **AI**: OpenAI GPT (summarization)
+- **Data**: Python + FastF1 (F1 telemetry), NBA Stats API proxy
+- **Deployment**: Railway + Docker
 
 ## Features
 
-- Race schedules
-- Session results (qualifying/race)
-- Driver telemetry
-- Fastest laps
-- Weather data
-- Best lap analysis
+| Feature | Description |
+|---|---|
+| NBA | Live standings, team rosters, and player stats via NBA Stats API |
+| F1 | Race schedules, results, telemetry, weather, and championship points via FastF1 |
+| Fantasy F1 | Custom fantasy scoring engine based on qualifying, race results, and overtakes |
+| YouTube | Recent videos from a YouTube channel via RSS feed |
+| Gallery | Authenticated image upload/delete with S3 storage and Sharp optimization |
+| Medical Journal | Protected CRUD journal for medical rotations (Auth0-gated) |
+| Feedback | Rotation feedback linked to journal entries |
+| ChatGPT | OpenAI-powered chat and journal entry summarization (Auth0-gated) |
+| Forum / Markers | Post forum and geolocation markers stored in PostgreSQL |
 
 ## API Endpoints
 
-- `GET /api/f1/schedule/:year` - Get race schedule for a specific season
-- `GET /api/f1/results/:year/:round/:session` - Get session results
-- `GET /api/f1/telemetry/:year/:round/:session/:driver/:lap` - Get driver telemetry
-- `GET /api/f1/fastest-laps/:year/:round/:session` - Get fastest laps
-- `GET /api/f1/best-lap/:year/:round/:session/:driver` - Get driver's best lap
-- `GET /api/f1/weather/:year/:round/:session` - Get session weather data
+### NBA — `/api/nba`
+
+| Method | Path | Description |
+|---|---|---|
+| GET | `/teams` | Current season standings |
+| GET | `/players/:teamId` | Roster for a team |
+| GET | `/stats/:playerId` | Player stats for the current season |
+
+### F1 — `/api/f1`
+
+| Method | Path | Description |
+|---|---|---|
+| GET | `/schedule/:year` | Race schedule for a season |
+| GET | `/results/:year/:round/:session` | Session results (Q/R) |
+| GET | `/telemetry/:year/:round/:session/:driver/:lap` | Driver telemetry |
+| GET | `/fastest-laps/:year/:round/:session` | Fastest laps |
+| GET | `/best-lap/:year/:round/:session/:driver` | Driver's best lap |
+| GET | `/weather/:year/:round/:session` | Session weather |
+| GET | `/driver-points/:year` | Driver championship standings |
+| GET | `/constructor-points/:year` | Constructor standings |
+| GET | `/driver-points/:year/:round` | Standings after a round |
+| GET | `/constructor-points/:year/:round` | Constructor standings after a round |
+| GET | `/driver-points-per-race/:year` | Points breakdown per race |
+| GET | `/constructor-points-per-race/:year` | Constructor breakdown per race |
+| GET | `/driver-points-per-race/:year/:round` | Driver points up to a round |
+| GET | `/constructor-points-per-race/:year/:round` | Constructor points up to a round |
+| GET | `/queue-status` | Current Python script queue status |
+| DELETE | `/cache` | Clear FastF1 cache (requires auth) |
+
+### Fantasy F1 — `/api/fantasy`
+
+| Method | Path | Description |
+|---|---|---|
+| GET | `/points/:year/:round` | Fantasy points for all drivers in a race |
+
+### YouTube — `/api/youtube`
+
+| Method | Path | Description |
+|---|---|---|
+| GET | `/recent?channel_id=<id>` | Recent videos from a channel |
+
+### Gallery — `/api/gallery`
+
+| Method | Path | Auth | Description |
+|---|---|---|---|
+| GET | `/` | — | Paginated gallery items |
+| POST | `/` | Required | Upload an image |
+| DELETE | `/:id` | Required | Delete an image |
+
+### Medical Journal — `/api/med-journal` *(Auth Required)*
+
+| Method | Path | Description |
+|---|---|---|
+| GET | `/entries` | Paginated journal entries (with search/filter) |
+| GET | `/edit-entry/:id` | Fetch a single entry |
+| POST | `/save-entry` | Create or update an entry |
+| DELETE | `/delete-entry/:id` | Delete an entry |
+
+### Feedback — `/api/feedback` *(Auth Required)*
+
+| Method | Path | Description |
+|---|---|---|
+| GET | `/` | Paginated feedback (with search/rotation filter) |
+| POST | `/` | Add feedback |
+| PUT | `/:id` | Update feedback |
+| DELETE | `/:id` | Delete feedback |
+
+### ChatGPT — `/api/chatgpt` *(Auth Required)*
+
+| Method | Path | Description |
+|---|---|---|
+| POST | `/` | Chat completion |
+| POST | `/summarize` | Reword text for medical journal |
+
+### General — `/api`
+
+| Method | Path | Auth | Description |
+|---|---|---|---|
+| GET | `/postforum` | — | Fetch all forum posts |
+| POST | `/postforum` | — | Create a forum post |
+| GET | `/markers` | — | Fetch all map markers |
+| POST | `/markers` | — | Add a map marker |
+| DELETE | `/markers/:id` | — | Delete a marker |
+| GET | `/tables` | Required | List database tables |
+| GET | `/table/:tableName` | Required | Inspect table schema |
 
 ## Local Development
 
 ### Prerequisites
 
 - Node.js >= 18
-- Python 3
+- Python 3.10+
+- PostgreSQL
 - Docker (optional)
 
 ### Setup
 
-1. Clone the repository:
-
 ```bash
+# Clone
 git clone <repository-url>
-cd f1-api
-```
+cd portfolio_api
 
-2. Install dependencies:
-
-```bash
-# Install Node.js dependencies
+# Install Node dependencies
 npm install
 
 # Install Python dependencies
 pip install -r requirements.txt
+
+# Copy and fill in environment variables
+cp .env.example .env
 ```
 
-3. Create .env file:
+### Environment Variables
 
-```bash
+```env
 PORT=3001
 NODE_ENV=development
+
+# Database
+DATABASE_URL=postgresql://user:pass@localhost:5432/portfolio
+
+# Auth0
+NEXT_PUBLIC_AUTH0_AUDIENCE=
+NEXT_PUBLIC_AUTH0_ISSUER_BASE_URL=
+
+# AWS S3
+AWS_ACCESS_KEY_ID=
+AWS_SECRET_ACCESS_KEY=
+AWS_REGION=
+AWS_S3_BUCKET_NAME=
+
+# OpenAI
+OPENAI_API_KEY=
 ```
 
-4. Run the development server:
+### Run
 
 ```bash
 npm run dev
 ```
 
-### Using Docker
-
-1. Build the image:
+### Docker
 
 ```bash
-docker build -t f1-api .
+docker compose up
 ```
 
-2. Run the container:
+## Deployment
 
-```bash
-docker run -p 3001:3001 --env-file .env f1-api
-```
+The app is deployed on [Railway](https://railway.app) using the included `Dockerfile`. Environment variables are configured in the Railway dashboard.
 
-## Railway Deployment
-
-1. Push your code to GitHub
-
-2. Create a new project on Railway and connect your repository
-
-3. Enable "Deploy from Dockerfile" in project settings
-
-4. Set environment variables in Railway dashboard:
-
-   - `PORT`
-   - `NODE_ENV`
-
-5. Deploy!
-
-## Cache
-
-FastF1 uses a cache to improve performance. The cache is stored in `cache/fastf1/`. In the Docker environment, this directory is created during build.
-
-## Error Handling
-
-The API includes comprehensive error handling:
-
-- Python script errors
-- JSON parsing errors
-- FastF1 API errors
-- Invalid parameters
-
-## Contributing
-
-1. Fork the repository
-2. Create your feature branch
-3. Commit your changes
-4. Push to the branch
-5. Create a Pull Request
+FastF1 cache is stored at `/tmp/fastf1_cache` in Railway environments.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "potfolio_api",
-  "version": "1.0.1",
+  "name": "portfolio_api",
+  "version": "1.1.0",
   "description": "Portfolio API with Node.js and Python",
   "main": "server.js",
   "scripts": {
@@ -16,7 +16,6 @@
     "express": "^4.18.2",
     "express-jwt": "^8.5.1",
     "express-oauth2-jwt-bearer": "^1.6.1",
-    "false": "^0.0.4",
     "helmet": "^7.0.0",
     "jwks-rsa": "^3.2.0",
     "morgan": "^1.10.0",
@@ -24,6 +23,7 @@
     "node-fetch": "2",
     "openai": "^4.98.0",
     "pg": "^8.14.1",
+    "uuid": "^9.0.0",
     "sharp": "^0.34.1",
     "xml2js": "^0.6.2"
   },

--- a/routes/db.js
+++ b/routes/db.js
@@ -1,16 +1,9 @@
 const express = require('express');
 const { pool } = require('../config/database');
+const { checkJwt } = require('../middleware/auth');
 const router = express.Router();
 
-// Log route registration
-console.log('Registering DB routes:');
-console.log('  GET /postforum');
-console.log('  POST /postforum');
-console.log('  POST /query');
-console.log('  GET /tables');
-console.log('  GET /table/:tableName');
-
-router.get("/tables", async (req, res, next) => {
+router.get("/tables", checkJwt, async (req, res, next) => {
   try {
     const result = await pool.query(`
       SELECT table_name 
@@ -23,7 +16,7 @@ router.get("/tables", async (req, res, next) => {
   }
 });
 
-router.get("/table/:tableName", async (req, res, next) => {
+router.get("/table/:tableName", checkJwt, async (req, res, next) => {
   try {
     const { tableName } = req.params;
     const result = await pool.query(`

--- a/routes/f1.js
+++ b/routes/f1.js
@@ -2,6 +2,7 @@ const express = require('express');
 const { spawn, exec } = require('child_process');
 const path = require('path');
 const fs = require('fs');
+const { checkJwt } = require('../middleware/auth');
 const router = express.Router();
 const requestQueue = require('../utils/queue');
 
@@ -10,116 +11,80 @@ const MEMORY_ERROR_MESSAGES = {
     THRESHOLD_EXCEEDED: 'Memory usage exceeded threshold',
     LOADING_ERROR: 'Memory limit exceeded while loading session data',
     PROCESSING_ERROR: 'Memory limit exceeded while processing data',
-    QUEUE_TIMEOUT: 'Request queue timeout'
+    QUEUE_TIMEOUT: 'Request queue timeout',
 };
 
 // Queue configuration
-const QUEUE_TIMEOUT = 600000; // 10 mins timeout for queued requests
-
-// Helper function to handle memory errors
-const handleMemoryError = (error, res) => {
-    if (error.includes(MEMORY_ERROR_MESSAGES.THRESHOLD_EXCEEDED) ||
-        error.includes(MEMORY_ERROR_MESSAGES.LOADING_ERROR) ||
-        error.includes(MEMORY_ERROR_MESSAGES.PROCESSING_ERROR)) {
-
-        return res.status(503).json({
-            error: 'Service temporarily unavailable',
-            details: 'The request requires more memory than currently available. Try again later or with a smaller data request.',
-            suggestion: 'Consider requesting less data or using more specific filters'
-        });
-    }
-    return false;
-};
+const QUEUE_TIMEOUT = 600000; // 10 minutes
 
 // Ensure cache directory exists
 const setupCacheDirectory = () => {
-    let cacheDir;
-
-    // Check if we're in Railway environment
-    if (process.env.RAILWAY_ENVIRONMENT) {
-        cacheDir = '/tmp/fastf1_cache';
-    } else {
-        cacheDir = path.join(__dirname, '..', 'cache', 'fastf1');
-    }
+    const cacheDir = process.env.RAILWAY_ENVIRONMENT
+        ? '/tmp/fastf1_cache'
+        : path.join(__dirname, '..', 'cache', 'fastf1');
 
     if (!fs.existsSync(cacheDir)) {
         try {
             fs.mkdirSync(cacheDir, { recursive: true });
-            console.log('FastF1 cache directory created at:', cacheDir);
         } catch (err) {
             console.error('Failed to create FastF1 cache directory:', err);
         }
     }
 
-    // Set appropriate permissions for the cache directory
     try {
         fs.chmodSync(cacheDir, '777');
-        console.log('Cache directory permissions updated');
     } catch (err) {
         console.error('Failed to update cache directory permissions:', err);
     }
 };
 
-// Setup cache directory
 setupCacheDirectory();
 
-// Ensure Python dependencies are installed
+// Ensure Python dependencies are installed on startup
 const installPythonDeps = () => {
     const requirementsPath = path.join(__dirname, '..', 'requirements.txt');
-
-    // Check if requirements.txt exists
-    if (!fs.existsSync(requirementsPath)) {
-        console.error('requirements.txt not found at:', requirementsPath);
-        return;
-    }
+    if (!fs.existsSync(requirementsPath)) return;
 
     exec('pip3 install -r requirements.txt', { cwd: path.join(__dirname, '..') }, (err, stdout, stderr) => {
         if (err) {
             console.error('Failed to install Python dependencies:', stderr);
-        } else {
-            console.log('Python dependencies installed successfully:', stdout);
         }
     });
 };
 
-// Install Python dependencies
 installPythonDeps();
 
-// Helper function to run Python scripts with memory monitoring and queuing
+// Run a Python script via the request queue
 const runPythonScriptQueued = async (scriptName, args = []) => {
     const task = () => new Promise((resolve, reject) => {
         const scriptPath = path.join(__dirname, '..', 'scripts', 'f1', scriptName);
-        const process = spawn('python3', [scriptPath, ...args]);
+        const proc = spawn('python3', [scriptPath, ...args]);
 
         let data = '';
         let error = '';
 
         const timeout = setTimeout(() => {
-            process.kill();
+            proc.kill();
             reject(new Error(MEMORY_ERROR_MESSAGES.QUEUE_TIMEOUT));
         }, QUEUE_TIMEOUT);
 
-        process.stdout.on('data', (chunk) => {
-            data += chunk.toString();
-        });
-
-        process.stderr.on('data', (chunk) => {
+        proc.stdout.on('data', (chunk) => { data += chunk.toString(); });
+        proc.stderr.on('data', (chunk) => {
             error += chunk.toString();
-            console.error('PYTHON STDERR:', error);
+            console.error('Python stderr:', error);
         });
 
-        process.on('close', (code) => {
+        proc.on('close', (code) => {
             clearTimeout(timeout);
 
             if (code !== 0 && error) {
                 try {
                     const errorData = JSON.parse(error);
                     if (errorData.memory_stats) {
-                        console.error('Memory usage stats:', errorData.memory_stats);
+                        console.error('Memory stats:', errorData.memory_stats);
                     }
                     reject(new Error(errorData.error || error));
-                } catch (e) {
-                    console.error(`Python script error (${scriptName}):`, error);
+                } catch {
                     reject(new Error(error));
                 }
                 return;
@@ -127,18 +92,15 @@ const runPythonScriptQueued = async (scriptName, args = []) => {
 
             try {
                 const jsonData = JSON.parse(data);
-
                 if (jsonData.memory_stats) {
-                    console.log('Memory usage stats:', {
+                    console.log('Memory stats:', {
                         current: `${(jsonData.memory_stats.current / 1024 / 1024).toFixed(2)}MB`,
-                        peak: `${(jsonData.memory_stats.peak / 1024 / 1024).toFixed(2)}MB`
+                        peak: `${(jsonData.memory_stats.peak / 1024 / 1024).toFixed(2)}MB`,
                     });
                     delete jsonData.memory_stats;
                 }
-
                 resolve(jsonData);
             } catch (err) {
-                console.error(`JSON parse error (${scriptName}):`, err);
                 reject(new Error('Invalid JSON from Python script'));
             }
         });
@@ -147,358 +109,141 @@ const runPythonScriptQueued = async (scriptName, args = []) => {
     return requestQueue.add(task);
 };
 
-// Middleware to add queue status to response headers
+// Middleware to expose queue status in response headers
 router.use((req, res, next) => {
     res.set({
         'X-Queue-Position': requestQueue.pendingCount,
-        'X-Active-Requests': requestQueue.activeCount
+        'X-Active-Requests': requestQueue.activeCount,
     });
     next();
 });
 
-// Debug route to test Python setup
-router.get('/debug-python', (req, res) => {
-    const py = spawn('python3', ['-c', 'import json; print(json.dumps({"status": "ok"}))']);
-    let output = '';
-    let error = '';
-
-    py.stdout.on('data', (chunk) => {
-        output += chunk.toString();
-    });
-
-    py.stderr.on('data', (chunk) => {
-        error += chunk.toString();
-        console.error('PYTHON STDERR (debug):', error);
-    });
-
-    py.on('close', (code) => {
-        if (code !== 0) {
-            return res.status(500).json({
-                error: 'Python debug script failed',
-                stderr: error
-            });
-        }
-        res.json({ message: 'Python debug successful', output: JSON.parse(output) });
-    });
-});
-
-// Get race schedule for a specific season
-router.get('/schedule/:year', async (req, res, next) => {
+// Helper to handle queue timeout responses
+const handleQueuedRoute = async (res, next, scriptName, args) => {
     try {
-        const { year } = req.params;
-        const data = await runPythonScriptQueued('get_schedule.py', [year]);
+        const data = await runPythonScriptQueued(scriptName, args);
         res.json(data);
     } catch (error) {
         if (error.message === MEMORY_ERROR_MESSAGES.QUEUE_TIMEOUT) {
             return res.status(503).json({
                 error: 'Request timeout',
-                details: 'The request took too long to process due to high server load.',
-                suggestion: 'Please try again later'
+                details: 'The request took too long due to high server load.',
+                suggestion: 'Please try again later',
             });
         }
-        console.error('F1 API Error:', error);
         next(error);
     }
+};
+
+// Race schedule
+router.get('/schedule/:year', (req, res, next) => {
+    handleQueuedRoute(res, next, 'get_schedule.py', [req.params.year]);
 });
 
-// Get session results (qualifying or race)
-router.get('/results/:year/:round/:session', async (req, res, next) => {
-    try {
-        const { year, round, session } = req.params;
-        const data = await runPythonScriptQueued('get_session_data.py', [year, round, session, 'results']);
-        res.json(data);
-    } catch (error) {
-        if (error.message === MEMORY_ERROR_MESSAGES.QUEUE_TIMEOUT) {
-            return res.status(503).json({
-                error: 'Request timeout',
-                details: 'The request took too long to process due to high server load.',
-                suggestion: 'Please try again later'
-            });
-        }
-        console.error('F1 API Error:', error);
-        next(error);
-    }
+// Session results (qualifying or race)
+router.get('/results/:year/:round/:session', (req, res, next) => {
+    const { year, round, session } = req.params;
+    handleQueuedRoute(res, next, 'get_session_data.py', [year, round, session, 'results']);
 });
 
-// Get driver telemetry for a specific lap
-router.get('/telemetry/:year/:round/:session/:driver/:lap', async (req, res, next) => {
-    try {
-        const { year, round, session, driver, lap } = req.params;
-        const data = await runPythonScriptQueued('get_session_data.py', [
-            year, round, session, 'telemetry', driver, lap
-        ]);
-        res.json(data);
-    } catch (error) {
-        console.error('F1 API Error:', error);
-        next(error);
-    }
+// Driver telemetry for a specific lap
+router.get('/telemetry/:year/:round/:session/:driver/:lap', (req, res, next) => {
+    const { year, round, session, driver, lap } = req.params;
+    handleQueuedRoute(res, next, 'get_session_data.py', [year, round, session, 'telemetry', driver, lap]);
 });
 
-// Get fastest laps for a session
-router.get('/fastest-laps/:year/:round/:session', async (req, res, next) => {
-    try {
-        const { year, round, session } = req.params;
-        const data = await runPythonScriptQueued('get_session_data.py', [
-            year, round, session, 'fastest_laps'
-        ]);
-        res.json(data);
-    } catch (error) {
-        console.error('F1 API Error:', error);
-        next(error);
-    }
+// Fastest laps for a session
+router.get('/fastest-laps/:year/:round/:session', (req, res, next) => {
+    const { year, round, session } = req.params;
+    handleQueuedRoute(res, next, 'get_session_data.py', [year, round, session, 'fastest_laps']);
 });
 
-// Get driver's best lap in a session
-router.get('/best-lap/:year/:round/:session/:driver', async (req, res, next) => {
-    try {
-        const { year, round, session, driver } = req.params;
-        const data = await runPythonScriptQueued('get_session_data.py', [
-            year, round, session, 'driver_best_lap', driver
-        ]);
-        res.json(data);
-    } catch (error) {
-        console.error('F1 API Error:', error);
-        next(error);
-    }
+// Driver's best lap in a session
+router.get('/best-lap/:year/:round/:session/:driver', (req, res, next) => {
+    const { year, round, session, driver } = req.params;
+    handleQueuedRoute(res, next, 'get_session_data.py', [year, round, session, 'driver_best_lap', driver]);
 });
 
-// Get session weather data
-router.get('/weather/:year/:round/:session', async (req, res, next) => {
-    try {
-        const { year, round, session } = req.params;
-        const data = await runPythonScriptQueued('get_session_data.py', [
-            year, round, session, 'weather'
-        ]);
-        res.json(data);
-    } catch (error) {
-        console.error('F1 API Error:', error);
-        next(error);
-    }
+// Session weather data
+router.get('/weather/:year/:round/:session', (req, res, next) => {
+    const { year, round, session } = req.params;
+    handleQueuedRoute(res, next, 'get_session_data.py', [year, round, session, 'weather']);
 });
 
-// Get driver points for a specific year
-router.get('/driver-points/:year', async (req, res, next) => {
-    try {
-        const { year } = req.params;
-        const data = await runPythonScriptQueued('get_championship_points.py', [year, 'driver']);
-        res.json(data);
-    } catch (error) {
-        console.error('F1 API Error:', error);
-        next(error);
-    }
+// Driver championship standings for a full year
+router.get('/driver-points/:year', (req, res, next) => {
+    handleQueuedRoute(res, next, 'get_championship_points.py', [req.params.year, 'driver']);
 });
 
-// Get constructor points for a specific year
-router.get('/constructor-points/:year', async (req, res, next) => {
-    try {
-        const { year } = req.params;
-        const data = await runPythonScriptQueued('get_championship_points.py', [year, 'constructor']);
-        res.json(data);
-    } catch (error) {
-        console.error('F1 API Error:', error);
-        next(error);
-    }
+// Constructor championship standings for a full year
+router.get('/constructor-points/:year', (req, res, next) => {
+    handleQueuedRoute(res, next, 'get_championship_points.py', [req.params.year, 'constructor']);
 });
 
-// Get driver points for a specific race in a year
-router.get('/driver-points/:year/:round', async (req, res, next) => {
-    try {
-        const { year, round } = req.params;
-        const data = await runPythonScriptQueued('get_championship_points.py', [year, round, 'driver']);
-        res.json(data);
-    } catch (error) {
-        console.error('F1 API Error:', error);
-        next(error);
-    }
+// Driver points after a specific round
+router.get('/driver-points/:year/:round', (req, res, next) => {
+    const { year, round } = req.params;
+    handleQueuedRoute(res, next, 'get_championship_points.py', [year, round, 'driver']);
 });
 
-// Get constructor points for a specific race in a year
-router.get('/constructor-points/:year/:round', async (req, res, next) => {
-    try {
-        const { year, round } = req.params;
-        const data = await runPythonScriptQueued('get_championship_points.py', [year, 'constructor', round]);
-        res.json(data);
-    } catch (error) {
-        console.error('F1 API Error:', error);
-        next(error);
-    }
+// Constructor points after a specific round
+router.get('/constructor-points/:year/:round', (req, res, next) => {
+    const { year, round } = req.params;
+    handleQueuedRoute(res, next, 'get_championship_points.py', [year, round, 'constructor']);
 });
 
-// Get driver points for a specific year, subdivided per race
-router.get('/driver-points-per-race/:year', async (req, res, next) => {
-    try {
-        const { year } = req.params;
-        const data = await runPythonScriptQueued('get_championship_points.py', [year, 'driver', 'per_race']);
-        res.json(data);
-    } catch (error) {
-        console.error('F1 API Error:', error);
-        next(error);
-    }
+// Driver points subdivided per race for a full year
+router.get('/driver-points-per-race/:year', (req, res, next) => {
+    handleQueuedRoute(res, next, 'get_championship_points.py', [req.params.year, 'driver', 'per_race']);
 });
 
-// Get constructor points for a specific year, subdivided per race
-router.get('/constructor-points-per-race/:year', async (req, res, next) => {
-    try {
-        const { year } = req.params;
-        const data = await runPythonScriptQueued('get_championship_points.py', [year, 'constructor', 'per_race']);
-        res.json(data);
-    } catch (error) {
-        console.error('F1 API Error:', error);
-        next(error);
-    }
+// Constructor points subdivided per race for a full year
+router.get('/constructor-points-per-race/:year', (req, res, next) => {
+    handleQueuedRoute(res, next, 'get_championship_points.py', [req.params.year, 'constructor', 'per_race']);
 });
 
-router.get('/driver-points-per-race/:year/:round', (req, res) => {
-    const year = req.params.year;
-    const round = req.params.round;
-
-    // Log the received parameters for debugging
-    console.log(`Route accessed: GET /driver-points-per-race/${year}/${round}`);
-
-    // Construct the path to the Python script
-    const scriptPath = path.join(__dirname, '..', 'scripts', 'f1', 'get_championship_points.py');
-
-    // Spawn the Python process
-    const py = spawn('python3', [scriptPath, year, round]);
-
-    let stdoutData = '';
-    let stderrData = '';
-
-    // Collect stdout data
-    py.stdout.on('data', (chunk) => {
-        stdoutData += chunk.toString();
-    });
-
-    // Collect stderr data
-    py.stderr.on('data', (chunk) => {
-        stderrData += chunk.toString();
-    });
-
-    // Handle process close
-    py.on('close', (code) => {
-        try {
-            // Extract JSON from stdoutData
-            const jsonStart = stdoutData.indexOf('{');
-            const jsonEnd = stdoutData.lastIndexOf('}');
-            if (jsonStart !== -1 && jsonEnd !== -1) {
-                const jsonStr = stdoutData.slice(jsonStart, jsonEnd + 1);
-                const result = JSON.parse(jsonStr);
-                return res.json(result);
-            } else {
-                console.error('No valid JSON found in output:', stdoutData);
-                return res.status(500).json({ error: 'Malformed response from Python script.' });
-            }
-        } catch (e) {
-            // Handle JSON parsing errors or unexpected output
-            console.error('Failed to parse Python output:', stdoutData);
-            return res.status(500).json({
-                error: 'Failed to parse Python output',
-                details: e.toString(),
-                raw_output: stdoutData,
-                stderr_logs: stderrData
-            });
-        }
-    });
+// Driver points per race up to a specific round
+router.get('/driver-points-per-race/:year/:round', (req, res, next) => {
+    const { year, round } = req.params;
+    handleQueuedRoute(res, next, 'get_championship_points.py', [year, round]);
 });
 
-router.get('/constructor-points-per-race/:year/:round', (req, res) => {
-    const year = req.params.year;
-    const round = req.params.round;
-
-    // Log the received parameters for debugging
-    console.log(`Routesss accessed: GET /constructor-points-per-race/${year}/${round}`);
-
-    // Construct the path to the Python script
-    const scriptPath = path.join(__dirname, '..', 'scripts', 'f1', 'get_championship_points.py');
-
-    // Spawn the Python process
-    const py = spawn('python3', [scriptPath, year, round, 'constructor']);
-
-    let stdoutData = '';
-    let stderrData = '';
-
-    // Collect stdout data
-    py.stdout.on('data', (chunk) => {
-        stdoutData += chunk.toString();
-    });
-
-    // Collect stderr data (but don't treat it as an error automatically)
-    py.stderr.on('data', (chunk) => {
-        stderrData += chunk.toString();
-    });
-
-    // Handle process close
-    py.on('close', (code) => {
-        try {
-            // Parse and return JSON response
-            const result = JSON.parse(stdoutData);
-            if (result.error) {
-                // If the result itself has an error field
-                return res.status(500).json({
-                    error: result.error,
-                    details: result.details || null,
-                    context: { year, round }
-                });
-            }
-            return res.json(result);
-        } catch (e) {
-            // Handle JSON parsing errors or unexpected output
-            console.error('Failed to parse Python output:', stdoutData);
-            return res.status(500).json({
-                error: 'Failed to parse Python output',
-                details: e.toString(),
-                raw_output: stdoutData,
-                stderr_logs: stderrData
-            });
-        }
-    });
+// Constructor points per race up to a specific round
+router.get('/constructor-points-per-race/:year/:round', (req, res, next) => {
+    const { year, round } = req.params;
+    handleQueuedRoute(res, next, 'get_championship_points.py', [year, round, 'constructor']);
 });
 
-// Route to clear the FastF1 cache
-router.get('/clear-cache', (req, res) => {
+// Clear the FastF1 cache (requires authentication)
+router.delete('/cache', checkJwt, (req, res) => {
     const cachePath = path.join(__dirname, '..', 'cache', 'fastf1');
 
-    // Read the contents of the cache directory
     fs.readdir(cachePath, (err, files) => {
         if (err) {
-            console.error('Failed to read cache directory:', err);
-            return res.status(500).json({ error: `Failed to read cache directory. ${err}` });
+            return res.status(500).json({ error: `Failed to read cache directory: ${err.message}` });
         }
 
-        // Delete each file in the directory
-        let deletePromises = files.map((file) => {
-            return new Promise((resolve, reject) => {
-                const filePath = path.join(cachePath, file);
-                fs.rm(filePath, { recursive: true, force: true }, (err) => {
-                    if (err) {
-                        console.error(`Failed to delete file: ${filePath}`, err);
-                        reject(err);
-                    } else {
-                        resolve();
-                    }
+        const deletePromises = files.map((file) =>
+            new Promise((resolve, reject) => {
+                fs.rm(path.join(cachePath, file), { recursive: true, force: true }, (err) => {
+                    if (err) reject(err);
+                    else resolve();
                 });
-            });
-        });
-
-        // Wait for all files to be deleted
-        Promise.all(deletePromises)
-            .then(() => {
-                console.log('Cache cleared successfully.');
-                res.json({ message: 'Cache cleared successfully' });
             })
-            .catch((err) => {
-                console.error('Failed to clear some cache files:', err);
-                res.status(500).json({ error: `Failed to clear some cache files. ${err}` });
-            });
+        );
+
+        Promise.all(deletePromises)
+            .then(() => res.json({ message: 'Cache cleared successfully' }))
+            .catch((err) => res.status(500).json({ error: `Failed to clear cache: ${err.message}` }));
     });
 });
 
-// Add queue status endpoint
+// Queue status
 router.get('/queue-status', (req, res) => {
     res.json({
         pending: requestQueue.pendingCount,
         active: requestQueue.activeCount,
-        maxConcurrent: requestQueue.maxConcurrent
+        maxConcurrent: requestQueue.maxConcurrent,
     });
 });
 

--- a/routes/fantasy.js
+++ b/routes/fantasy.js
@@ -1,85 +1,49 @@
 const express = require('express');
+const { spawn } = require('child_process');
+const path = require('path');
+
 const router = express.Router();
 
 // Scoring system
 const POINTS_SYSTEM = {
     race: {
         positions: {
-            1: 25,
-            2: 18,
-            3: 15,
-            4: 12,
-            5: 10,
-            6: 8,
-            7: 6,
-            8: 4,
-            9: 2,
-            10: 1,
-            11: 0,
-            12: 0,
-            13: 0,
-            14: 0,
-            15: 0,
-            16: 0,
-            17: 0,
-            18: 0,
-            19: 0,
-            20: 0
+            1: 25, 2: 18, 3: 15, 4: 12, 5: 10,
+            6: 8, 7: 6, 8: 4, 9: 2, 10: 1,
         },
-        positionsGained: 1, // 1 point per position gained
-        positionsLost: -1, // -1 point per position lost
-        overtakes: 1, // 1 point per overtake
-        fastestLap: 10, // 10 points for fastest lap
-        driverOfTheDay: 10, // 10 points for Driver of the Day
-        dnf: -20, // -20 points for DNF/Not Classified
-        disqualified: -20 // -20 points for disqualification
+        positionsGained: 1,
+        positionsLost: -1,
+        overtakes: 1,
+        fastestLap: 10,
+        driverOfTheDay: 10,
+        dnf: -20,
+        disqualified: -20,
     },
     qualifying: {
         Q3_appearance: 0,
         Q2_appearance: 0,
         positions: {
-            1: 10,
-            2: 9,
-            3: 8,
-            4: 7,
-            5: 6,
-            6: 5,
-            7: 4,
-            8: 3,
-            9: 2,
-            10: 1,
-        }
+            1: 10, 2: 9, 3: 8, 4: 7, 5: 6,
+            6: 5, 7: 4, 8: 3, 9: 2, 10: 1,
+        },
     },
     sprint: {
         positions: {
-            1: 8,
-            2: 7,
-            3: 6,
-            4: 5,
-            5: 4,
-            6: 3,
-            7: 2,
-            8: 1
+            1: 8, 2: 7, 3: 6, 4: 5, 5: 4, 6: 3, 7: 2, 8: 1,
         },
-        positionsGained: 1, // 1 point per position gained
-        positionsLost: -1, // -1 point per position lost
-        overtakes: 1, // 1 point per overtake
-        fastestLap: 5, // 5 points for fastest lap
-        dnf: -20, // -20 points for DNF/Not Classified
-        disqualified: -20 // -20 points for disqualification
-    }
+        positionsGained: 1,
+        positionsLost: -1,
+        overtakes: 1,
+        fastestLap: 5,
+        dnf: -20,
+        disqualified: -20,
+    },
 };
 
-/**
- * Calculate qualifying points for a driver
- * @param {Object} qualifyingResult - Driver's qualifying result
- * @returns {Object} Points breakdown and total
- */
 function calculateQualifyingPoints(qualifyingResult) {
     let points = 0;
     const breakdown = {};
 
-    // Q2 and Q3 appearance points
     if (qualifyingResult.Q2) {
         points += POINTS_SYSTEM.qualifying.Q2_appearance;
         breakdown.Q2_appearance = POINTS_SYSTEM.qualifying.Q2_appearance;
@@ -89,72 +53,60 @@ function calculateQualifyingPoints(qualifyingResult) {
         breakdown.Q3_appearance = POINTS_SYSTEM.qualifying.Q3_appearance;
     }
 
-    // Position points
-    const qualifyingPosition = qualifyingResult.position;
-    if (POINTS_SYSTEM.qualifying.positions[qualifyingPosition]) {
-        points += POINTS_SYSTEM.qualifying.positions[qualifyingPosition];
-        breakdown.position = POINTS_SYSTEM.qualifying.positions[qualifyingPosition];
+    const positionPoints = POINTS_SYSTEM.qualifying.positions[qualifyingResult.position];
+    if (positionPoints) {
+        points += positionPoints;
+        breakdown.position = positionPoints;
     }
 
     return { points, breakdown };
 }
 
-/**
- * Calculate race points for a driver
- * @param {Object} raceResult - Driver's race result
- * @param {Object} qualifyingResult - Driver's qualifying result
- * @returns {Object} Points breakdown and total
- */
 function calculateRacePoints(raceResult, qualifyingResult) {
     let points = 0;
     const breakdown = {};
+    let ignorePosLost = false;
 
-    // Position points
-    if (POINTS_SYSTEM.race.positions[raceResult.position] !== undefined) {
-        points += POINTS_SYSTEM.race.positions[raceResult.position];
-        breakdown.position = POINTS_SYSTEM.race.positions[raceResult.position];
+    const positionPoints = POINTS_SYSTEM.race.positions[raceResult.position];
+    if (positionPoints !== undefined) {
+        points += positionPoints;
+        breakdown.position = positionPoints;
     }
 
-    // Fastest lap points
     if (raceResult.fastestLap) {
         points += POINTS_SYSTEM.race.fastestLap;
         breakdown.fastestLap = POINTS_SYSTEM.race.fastestLap;
     }
 
-    // Driver of the Day points
     if (raceResult.driverOfTheDay) {
         points += POINTS_SYSTEM.race.driverOfTheDay;
         breakdown.driverOfTheDay = POINTS_SYSTEM.race.driverOfTheDay;
     }
 
-    // DNF/Not Classified penalty
-    ignorePosLost = false; // Reset ignorePosLost for
-    if (raceResult.status === 'DNF' || raceResult.status === 'Not Classified' || (raceResult.dnf && raceResult.status !== 'Lapped') || raceResult.status === 'Retired' || raceResult.status === 'Mechanical' || raceResult.status === 'Accident') {
-        ignorePosLost = true; // Ignore position lost points if DNF
+    const dnfStatuses = ['DNF', 'Not Classified', 'Retired', 'Mechanical', 'Accident'];
+    if (dnfStatuses.includes(raceResult.status) || (raceResult.dnf && raceResult.status !== 'Lapped')) {
+        ignorePosLost = true;
         points += POINTS_SYSTEM.race.dnf;
         breakdown.dnf = POINTS_SYSTEM.race.dnf;
     }
 
-    // Positions gained/lost points
     const positionsGained = qualifyingResult.position - raceResult.position;
     if (positionsGained > 0) {
         const gainedPoints = positionsGained * POINTS_SYSTEM.race.positionsGained;
         points += gainedPoints;
         breakdown.positionsGained = gainedPoints;
     } else if (positionsGained < 0 && !ignorePosLost) {
-        const lostPoints = Math.abs(positionsGained) * POINTS_SYSTEM.race.positionsLost; // Ensure lost points are negative
+        const lostPoints = Math.abs(positionsGained) * POINTS_SYSTEM.race.positionsLost;
         points += lostPoints;
         breakdown.positionsLost = lostPoints;
     }
 
-    // Overtakes made points
     if (raceResult.overtakes) {
         const overtakePoints = raceResult.overtakes * POINTS_SYSTEM.race.overtakes;
         points += overtakePoints;
         breakdown.overtakes = overtakePoints;
     }
 
-    // Disqualification penalty
     if (raceResult.status === 'Disqualified') {
         points += POINTS_SYSTEM.race.disqualified;
         breakdown.disqualified = POINTS_SYSTEM.race.disqualified;
@@ -163,247 +115,59 @@ function calculateRacePoints(raceResult, qualifyingResult) {
     return { points, breakdown };
 }
 
-/**
- * Calculate sprint points for a driver
- * @param {Object} sprintResult - Driver's sprint result
- * @returns {Object} Points breakdown and total
- */
-function calculateSprintPoints(sprintResult) {
-    let points = 0;
-    const breakdown = {};
-
-    // Sprint result position points
-    if (POINTS_SYSTEM.sprint.positions[sprintResult.position]) {
-        points += POINTS_SYSTEM.sprint.positions[sprintResult.position];
-        breakdown.position = POINTS_SYSTEM.sprint.positions[sprintResult.position];
-    }
-
-    // Positions gained/lost points
-    const positionsGained = sprintResult.startingPosition - sprintResult.position;
-    if (positionsGained > 0) {
-        const gainedPoints = positionsGained * POINTS_SYSTEM.sprint.positionsGained;
-        points += gainedPoints;
-        breakdown.positionsGained = gainedPoints;
-    } else if (positionsGained < 0) {
-        const lostPoints = positionsGained * POINTS_SYSTEM.sprint.positionsLost;
-        points += lostPoints;
-        breakdown.positionsLost = lostPoints;
-    }
-
-    // Overtakes made points
-    if (sprintResult.overtakes) {
-        const overtakePoints = sprintResult.overtakes * POINTS_SYSTEM.sprint.overtakes;
-        points += overtakePoints;
-        breakdown.overtakes = overtakePoints;
-    }
-
-    // Fastest lap points
-    if (sprintResult.fastestLap) {
-        points += POINTS_SYSTEM.sprint.fastestLap;
-        breakdown.fastestLap = POINTS_SYSTEM.sprint.fastestLap;
-    }
-
-    // DNF/Not Classified penalty
-    if (sprintResult.status === 'DNF' || sprintResult.status === 'Not Classified') {
-        points += POINTS_SYSTEM.sprint.dnf;
-        breakdown.dnf = POINTS_SYSTEM.sprint.dnf;
-    }
-
-    // Disqualification penalty
-    if (sprintResult.status === 'Disqualified') {
-        points += POINTS_SYSTEM.sprint.disqualified;
-        breakdown.disqualified = POINTS_SYSTEM.sprint.disqualified;
-    }
-
-    return { points, breakdown };
-}
-
 // Route to calculate fantasy points for a specific race
 router.get('/points/:year/:round', async (req, res) => {
-    try {
-        const { year, round } = req.params;
+    const { year, round } = req.params;
 
-        // Get race and qualifying results using FastF1
-        // Corrected Python script with proper variable interpolation
-        const pythonScript = `
-import fastf1
-import json
-import pandas as pd
+    const scriptPath = path.join(__dirname, '..', 'scripts', 'f1', 'get_fantasy_data.py');
+    const python = spawn('python3', [scriptPath, year, round]);
 
-# Enable caching
-fastf1.Cache.enable_cache('cache/fastf1')
+    let data = '';
+    let error = '';
 
-try:
-    # Load the session
-    quali = fastf1.get_session(${req.params.year}, ${req.params.round}, 'Q')
-    race = fastf1.get_session(${req.params.year}, ${req.params.round}, 'R')
+    python.stdout.on('data', (chunk) => { data += chunk; });
+    python.stderr.on('data', (chunk) => { error += chunk; });
 
-    # Load the data
-    quali.load()
-    race.load()
-
-    # Get qualifying results
-    quali_results = quali.results
-    quali_data = []
-    
-    for _, driver in quali_results.iterrows():
-        position = int(driver['Position'])
-        driver_code = driver['Abbreviation']
-        quali_data.append({
-            'driver': driver_code,
-            'position': position,
-            'Q2': not pd.isna(driver['Q2']),
-            'Q3': not pd.isna(driver['Q3'])
-        })
-
-    # Get race results
-    race_results = race.results
-    race_data = []
-
-    for _, driver in race_results.iterrows():
-        position = int(driver['Position']) if not pd.isna(driver['Position']) else None
-        driver_code = driver['Abbreviation']
-        status = driver['Status']
-
-        # Determine if the driver DNFed
-        dnf = status not in ['Finished'] and not status.startswith('+')
-
-        race_data.append({
-            'driver': driver_code,
-            'position': position,
-            'status': status,
-            'dnf': dnf,
-            'fastestLap': False,  # We'll update this next
-            'overtakes': 0  # Placeholder for overtakes
-        })
-
-    # Get fastest lap info
-    laps = race.laps
-    fastest_lap = laps.pick_fastest()
-    fastest_lap_driver = fastest_lap['Driver']
-
-    # Update fastest lap info
-    for race_entry in race_data:
-        if race_entry['driver'] == fastest_lap_driver:
-            race_entry['fastestLap'] = True
-            break
-
-    # Calculate overtakes
-    for driver in race.drivers:
-        driver_laps = race.laps.pick_drivers(driver)
-        overtakes = 0
-        for i in range(1, len(driver_laps)):
-            if driver_laps.iloc[i]['Position'] < driver_laps.iloc[i - 1]['Position']:
-                overtakes += 1
-        for race_entry in race_data:
-            if race_entry['driver'] == driver:
-                race_entry['overtakes'] = overtakes
-                break
-
-    # Prepare output
-    output = {
-        'qualifying': quali_data,
-        'race': race_data,
-        'event_info': {
-            'name': race.event['EventName'],
-            'year': ${req.params.year},
-            'round': ${req.params.round},
-            'date': str(race.date)
+    python.on('close', (code) => {
+        if (code !== 0) {
+            console.error('Fantasy data script error:', error);
+            return res.status(500).json({ error: 'Error fetching race data', details: error });
         }
-    }
 
-    print(json.dumps(output))
-except Exception as e:
-    error_output = {
-        'error': str(e),
-        'year': ${req.params.year},
-        'round': ${req.params.round}
-    }
-    print(json.dumps(error_output))
-`;
+        let results;
+        try {
+            results = JSON.parse(data);
+        } catch (err) {
+            return res.status(500).json({ error: 'Failed to parse race data', details: err.message });
+        }
 
-        // Execute Python script
-        const { spawn } = require('child_process');
-        const python = spawn('python3', ['-c', pythonScript]);
+        if (results.error) {
+            return res.status(500).json({ error: results.error });
+        }
 
-        let data = '';
-        let error = '';
+        const fantasyPoints = {};
 
-        python.stdout.on('data', (chunk) => {
-            data += chunk;
+        results.qualifying.forEach((qualiResult) => {
+            const driver = qualiResult.driver;
+            const raceResult = results.race.find((r) => r.driver === driver);
+            if (!raceResult) return;
+
+            const qualifyingPoints = calculateQualifyingPoints(qualiResult);
+            const racePoints = calculateRacePoints(raceResult, qualiResult);
+
+            fantasyPoints[driver] = {
+                total: qualifyingPoints.points + racePoints.points,
+                qualifying: qualifyingPoints,
+                race: racePoints,
+            };
         });
 
-        python.stderr.on('data', (chunk) => {
-            error += chunk;
-            // Log error immediately for debugging
-            console.log('Python Error:', chunk.toString());
+        res.json({
+            event: results.event_info,
+            points: fantasyPoints,
+            unprocessed: results,
         });
-
-        python.on('close', (code) => {
-            if (code !== 0) {
-                console.error('Python script error:', error);
-                return res.status(500).json({
-                    error: 'Error fetching race data',
-                    details: error
-                });
-            }
-
-            try {
-                // Extract JSON from the data string
-                const jsonStartIndex = data.indexOf('{');
-                const jsonEndIndex = data.lastIndexOf('}');
-                if (jsonStartIndex === -1 || jsonEndIndex === -1) {
-                    throw new Error('No JSON data found in Python script output');
-                }
-                const jsonString = data.substring(jsonStartIndex, jsonEndIndex + 1);
-
-                const results = JSON.parse(jsonString);
-
-                // Check if we got an error from Python
-                if (results.error) {
-                    return res.status(500).json({
-                        error: 'Error in Python script',
-                        details: results.error
-                    });
-                }
-
-                const fantasyPoints = {};
-
-                // Calculate points for each driver
-                results.qualifying.forEach(qualiResult => {
-                    const driver = qualiResult.driver;
-                    const raceResult = results.race.find(r => r.driver === driver);
-
-                    if (!raceResult) return;
-
-                    const qualifyingPoints = calculateQualifyingPoints(qualiResult);
-                    const racePoints = calculateRacePoints(raceResult, qualiResult);
-
-                    fantasyPoints[driver] = {
-                        total: qualifyingPoints.points + racePoints.points,
-                        qualifying: qualifyingPoints,
-                        race: racePoints
-                    };
-                });
-
-                res.json({
-                    event: results.event_info,
-                    points: fantasyPoints,
-                    unprocessed: results
-                });
-            } catch (err) {
-                console.error('Error processing results:', err);
-                res.status(500).json({
-                    error: 'Error processing results',
-                    details: err.message,
-                    data: data
-                });
-            }
-        });
-    } catch (error) {
-        console.error('Route error:', error);
-        res.status(500).json({ error: 'Internal server error' });
-    }
+    });
 });
 
 module.exports = router;

--- a/routes/nba.js
+++ b/routes/nba.js
@@ -40,8 +40,9 @@ router.get("/teams", nbaApiLimiter, async (req, res, next) => {
   try {
     const data = await getCachedData("teams", async () => {
       const startTime = Date.now();
+      const season = getCurrentSeason();
       const url =
-        "https://stats.nba.com/stats/leaguestandingsv3?LeagueID=00&Season=2024-25&SeasonType=Regular+Season";
+        `https://stats.nba.com/stats/leaguestandingsv3?LeagueID=00&Season=${season}&SeasonType=Regular+Season`;
       const response = await fetch(url, {
         headers: NBA_API.HEADERS,
       });
@@ -109,7 +110,7 @@ router.get("/players/:teamId", nbaApiLimiter, async (req, res, next) => {
     const data = await getCachedData(`team-players-${teamId}`, async () => {
       const url = new URL(`${NBA_API.BASE_URL}/commonteamroster`);
       url.searchParams.append("LeagueID", "00");
-      url.searchParams.append("Season", "2024-25");
+      url.searchParams.append("Season", getCurrentSeason());
       url.searchParams.append("TeamID", teamId.toString());
 
       const response = await fetch(url.toString(), {

--- a/scripts/f1/get_fantasy_data.py
+++ b/scripts/f1/get_fantasy_data.py
@@ -1,0 +1,85 @@
+import fastf1
+import json
+import pandas as pd
+import sys
+import os
+
+# Enable caching
+cache_dir = '/tmp/fastf1_cache' if os.environ.get('RAILWAY_ENVIRONMENT') else os.path.join(os.path.dirname(__file__), '..', '..', 'cache', 'fastf1')
+os.makedirs(cache_dir, exist_ok=True)
+fastf1.Cache.enable_cache(cache_dir)
+
+try:
+    year = int(sys.argv[1])
+    round_num = int(sys.argv[2])
+except (IndexError, ValueError):
+    print(json.dumps({'error': 'Usage: get_fantasy_data.py <year> <round>'}))
+    sys.exit(1)
+
+try:
+    quali = fastf1.get_session(year, round_num, 'Q')
+    race = fastf1.get_session(year, round_num, 'R')
+
+    quali.load()
+    race.load()
+
+    # Get qualifying results
+    quali_data = []
+    for _, driver in quali.results.iterrows():
+        quali_data.append({
+            'driver': driver['Abbreviation'],
+            'position': int(driver['Position']),
+            'Q2': not pd.isna(driver['Q2']),
+            'Q3': not pd.isna(driver['Q3']),
+        })
+
+    # Get race results
+    race_data = []
+    for _, driver in race.results.iterrows():
+        position = int(driver['Position']) if not pd.isna(driver['Position']) else None
+        status = driver['Status']
+        dnf = status not in ['Finished'] and not status.startswith('+')
+        race_data.append({
+            'driver': driver['Abbreviation'],
+            'position': position,
+            'status': status,
+            'dnf': dnf,
+            'fastestLap': False,
+            'overtakes': 0,
+        })
+
+    # Determine fastest lap driver
+    fastest_lap_driver = race.laps.pick_fastest()['Driver']
+    for entry in race_data:
+        if entry['driver'] == fastest_lap_driver:
+            entry['fastestLap'] = True
+            break
+
+    # Count overtakes per driver
+    for driver_code in race.drivers:
+        driver_laps = race.laps.pick_drivers(driver_code)
+        overtakes = sum(
+            1 for i in range(1, len(driver_laps))
+            if driver_laps.iloc[i]['Position'] < driver_laps.iloc[i - 1]['Position']
+        )
+        for entry in race_data:
+            if entry['driver'] == driver_code:
+                entry['overtakes'] = overtakes
+                break
+
+    output = {
+        'qualifying': quali_data,
+        'race': race_data,
+        'event_info': {
+            'name': race.event['EventName'],
+            'year': year,
+            'round': round_num,
+            'date': str(race.date),
+        },
+    }
+
+    print(json.dumps(output))
+
+except Exception as e:
+    print(json.dumps({'error': str(e), 'year': year, 'round': round_num}))
+    sys.exit(1)


### PR DESCRIPTION
# Changelog

## 2026-02-21

- removed duplicate `medJournalRoutes` mount in `server.js` — it was registered twice and the second one skipped auth
- cleaned logs in `server.js`
- `routes/nba.js` — `/teams` and `/players` were still using a hardcoded season string, swapped to `getCurrentSeason()`
- fixed wrong arg order in `constructor-points/:year/:round`
- standardised all F1 routes to go through `runPythonScriptQueued`, pulled repeated timeout handling into `handleQueuedRoute`
- removed the `/debug-python` enpoint from f1 routes, shouldn't be exposed in prod
- renamed `GET /clear-cache` to `DELETE /cache` and added `checkJwt`
- added `checkJwt` to the schema inspection routes in `db.js` (`/tables`, `/table/:tableName`)
- removed deprecated `calculateSprintPoints` function in `fantasy.js`, also moved the inline python script to its own file
- added `.venv/` to `.gitignore`
- updated readme and this changelog