### PR TITLE
add functionality for countdowns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 2026-03-11 - version 1.1.5
+
+- added `countdowns` table to the database — stores a title, optional description, target date (plain `DATE`, no time component to avoid timezone confusion), color, and `user_sub` for ownership scoping; same auth pattern as `calendar_events`
+- added five new routes under `/api/calendar/countdowns`: list all sorted by target date, get by id, create, partial update, and delete; all require a valid Auth0 JWT and are scoped to the requesting user via `req.auth.payload.sub`
+- added `getCountdowns`, `getCountdownById`, `createCountdown`, `updateCountdown`, and `deleteCountdown` to `utils/db.js`; the partial update uses the same `colMap` pattern as `updateCalendarEvent` so only the fields you pass actually change
+- `target_date` is stored as `DATE` and returned as a `"YYYY-MM-DD"` string; pg returns `DATE` columns as strings (unlike `TIMESTAMP` which becomes a `Date` object), so `toCountdown` can use it directly with no conversion
+
 ## 2026-02-28
 
 - `GET /api/vitals/by-version` — new endpoint returning P75 per metric for the last 5 distinct versions, sorted oldest→newest so charts render chronologically left to right; fetches top-5 versions first, then a single aggregation query using `ANY($1)` to avoid N queries

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Backend REST API for [paulsumido.com](https://paulsumido.com). Built with Node.j
 | Medical Journal | Protected CRUD journal for medical rotations (Auth0-gated)                      |
 | Feedback        | Rotation feedback linked to journal entries (Auth0-gated)                       |
 | ChatGPT         | OpenAI-powered chat and journal entry summarization (Auth0-gated)               |
-| Calendar        | Personal calendar events with Pokémon TCG card associations (Auth0-gated)       |
+| Calendar        | Personal calendar events with Pokémon TCG card associations, plus countdowns (Auth0-gated) |
 | Web Vitals      | Real-user Core Web Vitals collection, P75 aggregation, and per-version filtering |
 | Forum / Markers | Post forum and geolocation markers stored in PostgreSQL                         |
 
@@ -117,6 +117,11 @@ Backend REST API for [paulsumido.com](https://paulsumido.com). Built with Node.j
 | POST   | `/events/:id/cards`          | Add a card to an event (`cardId`, `cardName` required; metadata denormalized from TCGdex at insert) |
 | PUT    | `/events/:id/cards/:entryId` | Update `quantity` or `notes` on a card entry                                                        |
 | DELETE | `/events/:id/cards/:entryId` | Remove a card from an event                                                                         |
+| GET    | `/countdowns`                | List all countdowns for the authenticated user, sorted by target date ascending                     |
+| GET    | `/countdowns/:id`            | Get a single countdown                                                                              |
+| POST   | `/countdowns`                | Create a countdown (`title` and `targetDate` required, `targetDate` as `"YYYY-MM-DD"`)             |
+| PUT    | `/countdowns/:id`            | Partial update — send only the fields to change                                                     |
+| DELETE | `/countdowns/:id`            | Delete a countdown                                                                                  |
 
 ### Web Vitals — `/api/vitals`
 
@@ -235,6 +240,9 @@ node scripts/calendar/migrate_tcg.js
 
 # Create web_vitals table
 node scripts/vitals/migrate.js
+
+# Create countdowns table
+node scripts/calendar/migrate_countdowns.js
 ```
 
 ### Tests

--- a/init.sql
+++ b/init.sql
@@ -66,6 +66,21 @@ CREATE TABLE IF NOT EXISTS calendar_events (
     updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
 );
 
+-- Create countdowns table
+-- target_date is a plain DATE (no time, no timezone) because countdowns track days, not moments.
+-- user_sub matches the pattern used by calendar_events so ownership checks are consistent.
+CREATE TABLE IF NOT EXISTS countdowns (
+    id UUID PRIMARY KEY,
+    title TEXT NOT NULL,
+    description TEXT,
+    target_date DATE NOT NULL,
+    color TEXT NOT NULL DEFAULT '#6366f1',
+    user_sub TEXT NOT NULL,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS idx_countdowns_user_sub ON countdowns(user_sub);
+
 -- Grant privileges
 GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA public TO postgres;
 GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO postgres;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portfolio_api",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "description": "Portfolio API with Node.js and Python",
   "main": "server.js",
   "scripts": {

--- a/routes/calendar.js
+++ b/routes/calendar.js
@@ -216,4 +216,108 @@ router.delete("/events/:id/cards/:entryId", async (req, res) => {
   }
 });
 
+// ---------------------------------------------------------------------------
+// Countdowns — /api/calendar/countdowns
+// ---------------------------------------------------------------------------
+
+// GET /api/calendar/countdowns
+// returns all countdowns for the authenticated user, sorted by target date
+router.get("/countdowns", async (req, res) => {
+  const userSub = req.auth.payload.sub;
+
+  try {
+    const countdowns = await db.getCountdowns(userSub);
+    res.json({ countdowns });
+  } catch (err) {
+    console.error("GET /calendar/countdowns failed:", err.message);
+    res.status(500).json({ error: "Failed to fetch countdowns" });
+  }
+});
+
+// GET /api/calendar/countdowns/:id
+// returns a single countdown, 404 if it doesn't exist or belongs to someone else
+router.get("/countdowns/:id", async (req, res) => {
+  const userSub = req.auth.payload.sub;
+  const { id } = req.params;
+
+  try {
+    const countdown = await db.getCountdownById(id, userSub);
+
+    if (!countdown) {
+      return res.status(404).json({ error: "Countdown not found" });
+    }
+
+    res.json({ countdown });
+  } catch (err) {
+    console.error("GET /calendar/countdowns/:id failed:", err.message);
+    res.status(500).json({ error: "Failed to fetch countdown" });
+  }
+});
+
+// POST /api/calendar/countdowns
+// body: { title, description?, targetDate, color? }
+router.post("/countdowns", async (req, res) => {
+  const userSub = req.auth.payload.sub;
+  const { title, description, targetDate, color } = req.body;
+
+  if (!title || !targetDate) {
+    return res.status(400).json({ error: "title and targetDate are required" });
+  }
+
+  try {
+    const countdown = await db.createCountdown(
+      { title, description, targetDate, color },
+      userSub,
+    );
+    res.status(201).json({ countdown });
+  } catch (err) {
+    console.error("POST /calendar/countdowns failed:", err.message);
+    res.status(500).json({ error: "Failed to create countdown" });
+  }
+});
+
+// PUT /api/calendar/countdowns/:id
+// partial update, only send the fields you want to change
+router.put("/countdowns/:id", async (req, res) => {
+  const userSub = req.auth.payload.sub;
+  const { id } = req.params;
+  const fields = req.body;
+
+  if (!fields || Object.keys(fields).length === 0) {
+    return res.status(400).json({ error: "No fields provided to update" });
+  }
+
+  try {
+    const countdown = await db.updateCountdown(id, fields, userSub);
+
+    if (!countdown) {
+      return res.status(404).json({ error: "Countdown not found" });
+    }
+
+    res.json({ countdown });
+  } catch (err) {
+    console.error("PUT /calendar/countdowns/:id failed:", err.message);
+    res.status(500).json({ error: "Failed to update countdown" });
+  }
+});
+
+// DELETE /api/calendar/countdowns/:id
+router.delete("/countdowns/:id", async (req, res) => {
+  const userSub = req.auth.payload.sub;
+  const { id } = req.params;
+
+  try {
+    const deleted = await db.deleteCountdown(id, userSub);
+
+    if (!deleted) {
+      return res.status(404).json({ error: "Countdown not found" });
+    }
+
+    res.status(204).send();
+  } catch (err) {
+    console.error("DELETE /calendar/countdowns/:id failed:", err.message);
+    res.status(500).json({ error: "Failed to delete countdown" });
+  }
+});
+
 module.exports = router;

--- a/scripts/calendar/migrate_countdowns.js
+++ b/scripts/calendar/migrate_countdowns.js
@@ -1,0 +1,45 @@
+require('dotenv').config();
+
+const { Pool } = require('pg');
+
+const pool = new Pool({
+    connectionString: process.env.DATABASE_URL,
+    ssl: process.env.NODE_ENV === 'production' ? { rejectUnauthorized: false } : false
+});
+
+async function migrate() {
+    const client = await pool.connect();
+    try {
+        console.log('Running countdowns migration...');
+
+        // target_date is DATE, not TIMESTAMPTZ, because countdowns track days not moments.
+        // Storing a plain date avoids timezone math entirely on the server side.
+        await client.query(`
+            CREATE TABLE IF NOT EXISTS countdowns (
+              id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+              user_sub TEXT NOT NULL,
+              title TEXT NOT NULL,
+              description TEXT,
+              target_date DATE NOT NULL,
+              color TEXT NOT NULL DEFAULT '#6366f1',
+              created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+            );
+        `);
+        console.log('Created table: countdowns');
+
+        await client.query(`
+            CREATE INDEX IF NOT EXISTS idx_countdowns_user_sub ON countdowns(user_sub);
+        `);
+        console.log('Created index: idx_countdowns_user_sub');
+
+        console.log('Migration complete.');
+    } catch (err) {
+        console.error('Migration failed:', err.message);
+        process.exit(1);
+    } finally {
+        client.release();
+        await pool.end();
+    }
+}
+
+migrate();

--- a/utils/db.js
+++ b/utils/db.js
@@ -735,6 +735,132 @@ async function deleteEventCard(entryId, eventId, userSub) {
   return rows[0] ? toEventCard(rows[0]) : null;
 }
 
+// ---------------------------------------------------------------------------
+// Countdowns
+// ---------------------------------------------------------------------------
+
+// Maps a raw countdowns row to the shape the frontend expects.
+// target_date comes back from pg as a "YYYY-MM-DD" string (pg does not parse
+// DATE columns into Date objects, unlike TIMESTAMP), so we can use it as-is.
+function toCountdown(row) {
+  return {
+    id: row.id,
+    title: row.title,
+    description: row.description ?? undefined,
+    targetDate: row.target_date,
+    color: row.color,
+    createdAt: row.created_at instanceof Date ? row.created_at.toISOString() : row.created_at,
+  };
+}
+
+/**
+ * Returns all countdowns for a user, sorted by target date ascending
+ * so the nearest one always comes first.
+ *
+ * @param {string} userSub - Auth0 sub
+ * @returns {Promise<Array>}
+ */
+async function getCountdowns(userSub) {
+  const { rows } = await pool.query(
+    "SELECT * FROM countdowns WHERE user_sub = $1 ORDER BY target_date ASC",
+    [userSub],
+  );
+  return rows.map(toCountdown);
+}
+
+/**
+ * Fetches a single countdown by ID. Returns null if it doesn't exist
+ * or belongs to a different user.
+ *
+ * @param {string} id
+ * @param {string} userSub
+ * @returns {Promise<Object|null>}
+ */
+async function getCountdownById(id, userSub) {
+  const { rows } = await pool.query(
+    "SELECT * FROM countdowns WHERE id = $1 AND user_sub = $2",
+    [id, userSub],
+  );
+  return rows[0] ? toCountdown(rows[0]) : null;
+}
+
+/**
+ * Creates a new countdown for the authenticated user.
+ *
+ * @param {{ title: string, description?: string, targetDate: string, color?: string }} fields
+ * @param {string} userSub
+ * @returns {Promise<Object>} the newly created row
+ */
+async function createCountdown({ title, description, targetDate, color = "#6366f1" }, userSub) {
+  const id = uuidv4();
+
+  const { rows } = await pool.query(
+    `INSERT INTO countdowns (id, title, description, target_date, color, user_sub)
+     VALUES ($1, $2, $3, $4, $5, $6)
+     RETURNING *`,
+    [id, title, description || null, targetDate, color, userSub],
+  );
+
+  return toCountdown(rows[0]);
+}
+
+/**
+ * Partially updates a countdown. Only the owner can modify it.
+ * Pass only the fields you want to change, everything else stays as-is.
+ *
+ * @param {string} id
+ * @param {{ title?: string, description?: string, targetDate?: string, color?: string }} fields
+ * @param {string} userSub
+ * @returns {Promise<Object|null>} the updated row, or null if not found
+ */
+async function updateCountdown(id, fields, userSub) {
+  const colMap = {
+    title: "title",
+    description: "description",
+    targetDate: "target_date",
+    color: "color",
+  };
+
+  const setClauses = [];
+  const values = [];
+
+  for (const [key, col] of Object.entries(colMap)) {
+    if (key in fields) {
+      values.push(fields[key]);
+      setClauses.push(`${col} = $${values.length}`);
+    }
+  }
+
+  if (setClauses.length === 0) return null;
+
+  values.push(id, userSub);
+
+  const { rows } = await pool.query(
+    `UPDATE countdowns
+     SET ${setClauses.join(", ")}
+     WHERE id = $${values.length - 1} AND user_sub = $${values.length}
+     RETURNING *`,
+    values,
+  );
+
+  return rows[0] ? toCountdown(rows[0]) : null;
+}
+
+/**
+ * Deletes a countdown by ID. Only the owner can delete it.
+ *
+ * @param {string} id
+ * @param {string} userSub
+ * @returns {Promise<Object|null>} the deleted row, or null if not found
+ */
+async function deleteCountdown(id, userSub) {
+  const { rows } = await pool.query(
+    "DELETE FROM countdowns WHERE id = $1 AND user_sub = $2 RETURNING *",
+    [id, userSub],
+  );
+  return rows[0] ? toCountdown(rows[0]) : null;
+}
+
 module.exports = {
   addGalleryItem,
   getGalleryItemById,
@@ -757,4 +883,9 @@ module.exports = {
   addEventCard,
   updateEventCard,
   deleteEventCard,
+  getCountdowns,
+  getCountdownById,
+  createCountdown,
+  updateCountdown,
+  deleteCountdown,
 };


### PR DESCRIPTION
# Changelog

## 2026-03-11 - version 1.1.5

- added `countdowns` table to the database — stores a title, optional description, target date (plain `DATE`, no time component to avoid timezone confusion), color, and `user_sub` for ownership scoping; same auth pattern as `calendar_events`
- added five new routes under `/api/calendar/countdowns`: list all sorted by target date, get by id, create, partial update, and delete; all require a valid Auth0 JWT and are scoped to the requesting user via `req.auth.payload.sub`
- added `getCountdowns`, `getCountdownById`, `createCountdown`, `updateCountdown`, and `deleteCountdown` to `utils/db.js`; the partial update uses the same `colMap` pattern as `updateCalendarEvent` so only the fields you pass actually change
- `target_date` is stored as `DATE` and returned as a `"YYYY-MM-DD"` string; pg returns `DATE` columns as strings (unlike `TIMESTAMP` which becomes a `Date` object), so `toCountdown` can use it directly with no conversion
