### PR TITLE
Develop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 2026-03-12 - version 1.2.3
+
+- added `routes/googleWebhook.js` with `POST /api/google/webhook`; receives Google Calendar push notifications (body is always empty, all info is in headers); responds 200 immediately before any async work so Google never times out waiting
+- webhook handler skips events not in our DB (identified by `google_event_id`) so Gmail events and anything created directly in Google Calendar are ignored entirely
+- conflict resolution via `updated_at`: if Google's `item.updated` timestamp is newer than our `updated_at`, we apply the change; if ours is newer we skip (our version wins)
+- cancelled events (`item.status === "cancelled"`) are deleted from our DB
+- sync token is saved before processing items so a mid-batch crash doesn't re-apply the same changes on the next notification
+- added `getEventByGoogleId(googleEventId, userSub)` to `utils/db.js`; returns the raw row including `updated_at` for conflict comparison
+- added `updateCalendarEventFromWebhook(id, fields, userSub)` to `utils/db.js`; sets `sync_source='google'` instead of `'local'` so the push sync knows to fire on the next user-driven edit
+- registered `googleWebhook` router separately from `google` router in `server.js` to keep the unauthenticated webhook route clearly separated from the JWT-protected OAuth routes
+
 ## 2026-03-11 - version 1.2.2
 
 - added `utils/googleCalendar.js` with four helpers: `createGoogleEvent`, `updateGoogleEvent`, `deleteGoogleEvent`, `fetchIncrementalEvents`; all call `getValidAccessToken` internally and return null (or no-op) when the user is not connected

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 2026-03-11 - version 1.2.0
+
+- added `google_auth` table to store per-user Google OAuth tokens (access token, refresh token, expiry, watch channel info, sync token); one row per connected user, primary key on `user_id`
+- added `google_event_id` and `sync_source` columns to `calendar_events`; `google_event_id` maps our events to their Google Calendar counterparts, `sync_source` tracks whether the last change came from us or from a Google webhook (prevents push loops); partial index on `google_event_id` where not null
+- run `node scripts/calendar/migrate_google_sync.js` to apply the schema changes
+- added Google sync helpers to `utils/db.js`: `getGoogleAuth`, `upsertGoogleAuth`, `deleteGoogleAuth`, `updateChannelInfo`, `updateSyncToken`, `setEventGoogleId`, `clearEventGoogleId`
+- added `utils/googleToken.js` with `getValidAccessToken(userId)`: returns a cached token if still valid, otherwise hits the Google token endpoint with the refresh token and stores the new one; throws if the user is not connected
+
 ## 2026-03-11 - version 1.1.6
 
 - `GET /api/calendar/countdowns` now supports cursor-based pagination; pass `?cursor=YYYY-MM-DD__<uuid>` to get the next page; the cursor is a composite of `target_date` and `id` (double-underscore separator) which makes page boundaries stable — an insert or delete between fetches doesn't shift items the way OFFSET would

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 2026-03-12 - version 1.2.4
+
+- added `registerWatch(userId)` and `stopWatch(userId)` to `utils/googleCalendar.js`; `registerWatch` POSTs to the Google watch endpoint with a 6.5-day expiry, stores the channel info via `updateChannelInfo`, then runs a full initial sync to bootstrap the sync token; `stopWatch` swallows all errors since a 404 from Google just means the channel already expired
+- replaced the stubs in `routes/google.js` with real imports from `utils/googleCalendar.js`
+- added `utils/renewWatchChannels.js`: queries `google_auth` for rows with `channel_expiry` within 24 hours, stops each old channel then re-registers; failures per user are logged and skipped so one bad token doesn't block the rest; has a `require.main` block so it can be run directly with `node utils/renewWatchChannels.js`
+- no `setInterval` added to `server.js` -- renewal runs as a Railway cron job (`0 6 * * *`) to survive deploys; the comment in `server.js` already documents this
+- added Google Calendar env vars to README (`GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`, `GOOGLE_REDIRECT_URI`, `GOOGLE_STATE_SECRET`, `GOOGLE_WEBHOOK_URL`, `FRONTEND_URL`) with notes on the webhook URL needing to be publicly reachable and ngrok for local testing
+- documented the Railway cron job setup in README (command, schedule, shared env vars)
+
 ## 2026-03-12 - version 1.2.3
 
 - added `routes/googleWebhook.js` with `POST /api/google/webhook`; receives Google Calendar push notifications (body is always empty, all info is in headers); responds 200 immediately before any async work so Google never times out waiting

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 2026-03-11 - version 1.2.1
+
+- added `routes/google.js` with four routes under `/api/google/auth`: `GET /status` (connected check), `GET /url` (generates Google OAuth URL), `GET /callback` (exchanges code for tokens, saves to DB, registers watch channel), `DELETE /disconnect` (stops watch channel, deletes tokens)
+- OAuth state param is signed with HMAC-SHA256 using `GOOGLE_STATE_SECRET` so the callback can verify which user it belongs to without storing anything server-side; `timingSafeEqual` used for comparison to avoid timing attacks
+- `prompt=consent` and `access_type=offline` are set on the authorization URL to ensure a refresh token is always returned, even for returning users
+- callback redirects to `FRONTEND_URL/protected/settings?gcal=connected` on success, `?gcal=denied` if the user declined, `?gcal=error` on failure
+- `registerWatch` and `stopWatch` are stubbed in this route (implemented in prompt 5); watch failure on connect is non-fatal, user is still connected
+- registered router at `/api/google` in `server.js`; added comment explaining why watch channel renewal is a Railway cron job, not a setInterval
+- new required env vars: `GOOGLE_STATE_SECRET`, `FRONTEND_URL`
+
 ## 2026-03-11 - version 1.2.0
 
 - added `google_auth` table to store per-user Google OAuth tokens (access token, refresh token, expiry, watch channel info, sync token); one row per connected user, primary key on `user_id`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 2026-03-11 - version 1.2.2
+
+- added `utils/googleCalendar.js` with four helpers: `createGoogleEvent`, `updateGoogleEvent`, `deleteGoogleEvent`, `fetchIncrementalEvents`; all call `getValidAccessToken` internally and return null (or no-op) when the user is not connected
+- color mapping table in `googleCalendar.js` maps our 8 EVENT_COLORS hex values to Google Calendar colorIds; defaults to "9" (blueberry) for unknown colors
+- all-day events are sent to Google with `{ date: "YYYY-MM-DD" }` start/end; timed events use `{ dateTime, timeZone: "UTC" }`; PATCH uses the same field mapping as POST
+- `deleteGoogleEvent` swallows 404s since the event may have already been deleted on the Google side
+- wired push sync into `routes/calendar.js` for the three event mutation routes: create calls `createGoogleEvent` then `setEventGoogleId`; update calls `updateGoogleEvent` with the full updated event; delete calls `deleteGoogleEvent` using the `googleEventId` from the deleted row
+- Google sync failures in all three routes are caught and logged but never fail the response, the user's data is already saved
+- `toCalendarEvent` in `utils/db.js` now includes `googleEventId` so route handlers can read it without a second query
+- `updateCalendarEvent` always resets `sync_source = 'local'` on any user-driven update so the outbound push fires even if the event last arrived via webhook
+
 ## 2026-03-11 - version 1.2.1
 
 - added `routes/google.js` with four routes under `/api/google/auth`: `GET /status` (connected check), `GET /url` (generates Google OAuth URL), `GET /callback` (exchanges code for tokens, saves to DB, registers watch channel), `DELETE /disconnect` (stops watch channel, deletes tokens)

