### PR TITLE
Develop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 2026-02-27
+
+- added `app_version` column (`VARCHAR(20) NOT NULL DEFAULT 'unknown'`) to `web_vitals` table — run `node scripts/vitals/migrate.js` to apply
+- `POST /api/vitals` now stores `app_version` from the request body (defaults to `'unknown'` if omitted, so old clients continue to work)
+- `GET /api/vitals/summary` accepts `?v=X.Y.Z` and filters to rows from that version onwards; uses `string_to_array(app_version, '.')::int[]` for correct semver ordering (`0.10.0 > 0.9.0`)
+- `GET /api/vitals/by-page` same version filter applied to both the CTE and the outer join
+- `GET /api/vitals/versions` — new endpoint returning distinct `app_version` values sorted newest-first (excludes `'unknown'` rows); auth required
+
 ## 2026-02-26
 
 - added `web_vitals` table to track real-user Core Web Vitals (LCP, CLS, FCP, INP, TTFB) from the frontend

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Backend REST API for [paulsumido.com](https://paulsumido.com). Built with Node.j
 | Feedback        | Rotation feedback linked to journal entries (Auth0-gated)                       |
 | ChatGPT         | OpenAI-powered chat and journal entry summarization (Auth0-gated)               |
 | Calendar        | Personal calendar events with Pokémon TCG card associations (Auth0-gated)       |
-| Web Vitals      | Real-user Core Web Vitals collection and P75 aggregation (open POST, auth GET)  |
+| Web Vitals      | Real-user Core Web Vitals collection, P75 aggregation, and per-version filtering |
 | Forum / Markers | Post forum and geolocation markers stored in PostgreSQL                         |
 
 ## API Endpoints
@@ -122,9 +122,10 @@ Backend REST API for [paulsumido.com](https://paulsumido.com). Built with Node.j
 
 | Method | Path | Auth | Description |
 | ------ | ---- | ---- | ----------- |
-| POST | `/` | — | Ingest a Core Web Vitals metric (LCP, CLS, FCP, INP, TTFB) |
-| GET | `/summary` | Required | P75 + good/needs-improvement/poor counts per metric |
-| GET | `/by-page` | Required | Same aggregation grouped by pathname (min 5 samples per page) |
+| POST | `/` | — | Ingest a Core Web Vitals metric (LCP, CLS, FCP, INP, TTFB); accepts optional `app_version` |
+| GET | `/summary` | Required | P75 + good/needs-improvement/poor counts per metric; supports `?v=X.Y.Z` to filter by version |
+| GET | `/by-page` | Required | Same aggregation grouped by pathname (min 5 samples); supports `?v=X.Y.Z` |
+| GET | `/versions` | Required | Distinct `app_version` values sorted by semver descending |
 
 ### General — `/api`
 

--- a/scripts/vitals/migrate.js
+++ b/scripts/vitals/migrate.js
@@ -44,6 +44,19 @@ async function migrate() {
     `);
     console.log("Created index: idx_web_vitals_created_at");
 
+    // v0.3.1 — add app_version for version-based filtering
+    await client.query(`
+      ALTER TABLE web_vitals
+        ADD COLUMN IF NOT EXISTS app_version VARCHAR(20) NOT NULL DEFAULT 'unknown';
+    `);
+    console.log("Added column: app_version");
+
+    await client.query(`
+      CREATE INDEX IF NOT EXISTS idx_web_vitals_app_version
+        ON web_vitals(app_version);
+    `);
+    console.log("Created index: idx_web_vitals_app_version");
+
     console.log("Migration complete.");
   } catch (err) {
     console.error("Migration failed:", err.message);


### PR DESCRIPTION
# Changelog

## 2026-02-27

- added `app_version` column (`VARCHAR(20) NOT NULL DEFAULT 'unknown'`) to `web_vitals` table — run `node scripts/vitals/migrate.js` to apply
- `POST /api/vitals` now stores `app_version` from the request body (defaults to `'unknown'` if omitted, so old clients continue to work)
- `GET /api/vitals/summary` accepts `?v=X.Y.Z` and filters to rows from that version onwards; uses `string_to_array(app_version, '.')::int[]` for correct semver ordering (`0.10.0 > 0.9.0`)
- `GET /api/vitals/by-page` same version filter applied to both the CTE and the outer join
- `GET /api/vitals/versions` — new endpoint returning distinct `app_version` values sorted newest-first (excludes `'unknown'` rows); auth required
