### PR TITLE
Develop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## 2026-02-28
 
-- `GET /api/vitals/versions` — fixed bug where the endpoint always returned an empty array; `SELECT DISTINCT ... ORDER BY string_to_array(...)` fails in PostgreSQL because the ORDER BY expression must appear in the SELECT list when using DISTINCT; switched to `GROUP BY` which deduplicates the same way but allows arbitrary ORDER BY expressions
+- `GET /api/vitals/by-version` — new endpoint returning P75 per metric for the last 5 distinct versions, sorted oldest→newest so charts render chronologically left to right; fetches top-5 versions first, then a single aggregation query using `ANY($1)` to avoid N queries
+- `GET /api/vitals/versions` — fixed bug where endpoint always returned an empty array; `SELECT DISTINCT ... ORDER BY string_to_array(...)` fails in PostgreSQL because the ORDER BY expression must appear in the SELECT list when using DISTINCT; switched to `GROUP BY` which deduplicates the same way and allows arbitrary ORDER BY expressions
 
 ## 2026-02-27
 

--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ Backend REST API for [paulsumido.com](https://paulsumido.com). Built with Node.j
 | POST | `/` | — | Ingest a Core Web Vitals metric (LCP, CLS, FCP, INP, TTFB); accepts optional `app_version` |
 | GET | `/summary` | Required | P75 + good/needs-improvement/poor counts per metric; supports `?v=X.Y.Z` to filter by version |
 | GET | `/by-page` | Required | Same aggregation grouped by pathname (min 5 samples); supports `?v=X.Y.Z` |
+| GET | `/by-version` | Required | P75 per metric for the last 5 versions, sorted oldest→newest (for trend charts) |
 | GET | `/versions` | Required | Distinct `app_version` values sorted by semver descending |
 
 ### General — `/api`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portfolio_api",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "Portfolio API with Node.js and Python",
   "main": "server.js",
   "scripts": {


### PR DESCRIPTION
# Changelog

## 2026-02-28

- `GET /api/vitals/by-version` — new endpoint returning P75 per metric for the last 5 distinct versions, sorted oldest→newest so charts render chronologically left to right; fetches top-5 versions first, then a single aggregation query using `ANY($1)` to avoid N queries