--- a/README.md
+++ b/README.md
@@ -194,7 +194,32 @@ AWS_S3_BUCKET_NAME=
 
 # OpenAI
 OPENAI_API_KEY=
+
+# Google Calendar sync (optional, only needed if using the calendar sync feature)
+# Create an OAuth 2.0 client in Google Cloud Console (Web application type)
+GOOGLE_CLIENT_ID=
+GOOGLE_CLIENT_SECRET=
+# the callback URL you registered in Google Cloud Console
+GOOGLE_REDIRECT_URI=https://api.paulsumido.com/api/google/auth/callback
+# any random secret, used to sign the OAuth state param (openssl rand -hex 32)
+GOOGLE_STATE_SECRET=
+# publicly reachable URL for the webhook endpoint -- must be https, won't work on localhost
+# use ngrok or similar for local testing: ngrok http 3001, then set this to the tunnel URL
+GOOGLE_WEBHOOK_URL=https://api.paulsumido.com/api/google/webhook
+# the frontend URL the OAuth callback redirects back to after connect/disconnect
+FRONTEND_URL=https://paulsumido.com
 ```
+
+### Google Calendar watch channel renewal
+
+Watch channels expire after 7 days. The renewal job in `utils/renewWatchChannels.js`
+renews any channel expiring within 24 hours. Set it up as a Railway cron service:
+
+- **Command**: `node utils/renewWatchChannels.js`
+- **Schedule**: `0 6 * * *` (daily at 6am UTC)
+- The cron service lives in the same Railway project and shares the same env vars
+
+You can also run it manually: `node utils/renewWatchChannels.js`
 
 ### Run (without Docker)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portfolio_api",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "description": "Portfolio API with Node.js and Python",
   "main": "server.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portfolio_api",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "Portfolio API with Node.js and Python",
   "main": "server.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portfolio_api",
-  "version": "1.1.6",
+  "version": "1.2.0",
   "description": "Portfolio API with Node.js and Python",
   "main": "server.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portfolio_api",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Portfolio API with Node.js and Python",
   "main": "server.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portfolio_api",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Portfolio API with Node.js and Python",
   "main": "server.js",
   "scripts": {

--- a/routes/calendar.js
+++ b/routes/calendar.js
@@ -1,6 +1,11 @@
 const express = require("express");
 const db = require("../utils/db");
 const { checkJwt } = require("../middleware/auth");
+const {
+  createGoogleEvent,
+  updateGoogleEvent,
+  deleteGoogleEvent,
+} = require("../utils/googleCalendar");
 
 const router = express.Router();
 
@@ -73,6 +78,18 @@ router.post("/events", async (req, res) => {
       { title, description, startDate, endDate, allDay, color },
       userSub,
     );
+
+    // push to Google after the DB write. if it fails the event is still saved
+    // here, the sync just won't have a Google counterpart yet.
+    try {
+      const googleEventId = await createGoogleEvent(userSub, event);
+      if (googleEventId) {
+        await db.setEventGoogleId(event.id, googleEventId, userSub);
+      }
+    } catch (syncErr) {
+      console.error("POST /calendar/events Google sync failed:", syncErr.message);
+    }
+
     res.status(201).json({ event });
   } catch (err) {
     console.error("POST /calendar/events failed:", err.message);
@@ -98,6 +115,14 @@ router.put("/events/:id", async (req, res) => {
       return res.status(404).json({ error: "Event not found" });
     }
 
+    // sync the change to Google if this event has been pushed there before.
+    // we pass the full updated event so Google gets the current state, not just the diff.
+    try {
+      await updateGoogleEvent(userSub, event.googleEventId, event);
+    } catch (syncErr) {
+      console.error("PUT /calendar/events/:id Google sync failed:", syncErr.message);
+    }
+
     res.json({ event });
   } catch (err) {
     console.error("PUT /calendar/events/:id failed:", err.message);
@@ -111,10 +136,18 @@ router.delete("/events/:id", async (req, res) => {
   const { id } = req.params;
 
   try {
+    // deleteCalendarEvent returns the deleted row including googleEventId,
+    // so we can clean up Google after the DB row is gone.
     const deleted = await db.deleteCalendarEvent(id, userSub);
 
     if (!deleted) {
       return res.status(404).json({ error: "Event not found" });
+    }
+
+    try {
+      await deleteGoogleEvent(userSub, deleted.googleEventId);
+    } catch (syncErr) {
+      console.error("DELETE /calendar/events/:id Google sync failed:", syncErr.message);
     }
 
     res.status(204).send();

--- a/routes/google.js
+++ b/routes/google.js
@@ -2,17 +2,7 @@ const crypto = require("crypto");
 const express = require("express");
 const db = require("../utils/db");
 const { checkJwt } = require("../middleware/auth");
-
-// registerWatch and stopWatch live in googleCalendar.js (implemented in prompt 5).
-// stubbed here so the connect/disconnect flow compiles now.
-async function registerWatch(userId) {
-  // TODO: implement in prompt 5
-  console.log(`[google] registerWatch stub called for ${userId}`);
-}
-async function stopWatch(userId) {
-  // TODO: implement in prompt 5
-  console.log(`[google] stopWatch stub called for ${userId}`);
-}
+const { registerWatch, stopWatch } = require("../utils/googleCalendar");
 
 const router = express.Router();
 

--- a/routes/google.js
+++ b/routes/google.js
@@ -1,0 +1,231 @@
+const crypto = require("crypto");
+const express = require("express");
+const db = require("../utils/db");
+const { checkJwt } = require("../middleware/auth");
+
+// registerWatch and stopWatch live in googleCalendar.js (implemented in prompt 5).
+// stubbed here so the connect/disconnect flow compiles now.
+async function registerWatch(userId) {
+  // TODO: implement in prompt 5
+  console.log(`[google] registerWatch stub called for ${userId}`);
+}
+async function stopWatch(userId) {
+  // TODO: implement in prompt 5
+  console.log(`[google] stopWatch stub called for ${userId}`);
+}
+
+const router = express.Router();
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Signs a payload string with HMAC-SHA256 using GOOGLE_STATE_SECRET.
+ * We use this to generate and verify the OAuth state param so we can trust
+ * which user the callback belongs to without storing anything server-side.
+ *
+ * @param {string} payload
+ * @returns {string} hex digest
+ */
+function signState(payload) {
+  return crypto
+    .createHmac("sha256", process.env.GOOGLE_STATE_SECRET)
+    .update(payload)
+    .digest("hex");
+}
+
+/**
+ * Builds the state query param: "<userId>.<hmac>". The userId is the part
+ * before the dot, the hmac is everything after. We verify by re-signing
+ * the userId and comparing.
+ *
+ * @param {string} userId
+ * @returns {string}
+ */
+function buildState(userId) {
+  const sig = signState(userId);
+  return `${userId}.${sig}`;
+}
+
+/**
+ * Verifies the state param from the callback. Returns the userId if valid,
+ * null if tampered or malformed.
+ *
+ * @param {string} state
+ * @returns {string|null}
+ */
+function verifyState(state) {
+  if (!state || !state.includes(".")) return null;
+  const dotIdx = state.lastIndexOf(".");
+  const userId = state.slice(0, dotIdx);
+  const sig = state.slice(dotIdx + 1);
+  const expected = signState(userId);
+  // constant-time compare to avoid timing attacks
+  try {
+    if (!crypto.timingSafeEqual(Buffer.from(sig), Buffer.from(expected))) {
+      return null;
+    }
+  } catch {
+    // buffers were different lengths, definitely invalid
+    return null;
+  }
+  return userId;
+}
+
+// ---------------------------------------------------------------------------
+// Routes
+// ---------------------------------------------------------------------------
+
+/**
+ * GET /api/google/auth/status
+ *
+ * Tells the frontend whether this user has connected their Google Calendar.
+ * Quick check -- just a single row lookup, no Google API call.
+ */
+router.get("/auth/status", checkJwt, async (req, res) => {
+  const userId = req.auth.payload.sub;
+  try {
+    const auth = await db.getGoogleAuth(userId);
+    if (auth) {
+      res.json({ connected: true, googleCalId: auth.google_cal_id });
+    } else {
+      res.json({ connected: false });
+    }
+  } catch (err) {
+    console.error("[google] GET /auth/status failed:", err.message);
+    res.status(500).json({ error: "Failed to check connection status" });
+  }
+});
+
+/**
+ * GET /api/google/auth/url
+ *
+ * Generates the Google OAuth authorization URL for this user. The frontend
+ * redirects the user to this URL to kick off the connect flow.
+ *
+ * We sign the state param with an HMAC so the callback can verify it wasn't
+ * tampered with. prompt=consent is required to always get a refresh_token back,
+ * even if the user has connected before.
+ */
+router.get("/auth/url", checkJwt, async (req, res) => {
+  const userId = req.auth.payload.sub;
+  try {
+    const state = buildState(userId);
+    const params = new URLSearchParams({
+      client_id: process.env.GOOGLE_CLIENT_ID,
+      redirect_uri: process.env.GOOGLE_REDIRECT_URI,
+      response_type: "code",
+      scope: "https://www.googleapis.com/auth/calendar.events",
+      access_type: "offline",
+      prompt: "consent",
+      state,
+    });
+    res.json({ url: `https://accounts.google.com/o/oauth2/v2/auth?${params}` });
+  } catch (err) {
+    console.error("[google] GET /auth/url failed:", err.message);
+    res.status(500).json({ error: "Failed to generate authorization URL" });
+  }
+});
+
+/**
+ * GET /api/google/auth/callback
+ *
+ * Google redirects here after the user approves (or denies) the OAuth prompt.
+ * This route is not protected by checkJwt -- the browser arrives here without
+ * our token. We use the signed state param to figure out which user this is for.
+ *
+ * On success we save the tokens and register a watch channel, then bounce the
+ * browser back to the settings page with a ?gcal=connected flag so the UI can
+ * show a success message.
+ */
+router.get("/auth/callback", async (req, res) => {
+  const { code, state, error } = req.query;
+
+  // user clicked "deny" on the Google consent screen
+  if (error) {
+    console.warn("[google] OAuth denied by user:", error);
+    return res.redirect(
+      `${process.env.FRONTEND_URL}/protected/settings?gcal=denied`,
+    );
+  }
+
+  const userId = verifyState(state);
+  if (!userId) {
+    console.warn("[google] Invalid state param in callback");
+    return res.status(400).json({ error: "Invalid state parameter" });
+  }
+
+  try {
+    // exchange the authorization code for tokens
+    const tokenRes = await fetch("https://oauth2.googleapis.com/token", {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: new URLSearchParams({
+        code,
+        client_id: process.env.GOOGLE_CLIENT_ID,
+        client_secret: process.env.GOOGLE_CLIENT_SECRET,
+        redirect_uri: process.env.GOOGLE_REDIRECT_URI,
+        grant_type: "authorization_code",
+      }).toString(),
+    });
+
+    if (!tokenRes.ok) {
+      const body = await tokenRes.text();
+      console.error("[google] Token exchange failed:", body);
+      return res.redirect(
+        `${process.env.FRONTEND_URL}/protected/settings?gcal=error`,
+      );
+    }
+
+    const { access_token, refresh_token, expires_in } = await tokenRes.json();
+    const tokenExpiry = new Date(Date.now() + expires_in * 1000);
+
+    await db.upsertGoogleAuth(userId, {
+      accessToken: access_token,
+      refreshToken: refresh_token,
+      tokenExpiry,
+    });
+
+    // register the watch channel so Google can ping us when events change.
+    // non-fatal if it fails here -- user is still connected, they just won't
+    // get inbound sync until the next renewal cycle picks them up.
+    try {
+      await registerWatch(userId);
+    } catch (watchErr) {
+      console.error("[google] registerWatch failed after connect:", watchErr.message);
+    }
+
+    res.redirect(`${process.env.FRONTEND_URL}/protected/settings?gcal=connected`);
+  } catch (err) {
+    console.error("[google] Callback error:", err.message);
+    res.redirect(`${process.env.FRONTEND_URL}/protected/settings?gcal=error`);
+  }
+});
+
+/**
+ * DELETE /api/google/auth/disconnect
+ *
+ * Stops the watch channel and removes the user's tokens. After this their
+ * events will no longer sync with Google Calendar.
+ */
+router.delete("/auth/disconnect", checkJwt, async (req, res) => {
+  const userId = req.auth.payload.sub;
+  try {
+    // stop the watch channel first so Google stops pinging us.
+    // non-fatal if it fails (channel may have already expired).
+    try {
+      await stopWatch(userId);
+    } catch (watchErr) {
+      console.warn("[google] stopWatch failed on disconnect:", watchErr.message);
+    }
+
+    await db.deleteGoogleAuth(userId);
+    res.sendStatus(204);
+  } catch (err) {
+    console.error("[google] DELETE /auth/disconnect failed:", err.message);
+    res.status(500).json({ error: "Failed to disconnect Google Calendar" });
+  }
+});
+
+module.exports = router;

