### PR TITLE
update vitals query (#22)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2026-02-28
+
+- `GET /api/vitals/versions` — fixed bug where the endpoint always returned an empty array; `SELECT DISTINCT ... ORDER BY string_to_array(...)` fails in PostgreSQL because the ORDER BY expression must appear in the SELECT list when using DISTINCT; switched to `GROUP BY` which deduplicates the same way but allows arbitrary ORDER BY expressions
+
 ## 2026-02-27
 
 - added `app_version` column (`VARCHAR(20) NOT NULL DEFAULT 'unknown'`) to `web_vitals` table — run `node scripts/vitals/migrate.js` to apply

--- a/routes/vitals.js
+++ b/routes/vitals.js
@@ -169,9 +169,10 @@ router.get("/by-page", checkJwt, async (req, res) => {
 router.get("/versions", checkJwt, async (_req, res) => {
   try {
     const result = await pool.query(`
-      SELECT DISTINCT app_version
+      SELECT app_version
       FROM web_vitals
       WHERE app_version != 'unknown'
+      GROUP BY app_version
       ORDER BY string_to_array(app_version, '.')::int[] DESC
     `);
     res.json({ versions: result.rows.map((r) => r.app_version) });


### PR DESCRIPTION
# Changelog

## 2026-02-28

- `GET /api/vitals/versions` — fixed bug where the endpoint always returned an empty array; `SELECT DISTINCT ... ORDER BY string_to_array(...)` fails in PostgreSQL because the ORDER BY expression must appear in the SELECT list when using DISTINCT; switched to `GROUP BY` which deduplicates the same way but allows arbitrary ORDER BY expressions