### PR TITLE
update with web vitals functionality for storing and retriving important web vitals from front end

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 2026-02-26
+
+- added `web_vitals` table to track real-user Core Web Vitals (LCP, CLS, FCP, INP, TTFB) from the frontend
+- `POST /api/vitals` is open (no auth) — vitals aren't sensitive, anonymous collection is standard; validates metric name against a whitelist and rejects unknown values
+- `GET /api/vitals/summary` returns P75 + good/needs-improvement/poor counts per metric using `PERCENTILE_CONT(0.75)` — Postgres handles the percentile math natively, no application-layer sorting needed
+- `GET /api/vitals/by-page` same aggregation grouped by pathname first, min 5 samples per page to keep single-visit noise out of the numbers; results sorted by total page traffic descending
+- both GET routes require `checkJwt` — the aggregate view is only meaningful to the site owner
+- `scripts/vitals/migrate.js` creates the table and three indexes (metric, page, created_at) — same pattern as the calendar migration
+
 ## 2026-02-23
 
 - added calendar feature — create and manage personal events, Auth0-gated with dates stored and returned in UTC

--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ Backend REST API for [paulsumido.com](https://paulsumido.com). Built with Node.j
 | Medical Journal | Protected CRUD journal for medical rotations (Auth0-gated)                      |
 | Feedback        | Rotation feedback linked to journal entries (Auth0-gated)                       |
 | ChatGPT         | OpenAI-powered chat and journal entry summarization (Auth0-gated)               |
-| Calendar        | Personal calendar events stored in PostgreSQL (Auth0-gated) — _in progress_     |
+| Calendar        | Personal calendar events with Pokémon TCG card associations (Auth0-gated)       |
+| Web Vitals      | Real-user Core Web Vitals collection and P75 aggregation (open POST, auth GET)  |
 | Forum / Markers | Post forum and geolocation markers stored in PostgreSQL                         |
 
 ## API Endpoints
@@ -103,7 +104,7 @@ Backend REST API for [paulsumido.com](https://paulsumido.com). Built with Node.j
 | POST   | `/`          | Chat completion                 |
 | POST   | `/summarize` | Reword text for medical journal |
 
-### Calendar — `/api/calendar` _(Auth Required, in progress)_
+### Calendar — `/api/calendar` _(Auth Required)_
 
 | Method | Path                         | Description                                                                                         |
 | ------ | ---------------------------- | --------------------------------------------------------------------------------------------------- |
@@ -116,6 +117,14 @@ Backend REST API for [paulsumido.com](https://paulsumido.com). Built with Node.j
 | POST   | `/events/:id/cards`          | Add a card to an event (`cardId`, `cardName` required; metadata denormalized from TCGdex at insert) |
 | PUT    | `/events/:id/cards/:entryId` | Update `quantity` or `notes` on a card entry                                                        |
 | DELETE | `/events/:id/cards/:entryId` | Remove a card from an event                                                                         |
+
+### Web Vitals — `/api/vitals`
+
+| Method | Path | Auth | Description |
+| ------ | ---- | ---- | ----------- |
+| POST | `/` | — | Ingest a Core Web Vitals metric (LCP, CLS, FCP, INP, TTFB) |
+| GET | `/summary` | Required | P75 + good/needs-improvement/poor counts per metric |
+| GET | `/by-page` | Required | Same aggregation grouped by pathname (min 5 samples per page) |
 
 ### General — `/api`
 
@@ -221,6 +230,9 @@ node scripts/calendar/migrate.js
 
 # Create event_cards junction table (TCG card ↔ event)
 node scripts/calendar/migrate_tcg.js
+
+# Create web_vitals table
+node scripts/vitals/migrate.js
 ```
 
 ### Tests

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portfolio_api",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "Portfolio API with Node.js and Python",
   "main": "server.js",
   "scripts": {

--- a/routes/vitals.js
+++ b/routes/vitals.js
@@ -1,0 +1,142 @@
+const express = require("express");
+const { pool } = require("../config/database");
+const { checkJwt } = require("../middleware/auth");
+
+const router = express.Router();
+
+// only these five names are valid — anything else is a misconfigured reporter
+const VALID_METRICS = new Set(["LCP", "CLS", "FCP", "INP", "TTFB"]);
+const VALID_RATINGS = new Set(["good", "needs-improvement", "poor"]);
+
+// pages with fewer than this many samples are excluded from the by-page breakdown
+// to avoid one-visit noise skewing the numbers
+const MIN_PAGE_SAMPLES = 5;
+
+// POST /api/vitals
+// open ingestion, no auth — vitals are non-sensitive and anonymous collection is fine
+router.post("/", async (req, res) => {
+  const { metric, value, rating, page, nav_type } = req.body;
+
+  if (!metric || value === undefined || value === null || !rating || !page) {
+    return res
+      .status(400)
+      .json({ error: "metric, value, rating, and page are required" });
+  }
+
+  if (!VALID_METRICS.has(metric)) {
+    return res.status(400).json({
+      error: `metric must be one of: ${[...VALID_METRICS].join(", ")}`,
+    });
+  }
+
+  if (!VALID_RATINGS.has(rating)) {
+    return res.status(400).json({
+      error: `rating must be one of: ${[...VALID_RATINGS].join(", ")}`,
+    });
+  }
+
+  if (typeof value !== "number") {
+    return res.status(400).json({ error: "value must be a number" });
+  }
+
+  try {
+    const result = await pool.query(
+      `INSERT INTO web_vitals (metric, value, rating, page, nav_type)
+       VALUES ($1, $2, $3, $4, $5)
+       RETURNING *`,
+      [metric, value, rating, page, nav_type ?? null],
+    );
+    res.status(201).json(result.rows[0]);
+  } catch (err) {
+    console.error("POST /vitals failed:", err.message);
+    res.status(500).json({ error: "Failed to store vital" });
+  }
+});
+
+// GET /api/vitals/summary
+// P75 value + rating distribution + total count per metric — auth required
+router.get("/summary", checkJwt, async (req, res) => {
+  try {
+    const result = await pool.query(`
+      SELECT
+        metric,
+        PERCENTILE_CONT(0.75) WITHIN GROUP (ORDER BY value) AS p75,
+        COUNT(*) FILTER (WHERE rating = 'good')              AS good,
+        COUNT(*) FILTER (WHERE rating = 'needs-improvement') AS needs_improvement,
+        COUNT(*) FILTER (WHERE rating = 'poor')              AS poor,
+        COUNT(*)                                             AS total
+      FROM web_vitals
+      GROUP BY metric
+    `);
+
+    // pivot rows into { LCP: { p75, good, needsImprovement, poor, total }, ... }
+    const summary = {};
+    for (const row of result.rows) {
+      summary[row.metric] = {
+        p75: parseFloat(row.p75),
+        good: parseInt(row.good, 10),
+        needsImprovement: parseInt(row.needs_improvement, 10),
+        poor: parseInt(row.poor, 10),
+        total: parseInt(row.total, 10),
+      };
+    }
+
+    res.json({ summary });
+  } catch (err) {
+    console.error("GET /vitals/summary failed:", err.message);
+    res.status(500).json({ error: "Failed to fetch vitals summary" });
+  }
+});
+
+// GET /api/vitals/by-page
+// same aggregation but grouped by page first; pages under MIN_PAGE_SAMPLES are excluded
+// so one-off visits don't show up as permanent data points — auth required
+router.get("/by-page", checkJwt, async (req, res) => {
+  try {
+    const result = await pool.query(
+      `
+      WITH page_totals AS (
+        SELECT page, COUNT(*) AS total
+        FROM web_vitals
+        GROUP BY page
+        HAVING COUNT(*) >= $1
+      )
+      SELECT
+        w.page,
+        w.metric,
+        PERCENTILE_CONT(0.75) WITHIN GROUP (ORDER BY w.value) AS p75,
+        COUNT(*)                                               AS count,
+        pt.total                                               AS page_total
+      FROM web_vitals w
+      JOIN page_totals pt ON pt.page = w.page
+      GROUP BY w.page, w.metric, pt.total
+      ORDER BY pt.total DESC, w.page, w.metric
+      `,
+      [MIN_PAGE_SAMPLES],
+    );
+
+    // reshape flat rows into [{page, total, metrics: {LCP: {p75, count}, ...}}]
+    // sorted by total samples so busiest pages come first
+    const pageMap = {};
+    for (const row of result.rows) {
+      if (!pageMap[row.page]) {
+        pageMap[row.page] = {
+          page: row.page,
+          total: parseInt(row.page_total, 10),
+          metrics: {},
+        };
+      }
+      pageMap[row.page].metrics[row.metric] = {
+        p75: parseFloat(row.p75),
+        count: parseInt(row.count, 10),
+      };
+    }
+
+    res.json({ byPage: Object.values(pageMap) });
+  } catch (err) {
+    console.error("GET /vitals/by-page failed:", err.message);
+    res.status(500).json({ error: "Failed to fetch vitals by page" });
+  }
+});
+
+module.exports = router;

--- a/scripts/vitals/migrate.js
+++ b/scripts/vitals/migrate.js
@@ -1,0 +1,57 @@
+require("dotenv").config();
+
+const { Pool } = require("pg");
+
+const pool = new Pool({
+  connectionString: process.env.DATABASE_URL,
+  ssl:
+    process.env.NODE_ENV === "production" ? { rejectUnauthorized: false } : false,
+});
+
+async function migrate() {
+  const client = await pool.connect();
+  try {
+    console.log("Running web_vitals migration...");
+
+    await client.query(`
+      CREATE TABLE IF NOT EXISTS web_vitals (
+        id          UUID             PRIMARY KEY DEFAULT gen_random_uuid(),
+        metric      TEXT             NOT NULL,
+        value       DOUBLE PRECISION NOT NULL,
+        rating      TEXT             NOT NULL,
+        page        TEXT             NOT NULL,
+        nav_type    TEXT,
+        created_at  TIMESTAMPTZ      NOT NULL DEFAULT NOW()
+      );
+    `);
+    console.log("Created table: web_vitals");
+
+    await client.query(`
+      CREATE INDEX IF NOT EXISTS idx_web_vitals_metric
+        ON web_vitals(metric);
+    `);
+    console.log("Created index: idx_web_vitals_metric");
+
+    await client.query(`
+      CREATE INDEX IF NOT EXISTS idx_web_vitals_page
+        ON web_vitals(page);
+    `);
+    console.log("Created index: idx_web_vitals_page");
+
+    await client.query(`
+      CREATE INDEX IF NOT EXISTS idx_web_vitals_created_at
+        ON web_vitals(created_at);
+    `);
+    console.log("Created index: idx_web_vitals_created_at");
+
+    console.log("Migration complete.");
+  } catch (err) {
+    console.error("Migration failed:", err.message);
+    process.exit(1);
+  } finally {
+    client.release();
+    await pool.end();
+  }
+}
+
+migrate();

--- a/server.js
+++ b/server.js
@@ -19,6 +19,7 @@ const medJournalRoutes = require("./routes/med-journal");
 const feedbackRoutes = require("./routes/feedback");
 const chatgptRoutes = require("./routes/chat-gpt");
 const calendarRoutes = require("./routes/calendar");
+const vitalsRoutes = require("./routes/vitals");
 
 const app = express();
 const port = process.env.PORT || 3001;
@@ -65,6 +66,7 @@ app.use("/api/med-journal", medJournalRoutes);
 app.use("/api/feedback", feedbackRoutes);
 app.use("/api/chatgpt", chatgptRoutes);
 app.use("/api/calendar", calendarRoutes);
+app.use("/api/vitals", vitalsRoutes);
 app.use("/api", dbRoutes);
 
 // Error handling middleware


### PR DESCRIPTION
# Changelog

## 2026-02-26

- added `web_vitals` table to track real-user Core Web Vitals (LCP, CLS, FCP, INP, TTFB) from the frontend
- `POST /api/vitals` is open (no auth) — vitals aren't sensitive, anonymous collection is standard; validates metric name against a whitelist and rejects unknown values
- `GET /api/vitals/summary` returns P75 + good/needs-improvement/poor counts per metric using `PERCENTILE_CONT(0.75)` — Postgres handles the percentile math natively, no application-layer sorting needed
- `GET /api/vitals/by-page` same aggregation grouped by pathname first, min 5 samples per page to keep single-visit noise out of the numbers; results sorted by total page traffic descending
- both GET routes require `checkJwt` — the aggregate view is only meaningful to the site owner
- `scripts/vitals/migrate.js` creates the table and three indexes (metric, page, created_at) — same pattern as the calendar migration