--- a/routes/googleWebhook.js
+++ b/routes/googleWebhook.js
@@ -1,0 +1,118 @@
+const express = require("express");
+const db = require("../utils/db");
+const { fetchIncrementalEvents } = require("../utils/googleCalendar");
+
+const router = express.Router();
+
+// reverse color map: Google colorId back to our hex values.
+// used when applying Google-side color changes to our events.
+const GOOGLE_COLOR_TO_HEX = {
+  "9": "#6366f1",  // blueberry
+  "11": "#f43f5e", // tomato
+  "6": "#f97316",  // tangerine
+  "5": "#eab308",  // banana
+  "10": "#22c55e", // sage
+  "7": "#06b6d4",  // peacock
+  "3": "#8b5cf6",  // grape
+  "4": "#ec4899",  // flamingo
+};
+
+/**
+ * Converts a Google Calendar Event item to the field shape our DB update expects.
+ * Returns only the fields that are present on the Google event, so the DB update
+ * leaves anything else untouched.
+ *
+ * @param {Object} item - a Google Calendar Event resource
+ * @returns {{ title?: string, description?: string, startDate?: string, endDate?: string, allDay?: boolean, color?: string }}
+ */
+function fromGoogleEvent(item) {
+  const fields = {};
+
+  if (item.summary !== undefined) fields.title = item.summary ?? "";
+  if (item.description !== undefined) fields.description = item.description ?? null;
+
+  if (item.start) {
+    const allDay = Boolean(item.start.date && !item.start.dateTime);
+    fields.allDay = allDay;
+    fields.startDate = allDay ? item.start.date : item.start.dateTime;
+    fields.endDate = allDay
+      ? item.end.date
+      : item.end.dateTime;
+  }
+
+  if (item.colorId !== undefined) {
+    fields.color = GOOGLE_COLOR_TO_HEX[item.colorId] ?? "#6366f1";
+  }
+
+  return fields;
+}
+
+/**
+ * POST /api/google/webhook
+ *
+ * Google pushes a notification here whenever something changes on the user's
+ * primary calendar. The body is always empty -- everything useful is in the
+ * headers. We respond 200 no matter what, because a 4xx or 5xx tells Google to
+ * retry and eventually blacklist the channel.
+ *
+ * We only act on events that exist in our DB (identified by google_event_id).
+ * Anything Google created on its own (Gmail RSVPs, events typed directly in
+ * Google Calendar, etc.) is ignored -- we don't import foreign events.
+ */
+router.post("/webhook", async (req, res) => {
+  // respond immediately so Google doesn't time out waiting for us
+  res.sendStatus(200);
+
+  const userId = req.headers["x-goog-channel-token"];
+  const resourceState = req.headers["x-goog-resource-state"];
+
+  if (!userId) return;
+
+  // "sync" is Google's initial handshake ping right after channel registration.
+  // there are no actual changes to process, just acknowledge it.
+  if (resourceState === "sync") return;
+
+  try {
+    const auth = await db.getGoogleAuth(userId);
+    if (!auth) return;
+
+    const { items, nextSyncToken } = await fetchIncrementalEvents(
+      userId,
+      auth.sync_token,
+    );
+
+    // save the new sync token before processing items so if we crash partway
+    // through we don't re-process the same batch on the next notification.
+    await db.updateSyncToken(userId, nextSyncToken);
+
+    for (const item of items) {
+      // look up by google_event_id scoped to this user.
+      // if we don't have it, it's a foreign event and we skip it.
+      const existing = await db.getEventByGoogleId(item.id, userId);
+      if (!existing) continue;
+
+      if (item.status === "cancelled") {
+        await db.deleteCalendarEvent(existing.id, userId);
+        continue;
+      }
+
+      // last-write wins: if Google's timestamp is newer, apply the change.
+      // if ours is newer it means the user just edited it here and the webhook
+      // is stale -- our version is already correct, skip it.
+      const googleUpdated = new Date(item.updated);
+      const ourUpdated = new Date(existing.updated_at);
+
+      if (googleUpdated <= ourUpdated) continue;
+
+      const fields = fromGoogleEvent(item);
+      if (Object.keys(fields).length > 0) {
+        await db.updateCalendarEventFromWebhook(existing.id, fields, userId);
+      }
+    }
+  } catch (err) {
+    // log but don't throw, the 200 is already sent
+    console.error("[googleWebhook] Error processing notification:", err.message);
+  }
+});
+
+module.exports = router;

--- a/scripts/calendar/migrate_google_sync.js
+++ b/scripts/calendar/migrate_google_sync.js
@@ -1,0 +1,68 @@
+require('dotenv').config();
+
+const { Pool } = require('pg');
+
+const pool = new Pool({
+    connectionString: process.env.DATABASE_URL,
+    ssl: process.env.NODE_ENV === 'production' ? { rejectUnauthorized: false } : false
+});
+
+async function migrate() {
+    const client = await pool.connect();
+    try {
+        console.log('Running google sync migration...');
+
+        // one row per user, stores the oauth tokens and watch channel info.
+        // sync_token is Google's cursor -- we hand it back on the next incremental
+        // fetch so Google knows what we've already seen.
+        await client.query(`
+            CREATE TABLE IF NOT EXISTS google_auth (
+              user_id        TEXT PRIMARY KEY,
+              access_token   TEXT NOT NULL,
+              refresh_token  TEXT NOT NULL,
+              token_expiry   TIMESTAMPTZ NOT NULL,
+              google_cal_id  TEXT NOT NULL DEFAULT 'primary',
+              channel_id     TEXT,
+              resource_id    TEXT,
+              channel_expiry TIMESTAMPTZ,
+              sync_token     TEXT,
+              created_at     TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+              updated_at     TIMESTAMPTZ NOT NULL DEFAULT NOW()
+            );
+        `);
+        console.log('Created table: google_auth');
+
+        // lets us look up which of our events maps to which Google event id,
+        // and lets the webhook handler skip events we didn't create here.
+        await client.query(`
+            ALTER TABLE calendar_events ADD COLUMN IF NOT EXISTS google_event_id TEXT;
+        `);
+        console.log('Added column: calendar_events.google_event_id');
+
+        // tracks whether the last change to this event came from us or from
+        // a Google webhook, so we can skip the outbound push on webhook-driven updates.
+        await client.query(`
+            ALTER TABLE calendar_events ADD COLUMN IF NOT EXISTS sync_source TEXT DEFAULT 'local';
+        `);
+        console.log('Added column: calendar_events.sync_source');
+
+        // partial index so lookups by google_event_id are fast without bloating
+        // rows that have never been synced (the NULL rows are excluded).
+        await client.query(`
+            CREATE INDEX IF NOT EXISTS idx_calendar_events_google
+              ON calendar_events(google_event_id)
+              WHERE google_event_id IS NOT NULL;
+        `);
+        console.log('Created index: idx_calendar_events_google');
+
+        console.log('Migration complete.');
+    } catch (err) {
+        console.error('Migration failed:', err.message);
+        process.exit(1);
+    } finally {
+        client.release();
+        await pool.end();
+    }
+}
+
+migrate();

--- a/server.js
+++ b/server.js
@@ -20,6 +20,9 @@ const feedbackRoutes = require("./routes/feedback");
 const chatgptRoutes = require("./routes/chat-gpt");
 const calendarRoutes = require("./routes/calendar");
 const vitalsRoutes = require("./routes/vitals");
+const googleRoutes = require("./routes/google");
+// watch channel renewal runs as a Railway cron job (utils/renewWatchChannels.js)
+// not as a setInterval here, since deploys restart the process and would reset the timer
 
 const app = express();
 const port = process.env.PORT || 3001;
@@ -67,6 +70,7 @@ app.use("/api/feedback", feedbackRoutes);
 app.use("/api/chatgpt", chatgptRoutes);
 app.use("/api/calendar", calendarRoutes);
 app.use("/api/vitals", vitalsRoutes);
+app.use("/api/google", googleRoutes);
 app.use("/api", dbRoutes);
 
 // Error handling middleware

--- a/server.js
+++ b/server.js
@@ -21,6 +21,7 @@ const chatgptRoutes = require("./routes/chat-gpt");
 const calendarRoutes = require("./routes/calendar");
 const vitalsRoutes = require("./routes/vitals");
 const googleRoutes = require("./routes/google");
+const googleWebhookRoutes = require("./routes/googleWebhook");
 // watch channel renewal runs as a Railway cron job (utils/renewWatchChannels.js)
 // not as a setInterval here, since deploys restart the process and would reset the timer
 
@@ -71,6 +72,7 @@ app.use("/api/chatgpt", chatgptRoutes);
 app.use("/api/calendar", calendarRoutes);
 app.use("/api/vitals", vitalsRoutes);
 app.use("/api/google", googleRoutes);
+app.use("/api/google", googleWebhookRoutes);
 app.use("/api", dbRoutes);
 
 // Error handling middleware

--- a/utils/db.js
+++ b/utils/db.js
@@ -490,6 +490,8 @@ function toCalendarEvent(row) {
     endDate: row.end_date instanceof Date ? row.end_date.toISOString() : row.end_date,
     allDay: row.all_day,
     color: row.color,
+    // included so route handlers can read it for Google push sync without a second query
+    googleEventId: row.google_event_id ?? undefined,
   };
 }
 
@@ -596,6 +598,10 @@ async function updateCalendarEvent(id, fields, userSub) {
   }
 
   if (setClauses.length === 0) return null;
+
+  // always reset sync_source to 'local' on a user-driven update, so the
+  // outbound Google push fires even if the event last arrived via webhook.
+  setClauses.push(`sync_source = 'local'`);
 
   // always bump updated_at
   values.push(new Date());

--- a/utils/db.js
+++ b/utils/db.js
@@ -736,6 +736,78 @@ async function updateSyncToken(userId, syncToken) {
 }
 
 /**
+ * Finds a calendar event by its Google event ID, scoped to the user.
+ * Returns the raw DB row (not toCalendarEvent) so the caller can read
+ * updated_at directly for conflict resolution.
+ *
+ * @param {string} googleEventId
+ * @param {string} userSub
+ * @returns {Promise<Object|null>}
+ */
+async function getEventByGoogleId(googleEventId, userSub) {
+  const { rows } = await pool.query(
+    "SELECT * FROM calendar_events WHERE google_event_id = $1 AND user_sub = $2",
+    [googleEventId, userSub],
+  );
+  return rows[0] || null;
+}
+
+/**
+ * Updates a calendar event with data that arrived from a Google webhook.
+ * Sets sync_source='google' instead of 'local' so the next user-driven
+ * mutation knows to push back out rather than skip.
+ *
+ * Only updates the fields that Google actually tracks (title, description,
+ * startDate, endDate, allDay, color). Uses the same colMap pattern as
+ * updateCalendarEvent.
+ *
+ * @param {string} id - our UUID
+ * @param {{ title?: string, description?: string, startDate?: string, endDate?: string, allDay?: boolean, color?: string }} fields
+ * @param {string} userSub
+ * @returns {Promise<Object|null>}
+ */
+async function updateCalendarEventFromWebhook(id, fields, userSub) {
+  const colMap = {
+    title: "title",
+    description: "description",
+    startDate: "start_date",
+    endDate: "end_date",
+    allDay: "all_day",
+    color: "color",
+  };
+
+  const setClauses = [];
+  const values = [];
+
+  for (const [key, col] of Object.entries(colMap)) {
+    if (key in fields) {
+      values.push(fields[key]);
+      setClauses.push(`${col} = $${values.length}`);
+    }
+  }
+
+  if (setClauses.length === 0) return null;
+
+  // mark as coming from Google so the next user edit knows it needs a push
+  setClauses.push(`sync_source = 'google'`);
+
+  values.push(new Date());
+  setClauses.push(`updated_at = $${values.length}`);
+
+  values.push(id, userSub);
+
+  const { rows } = await pool.query(
+    `UPDATE calendar_events
+     SET ${setClauses.join(", ")}
+     WHERE id = $${values.length - 1} AND user_sub = $${values.length}
+     RETURNING *`,
+    values,
+  );
+
+  return rows[0] ? toCalendarEvent(rows[0]) : null;
+}
+
+/**
  * Stores the Google event ID on one of our events after a successful push.
  * We use this later to look up the event when Google sends us a webhook.
  *
@@ -1068,6 +1140,8 @@ module.exports = {
   createCountdown,
   updateCountdown,
   deleteCountdown,
+  getEventByGoogleId,
+  updateCalendarEventFromWebhook,
   getGoogleAuth,
   upsertGoogleAuth,
   deleteGoogleAuth,

--- a/utils/db.js
+++ b/utils/db.js
@@ -631,6 +631,134 @@ async function deleteCalendarEvent(id, userSub) {
 }
 
 // ---------------------------------------------------------------------------
+// Google Calendar sync helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns the google_auth row for a user, or null if they haven't connected.
+ *
+ * @param {string} userId - Auth0 sub
+ * @returns {Promise<Object|null>}
+ */
+async function getGoogleAuth(userId) {
+  const { rows } = await pool.query(
+    "SELECT * FROM google_auth WHERE user_id = $1",
+    [userId],
+  );
+  return rows[0] || null;
+}
+
+/**
+ * Creates or updates the google_auth row for a user. Partial updates are fine,
+ * any field you leave out just stays as-is (except updated_at, which always refreshes).
+ *
+ * @param {string} userId
+ * @param {{ accessToken?: string, refreshToken?: string, tokenExpiry?: Date,
+ *            googleCalId?: string, channelId?: string, resourceId?: string,
+ *            channelExpiry?: Date, syncToken?: string }} fields
+ */
+async function upsertGoogleAuth(userId, fields) {
+  const {
+    accessToken,
+    refreshToken,
+    tokenExpiry,
+    googleCalId,
+    channelId,
+    resourceId,
+    channelExpiry,
+    syncToken,
+  } = fields;
+
+  await pool.query(
+    `INSERT INTO google_auth
+       (user_id, access_token, refresh_token, token_expiry, google_cal_id,
+        channel_id, resource_id, channel_expiry, sync_token, updated_at)
+     VALUES ($1, $2, $3, $4, COALESCE($5, 'primary'), $6, $7, $8, $9, NOW())
+     ON CONFLICT (user_id) DO UPDATE SET
+       access_token   = COALESCE($2, google_auth.access_token),
+       refresh_token  = COALESCE($3, google_auth.refresh_token),
+       token_expiry   = COALESCE($4, google_auth.token_expiry),
+       google_cal_id  = COALESCE($5, google_auth.google_cal_id),
+       channel_id     = COALESCE($6, google_auth.channel_id),
+       resource_id    = COALESCE($7, google_auth.resource_id),
+       channel_expiry = COALESCE($8, google_auth.channel_expiry),
+       sync_token     = COALESCE($9, google_auth.sync_token),
+       updated_at     = NOW()`,
+    [userId, accessToken, refreshToken, tokenExpiry, googleCalId,
+     channelId, resourceId, channelExpiry, syncToken],
+  );
+}
+
+/**
+ * Removes the google_auth row when a user disconnects. Also clears their
+ * channel info so the renewal job skips them.
+ *
+ * @param {string} userId
+ */
+async function deleteGoogleAuth(userId) {
+  await pool.query("DELETE FROM google_auth WHERE user_id = $1", [userId]);
+}
+
+/**
+ * Saves the watch channel details after registering a new channel with Google.
+ * Called right after a successful POST to the Google watch endpoint.
+ *
+ * @param {string} userId
+ * @param {{ channelId: string, resourceId: string, channelExpiry: Date }} info
+ */
+async function updateChannelInfo(userId, { channelId, resourceId, channelExpiry }) {
+  await pool.query(
+    `UPDATE google_auth
+     SET channel_id = $2, resource_id = $3, channel_expiry = $4, updated_at = NOW()
+     WHERE user_id = $1`,
+    [userId, channelId, resourceId, channelExpiry],
+  );
+}
+
+/**
+ * Saves the latest sync token after processing an incremental fetch from Google.
+ * The token is Google's cursor, we hand it back next time to get only the delta.
+ *
+ * @param {string} userId
+ * @param {string} syncToken
+ */
+async function updateSyncToken(userId, syncToken) {
+  await pool.query(
+    "UPDATE google_auth SET sync_token = $2, updated_at = NOW() WHERE user_id = $1",
+    [userId, syncToken],
+  );
+}
+
+/**
+ * Stores the Google event ID on one of our events after a successful push.
+ * We use this later to look up the event when Google sends us a webhook.
+ *
+ * @param {string} eventId - our UUID
+ * @param {string} googleEventId - the id Google assigned
+ * @param {string} userSub
+ */
+async function setEventGoogleId(eventId, googleEventId, userSub) {
+  await pool.query(
+    "UPDATE calendar_events SET google_event_id = $1 WHERE id = $2 AND user_sub = $3",
+    [googleEventId, eventId, userSub],
+  );
+}
+
+/**
+ * Clears the google_event_id from our event row after Google confirms a delete,
+ * or when we need to unlink for any reason.
+ *
+ * @param {string} googleEventId
+ * @param {string} userSub
+ */
+async function clearEventGoogleId(googleEventId, userSub) {
+  await pool.query(
+    "UPDATE calendar_events SET google_event_id = NULL WHERE google_event_id = $1 AND user_sub = $2",
+    [googleEventId, userSub],
+  );
+}
+
+// ---------------------------------------------------------------------------
 // Event cards (TCG card ↔ calendar event junction)
 // ---------------------------------------------------------------------------
 
@@ -934,4 +1062,11 @@ module.exports = {
   createCountdown,
   updateCountdown,
   deleteCountdown,
+  getGoogleAuth,
+  upsertGoogleAuth,
+  deleteGoogleAuth,
+  updateChannelInfo,
+  updateSyncToken,
+  setEventGoogleId,
+  clearEventGoogleId,
 };

--- a/utils/googleCalendar.js
+++ b/utils/googleCalendar.js
@@ -1,4 +1,6 @@
+const { v4: uuidv4 } = require("uuid");
 const { getValidAccessToken } = require("./googleToken");
+const db = require("./db");
 
 const GCAL_BASE = "https://www.googleapis.com/calendar/v3/calendars/primary";
 
@@ -183,9 +185,95 @@ async function fetchIncrementalEvents(userId, syncToken) {
   return { items: data.items ?? [], nextSyncToken: data.nextSyncToken };
 }
 
+/**
+ * Registers a Google Calendar push notification channel for the user.
+ * Google will POST to GOOGLE_WEBHOOK_URL whenever something changes on their
+ * primary calendar. The channel lives for 6.5 days, the Railway cron job
+ * (utils/renewWatchChannels.js) renews it before it expires.
+ *
+ * Also kicks off an initial full sync so we bootstrap our sync token and
+ * pick up any events the user may have already synced in the past.
+ *
+ * @param {string} userId - Auth0 sub
+ */
+async function registerWatch(userId) {
+  const token = await getValidAccessToken(userId);
+  const channelId = uuidv4();
+  const expiration = Date.now() + 6.5 * 24 * 60 * 60 * 1000;
+
+  const res = await fetch(`${GCAL_BASE}/events/watch`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      id: channelId,
+      type: "web_hook",
+      address: process.env.GOOGLE_WEBHOOK_URL,
+      token: userId,           // echoed back as X-Goog-Channel-Token on each ping
+      expiration,
+    }),
+  });
+
+  if (!res.ok) {
+    const body = await res.text();
+    throw new Error(`registerWatch failed (${res.status}): ${body}`);
+  }
+
+  const data = await res.json();
+  await db.updateChannelInfo(userId, {
+    channelId: data.id,
+    resourceId: data.resourceId,
+    channelExpiry: new Date(parseInt(data.expiration, 10)),
+  });
+
+  // bootstrap the sync token with a full sync so future incremental fetches
+  // have a valid cursor to start from.
+  try {
+    const { nextSyncToken } = await fetchIncrementalEvents(userId, null);
+    await db.updateSyncToken(userId, nextSyncToken);
+  } catch (syncErr) {
+    console.warn(`[googleCalendar] initial sync after registerWatch failed for ${userId}:`, syncErr.message);
+  }
+}
+
+/**
+ * Stops an existing watch channel. Called on disconnect and before re-registering
+ * during renewal. Swallows errors since Google returns 404 for already-expired
+ * channels, which is fine.
+ *
+ * @param {string} userId - Auth0 sub
+ */
+async function stopWatch(userId) {
+  try {
+    const auth = await db.getGoogleAuth(userId);
+    if (!auth?.channel_id || !auth?.resource_id) return;
+
+    const token = await getValidAccessToken(userId);
+
+    await fetch("https://www.googleapis.com/calendar/v3/channels/stop", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        id: auth.channel_id,
+        resourceId: auth.resource_id,
+      }),
+    });
+    // we don't check res.ok here, a 404 just means the channel already expired
+  } catch (err) {
+    console.warn(`[googleCalendar] stopWatch failed for ${userId}:`, err.message);
+  }
+}
+
 module.exports = {
   createGoogleEvent,
   updateGoogleEvent,
   deleteGoogleEvent,
   fetchIncrementalEvents,
+  registerWatch,
+  stopWatch,
 };

--- a/utils/googleCalendar.js
+++ b/utils/googleCalendar.js
@@ -1,0 +1,191 @@
+const { getValidAccessToken } = require("./googleToken");
+
+const GCAL_BASE = "https://www.googleapis.com/calendar/v3/calendars/primary";
+
+// maps our EVENT_COLORS hex values to the closest Google Calendar colorId.
+// Google's colorId reference: https://developers.google.com/calendar/api/v3/reference/colors/get
+const COLOR_MAP = {
+  "#6366f1": "9",  // blueberry
+  "#f43f5e": "11", // tomato
+  "#f97316": "6",  // tangerine
+  "#eab308": "5",  // banana
+  "#22c55e": "10", // sage
+  "#06b6d4": "7",  // peacock
+  "#8b5cf6": "3",  // grape
+  "#ec4899": "4",  // flamingo
+};
+
+/**
+ * Converts one of our event objects to the shape Google Calendar expects.
+ * All-day events use { date: "YYYY-MM-DD" }, timed events use { dateTime, timeZone }.
+ *
+ * @param {{ title: string, description?: string, startDate: string, endDate: string, allDay: boolean, color?: string }} event
+ * @returns {Object} Google Calendar Event resource body
+ */
+function toGoogleEvent(event) {
+  const { title, description, startDate, endDate, allDay, color } = event;
+
+  // for all-day events Google wants just the date, not a full ISO timestamp.
+  // we slice the first 10 chars which gives us "YYYY-MM-DD" regardless of
+  // whether startDate is already a date string or a full ISO datetime.
+  const dateOnly = (iso) => iso.slice(0, 10);
+
+  const start = allDay
+    ? { date: dateOnly(startDate) }
+    : { dateTime: startDate, timeZone: "UTC" };
+
+  const end = allDay
+    ? { date: dateOnly(endDate) }
+    : { dateTime: endDate, timeZone: "UTC" };
+
+  const body = {
+    summary: title,
+    start,
+    end,
+  };
+
+  if (description) body.description = description;
+  if (color) body.colorId = COLOR_MAP[color.toLowerCase()] ?? "9";
+
+  return body;
+}
+
+/**
+ * Creates an event in Google Calendar and returns the Google event ID.
+ * Returns null if the user is not connected, so callers don't have to check
+ * connection status before calling this.
+ *
+ * @param {string} userId - Auth0 sub
+ * @param {{ title: string, description?: string, startDate: string, endDate: string, allDay: boolean, color?: string }} event
+ * @returns {Promise<string|null>} Google event ID, or null if user is not connected
+ */
+async function createGoogleEvent(userId, event) {
+  let token;
+  try {
+    token = await getValidAccessToken(userId);
+  } catch {
+    // user is not connected, nothing to do
+    return null;
+  }
+
+  const res = await fetch(`${GCAL_BASE}/events`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(toGoogleEvent(event)),
+  });
+
+  if (!res.ok) {
+    const body = await res.text();
+    throw new Error(`Google create event failed (${res.status}): ${body}`);
+  }
+
+  const data = await res.json();
+  return data.id;
+}
+
+/**
+ * Updates an existing Google Calendar event. Skips silently if googleEventId
+ * is null or undefined, which happens for events created before sync was connected.
+ *
+ * @param {string} userId - Auth0 sub
+ * @param {string|null} googleEventId
+ * @param {{ title?: string, description?: string, startDate?: string, endDate?: string, allDay?: boolean, color?: string }} fields
+ */
+async function updateGoogleEvent(userId, googleEventId, fields) {
+  if (!googleEventId) return;
+
+  let token;
+  try {
+    token = await getValidAccessToken(userId);
+  } catch {
+    return;
+  }
+
+  const res = await fetch(`${GCAL_BASE}/events/${googleEventId}`, {
+    method: "PATCH",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(toGoogleEvent(fields)),
+  });
+
+  if (!res.ok) {
+    const body = await res.text();
+    throw new Error(`Google update event failed (${res.status}): ${body}`);
+  }
+}
+
+/**
+ * Deletes an event from Google Calendar. 404s are swallowed since the event
+ * may have already been deleted on the Google side before we got here.
+ *
+ * @param {string} userId - Auth0 sub
+ * @param {string} googleEventId
+ */
+async function deleteGoogleEvent(userId, googleEventId) {
+  if (!googleEventId) return;
+
+  let token;
+  try {
+    token = await getValidAccessToken(userId);
+  } catch {
+    return;
+  }
+
+  const res = await fetch(`${GCAL_BASE}/events/${googleEventId}`, {
+    method: "DELETE",
+    headers: { Authorization: `Bearer ${token}` },
+  });
+
+  // 404 means it's already gone, that's fine
+  if (!res.ok && res.status !== 404) {
+    const body = await res.text();
+    throw new Error(`Google delete event failed (${res.status}): ${body}`);
+  }
+}
+
+/**
+ * Fetches incremental changes from Google Calendar using the stored sync token.
+ * Passing null for syncToken triggers a full sync (bootstrapping or after a 410).
+ * Returns { items, nextSyncToken } where items may include cancelled events.
+ *
+ * @param {string} userId - Auth0 sub
+ * @param {string|null} syncToken
+ * @returns {Promise<{ items: Array, nextSyncToken: string }>}
+ */
+async function fetchIncrementalEvents(userId, syncToken) {
+  const token = await getValidAccessToken(userId);
+
+  const params = new URLSearchParams({ singleEvents: "true" });
+  if (syncToken) params.set("syncToken", syncToken);
+
+  const res = await fetch(
+    `${GCAL_BASE}/events?${params}`,
+    { headers: { Authorization: `Bearer ${token}` } },
+  );
+
+  // 410 Gone means the sync token is stale, do a full re-sync
+  if (res.status === 410) {
+    console.log(`[googleCalendar] sync token expired for ${userId}, doing full sync`);
+    return fetchIncrementalEvents(userId, null);
+  }
+
+  if (!res.ok) {
+    const body = await res.text();
+    throw new Error(`Google list events failed (${res.status}): ${body}`);
+  }
+
+  const data = await res.json();
+  return { items: data.items ?? [], nextSyncToken: data.nextSyncToken };
+}
+
+module.exports = {
+  createGoogleEvent,
+  updateGoogleEvent,
+  deleteGoogleEvent,
+  fetchIncrementalEvents,
+};

--- a/utils/googleToken.js
+++ b/utils/googleToken.js
@@ -1,0 +1,54 @@
+const db = require("./db");
+
+/**
+ * Returns a valid access token for the user, refreshing it from Google if it's
+ * going to expire within the next 5 minutes. Throws if the user hasn't connected
+ * their Google Calendar or if the refresh request fails.
+ *
+ * @param {string} userId - Auth0 sub
+ * @returns {Promise<string>} a non-expired access token
+ */
+async function getValidAccessToken(userId) {
+  const auth = await db.getGoogleAuth(userId);
+  if (!auth) throw new Error("Google Calendar not connected");
+
+  const expiresAt = new Date(auth.token_expiry);
+  const fiveMinFromNow = new Date(Date.now() + 5 * 60 * 1000);
+
+  // still good for at least 5 minutes, use it as-is
+  if (expiresAt > fiveMinFromNow) {
+    return auth.access_token;
+  }
+
+  // access token is stale, use the refresh token to get a new one
+  const params = new URLSearchParams({
+    client_id: process.env.GOOGLE_CLIENT_ID,
+    client_secret: process.env.GOOGLE_CLIENT_SECRET,
+    refresh_token: auth.refresh_token,
+    grant_type: "refresh_token",
+  });
+
+  const res = await fetch("https://oauth2.googleapis.com/token", {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: params.toString(),
+  });
+
+  if (!res.ok) {
+    const body = await res.text();
+    throw new Error(`Token refresh failed: ${body}`);
+  }
+
+  const { access_token, expires_in } = await res.json();
+  const newExpiry = new Date(Date.now() + expires_in * 1000);
+
+  await db.upsertGoogleAuth(userId, {
+    accessToken: access_token,
+    refreshToken: auth.refresh_token,
+    tokenExpiry: newExpiry,
+  });
+
+  return access_token;
+}
+
+module.exports = { getValidAccessToken };

--- a/utils/renewWatchChannels.js
+++ b/utils/renewWatchChannels.js
@@ -1,0 +1,54 @@
+require("dotenv").config();
+
+const { pool } = require("../config/database");
+const { registerWatch, stopWatch } = require("./googleCalendar");
+
+/**
+ * Finds all connected users whose watch channel expires within the next 24 hours
+ * and renews them. Runs as a Railway cron job daily at 6am UTC so channels never
+ * lapse -- Google stops sending webhooks as soon as a channel expires.
+ *
+ * Each user is renewed independently so one failure doesn't block the rest.
+ */
+async function renewExpiringChannels() {
+  const { rows } = await pool.query(`
+    SELECT user_id
+    FROM google_auth
+    WHERE channel_expiry < NOW() + INTERVAL '24 hours'
+      AND channel_id IS NOT NULL
+  `);
+
+  if (rows.length === 0) {
+    console.log("[renewWatchChannels] nothing to renew");
+    return;
+  }
+
+  console.log(`[renewWatchChannels] renewing ${rows.length} channel(s)`);
+
+  for (const { user_id } of rows) {
+    try {
+      // stop first so Google doesn't end up with two active channels for the same calendar
+      await stopWatch(user_id);
+      await registerWatch(user_id);
+      console.log(`[renewWatchChannels] renewed channel for ${user_id}`);
+    } catch (err) {
+      // log and keep going, one bad token shouldn't block everyone else
+      console.error(`[renewWatchChannels] failed for ${user_id}:`, err.message);
+    }
+  }
+
+  console.log("[renewWatchChannels] done");
+}
+
+module.exports = { renewExpiringChannels };
+
+// run directly: node utils/renewWatchChannels.js
+// set up as a Railway cron job: command = node utils/renewWatchChannels.js, schedule = 0 6 * * *
+if (require.main === module) {
+  renewExpiringChannels()
+    .then(() => process.exit(0))
+    .catch((err) => {
+      console.error("renewal job failed:", err.message);
+      process.exit(1);
+    });
+}


### PR DESCRIPTION
# Changelog

## 2026-03-12 - version 1.2.4

- added `registerWatch(userId)` and `stopWatch(userId)` to `utils/googleCalendar.js`; `registerWatch` POSTs to the Google watch endpoint with a 6.5-day expiry, stores the channel info via `updateChannelInfo`, then runs a full initial sync to bootstrap the sync token; `stopWatch` swallows all errors since a 404 from Google just means the channel already expired
- replaced the stubs in `routes/google.js` with real imports from `utils/googleCalendar.js`
- added `utils/renewWatchChannels.js`: queries `google_auth` for rows with `channel_expiry` within 24 hours, stops each old channel then re-registers; failures per user are logged and skipped so one bad token doesn't block the rest; has a `require.main` block so it can be run directly with `node utils/renewWatchChannels.js`
- no `setInterval` added to `server.js` -- renewal runs as a Railway cron job (`0 6 * * *`) to survive deploys; the comment in `server.js` already documents this
- added Google Calendar env vars to README (`GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`, `GOOGLE_REDIRECT_URI`, `GOOGLE_STATE_SECRET`, `GOOGLE_WEBHOOK_URL`, `FRONTEND_URL`) with notes on the webhook URL needing to be publicly reachable and ngrok for local testing
- documented the Railway cron job setup in README (command, schedule, shared env vars)

## 2026-03-12 - version 1.2.3

- added `routes/googleWebhook.js` with `POST /api/google/webhook`; receives Google Calendar push notifications (body is always empty, all info is in headers); responds 200 immediately before any async work so Google never times out waiting
- webhook handler skips events not in our DB (identified by `google_event_id`) so Gmail events and anything created directly in Google Calendar are ignored entirely
- conflict resolution via `updated_at`: if Google's `item.updated` timestamp is newer than our `updated_at`, we apply the change; if ours is newer we skip (our version wins)
- cancelled events (`item.status === "cancelled"`) are deleted from our DB
- sync token is saved before processing items so a mid-batch crash doesn't re-apply the same changes on the next notification
- added `getEventByGoogleId(googleEventId, userSub)` to `utils/db.js`; returns the raw row including `updated_at` for conflict comparison
- added `updateCalendarEventFromWebhook(id, fields, userSub)` to `utils/db.js`; sets `sync_source='google'` instead of `'local'` so the push sync knows to fire on the next user-driven edit
- registered `googleWebhook` router separately from `google` router in `server.js` to keep the unauthenticated webhook route clearly separated from the JWT-protected OAuth routes

## 2026-03-11 - version 1.2.2

- added `utils/googleCalendar.js` with four helpers: `createGoogleEvent`, `updateGoogleEvent`, `deleteGoogleEvent`, `fetchIncrementalEvents`; all call `getValidAccessToken` internally and return null (or no-op) when the user is not connected
- color mapping table in `googleCalendar.js` maps our 8 EVENT_COLORS hex values to Google Calendar colorIds; defaults to "9" (blueberry) for unknown colors
- all-day events are sent to Google with `{ date: "YYYY-MM-DD" }` start/end; timed events use `{ dateTime, timeZone: "UTC" }`; PATCH uses the same field mapping as POST
- `deleteGoogleEvent` swallows 404s since the event may have already been deleted on the Google side
- wired push sync into `routes/calendar.js` for the three event mutation routes: create calls `createGoogleEvent` then `setEventGoogleId`; update calls `updateGoogleEvent` with the full updated event; delete calls `deleteGoogleEvent` using the `googleEventId` from the deleted row
- Google sync failures in all three routes are caught and logged but never fail the response, the user's data is already saved
- `toCalendarEvent` in `utils/db.js` now includes `googleEventId` so route handlers can read it without a second query
- `updateCalendarEvent` always resets `sync_source = 'local'` on any user-driven update so the outbound push fires even if the event last arrived via webhook

## 2026-03-11 - version 1.2.1

- added `routes/google.js` with four routes under `/api/google/auth`: `GET /status` (connected check), `GET /url` (generates Google OAuth URL), `GET /callback` (exchanges code for tokens, saves to DB, registers watch channel), `DELETE /disconnect` (stops watch channel, deletes tokens)
- OAuth state param is signed with HMAC-SHA256 using `GOOGLE_STATE_SECRET` so the callback can verify which user it belongs to without storing anything server-side; `timingSafeEqual` used for comparison to avoid timing attacks
- `prompt=consent` and `access_type=offline` are set on the authorization URL to ensure a refresh token is always returned, even for returning users
- callback redirects to `FRONTEND_URL/protected/settings?gcal=connected` on success, `?gcal=denied` if the user declined, `?gcal=error` on failure
- `registerWatch` and `stopWatch` are stubbed in this route (implemented in prompt 5); watch failure on connect is non-fatal, user is still connected
- registered router at `/api/google` in `server.js`; added comment explaining why watch channel renewal is a Railway cron job, not a setInterval
- new required env vars: `GOOGLE_STATE_SECRET`, `FRONTEND_URL`

## 2026-03-11 - version 1.2.0

- added `google_auth` table to store per-user Google OAuth tokens (access token, refresh token, expiry, watch channel info, sync token); one row per connected user, primary key on `user_id`
- added `google_event_id` and `sync_source` columns to `calendar_events`; `google_event_id` maps our events to their Google Calendar counterparts, `sync_source` tracks whether the last change came from us or from a Google webhook (prevents push loops); partial index on `google_event_id` where not null
- run `node scripts/calendar/migrate_google_sync.js` to apply the schema changes
- added Google sync helpers to `utils/db.js`: `getGoogleAuth`, `upsertGoogleAuth`, `deleteGoogleAuth`, `updateChannelInfo`, `updateSyncToken`, `setEventGoogleId`, `clearEventGoogleId`
- added `utils/googleToken.js` with `getValidAccessToken(userId)`: returns a cached token if still valid, otherwise hits the Google token endpoint with the refresh token and stores the new one; throws if the user is not connected