### PR TITLE
Bugfixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2026-03-12 - version 1.2.5
+
+- fixed `COLOR_MAP` in `utils/googleCalendar.js`: previous hex values did not match the actual `EVENT_COLORS` used in the frontend, so almost every event fell back to blueberry "9"; map now keyed by the real event color hex values (`#3b82f6`, `#10b981`, `#f59e0b`, `#ef4444`, `#8b5cf6`, `#ec4899`, `#14b8a6`, `#f97316`)
+- fixed `GOOGLE_COLOR_TO_HEX` reverse map in `routes/googleWebhook.js` to match, so colors round-trip correctly when Google-side changes are pulled back in
+- fixed timestamp race in webhook handler: when we push an edit to Google, Google fires a webhook back almost immediately with `item.updated` slightly after our `updated_at`; the old `<=` comparison treated this echo as a real inbound change and wrote Google's version back, flipping `sync_source` to `'google'`; now uses a 10-second buffer (`SYNC_BUFFER_MS = 10_000`) so only genuine Google-side changes (made more than 10s after our last write) are applied
+
 ## 2026-03-12 - version 1.2.4
 
 - added `registerWatch(userId)` and `stopWatch(userId)` to `utils/googleCalendar.js`; `registerWatch` POSTs to the Google watch endpoint with a 6.5-day expiry, stores the channel info via `updateChannelInfo`, then runs a full initial sync to bootstrap the sync token; `stopWatch` swallows all errors since a 404 from Google just means the channel already expired

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portfolio_api",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "description": "Portfolio API with Node.js and Python",
   "main": "server.js",
   "scripts": {

--- a/routes/googleWebhook.js
+++ b/routes/googleWebhook.js
@@ -4,17 +4,17 @@ const { fetchIncrementalEvents } = require("../utils/googleCalendar");
 
 const router = express.Router();
 
-// reverse color map: Google colorId back to our hex values.
-// used when applying Google-side color changes to our events.
+// reverse color map: Google colorId back to our EVENT_COLORS hex values.
+// "7" (peacock) maps back to blue since both blue and teal map to peacock on the way out.
 const GOOGLE_COLOR_TO_HEX = {
-  "9": "#6366f1",  // blueberry
-  "11": "#f43f5e", // tomato
-  "6": "#f97316",  // tangerine
-  "5": "#eab308",  // banana
-  "10": "#22c55e", // sage
-  "7": "#06b6d4",  // peacock
-  "3": "#8b5cf6",  // grape
-  "4": "#ec4899",  // flamingo
+  "7": "#3b82f6",  // peacock   -> blue
+  "10": "#10b981", // sage      -> emerald
+  "5": "#f59e0b",  // banana    -> amber
+  "11": "#ef4444", // tomato    -> red
+  "3": "#8b5cf6",  // grape     -> violet
+  "4": "#ec4899",  // flamingo  -> pink
+  "6": "#f97316",  // tangerine -> orange
+  "9": "#3b82f6",  // blueberry -> blue (fallback for old events)
 };
 
 /**
@@ -96,13 +96,18 @@ router.post("/webhook", async (req, res) => {
         continue;
       }
 
-      // last-write wins: if Google's timestamp is newer, apply the change.
-      // if ours is newer it means the user just edited it here and the webhook
-      // is stale -- our version is already correct, skip it.
+      // last-write wins, but with a 10-second buffer. when we push an edit to
+      // Google, Google fires a webhook back almost immediately and item.updated
+      // ends up slightly after our updated_at (Google processes it after we write
+      // to DB). without the buffer, that echo would trip the comparison and write
+      // Google's version back over ours, flipping sync_source to 'google'. the
+      // buffer means a Google-side change needs to be at least 10s newer than our
+      // last write to be treated as a real inbound change.
       const googleUpdated = new Date(item.updated);
       const ourUpdated = new Date(existing.updated_at);
+      const SYNC_BUFFER_MS = 10_000;
 
-      if (googleUpdated <= ourUpdated) continue;
+      if (googleUpdated <= new Date(ourUpdated.getTime() + SYNC_BUFFER_MS)) continue;
 
       const fields = fromGoogleEvent(item);
       if (Object.keys(fields).length > 0) {

--- a/utils/googleCalendar.js
+++ b/utils/googleCalendar.js
@@ -3,18 +3,20 @@ const { getValidAccessToken } = require("./googleToken");
 const db = require("./db");
 
 const GCAL_BASE = "https://www.googleapis.com/calendar/v3/calendars/primary";
+const FETCH_TIMEOUT_MS = 30_000;
 
 // maps our EVENT_COLORS hex values to the closest Google Calendar colorId.
+// these match the actual EVENT_COLORS array in src/lib/calendar.ts exactly.
 // Google's colorId reference: https://developers.google.com/calendar/api/v3/reference/colors/get
 const COLOR_MAP = {
-  "#6366f1": "9",  // blueberry
-  "#f43f5e": "11", // tomato
-  "#f97316": "6",  // tangerine
-  "#eab308": "5",  // banana
-  "#22c55e": "10", // sage
-  "#06b6d4": "7",  // peacock
-  "#8b5cf6": "3",  // grape
-  "#ec4899": "4",  // flamingo
+  "#3b82f6": "7",  // blue      -> peacock
+  "#10b981": "10", // emerald   -> sage
+  "#f59e0b": "5",  // amber     -> banana
+  "#ef4444": "11", // red       -> tomato
+  "#8b5cf6": "3",  // violet    -> grape
+  "#ec4899": "4",  // pink      -> flamingo
+  "#14b8a6": "7",  // teal      -> peacock (closest match)
+  "#f97316": "6",  // orange    -> tangerine
 };
 
 /**
@@ -77,6 +79,7 @@ async function createGoogleEvent(userId, event) {
       "Content-Type": "application/json",
     },
     body: JSON.stringify(toGoogleEvent(event)),
+    signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
   });
 
   if (!res.ok) {
@@ -113,6 +116,7 @@ async function updateGoogleEvent(userId, googleEventId, fields) {
       "Content-Type": "application/json",
     },
     body: JSON.stringify(toGoogleEvent(fields)),
+    signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
   });
 
   if (!res.ok) {
@@ -141,6 +145,7 @@ async function deleteGoogleEvent(userId, googleEventId) {
   const res = await fetch(`${GCAL_BASE}/events/${googleEventId}`, {
     method: "DELETE",
     headers: { Authorization: `Bearer ${token}` },
+    signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
   });
 
   // 404 means it's already gone, that's fine
@@ -167,7 +172,7 @@ async function fetchIncrementalEvents(userId, syncToken) {
 
   const res = await fetch(
     `${GCAL_BASE}/events?${params}`,
-    { headers: { Authorization: `Bearer ${token}` } },
+    { headers: { Authorization: `Bearer ${token}` }, signal: AbortSignal.timeout(FETCH_TIMEOUT_MS) },
   );
 
   // 410 Gone means the sync token is stale, do a full re-sync
@@ -214,6 +219,7 @@ async function registerWatch(userId) {
       token: userId,           // echoed back as X-Goog-Channel-Token on each ping
       expiration,
     }),
+    signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
   });
 
   if (!res.ok) {
@@ -262,6 +268,7 @@ async function stopWatch(userId) {
         id: auth.channel_id,
         resourceId: auth.resource_id,
       }),
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
     });
     // we don't check res.ok here, a 404 just means the channel already expired
   } catch (err) {


### PR DESCRIPTION
# Changelog

## 2026-03-12 - version 1.2.5

- fixed `COLOR_MAP` in `utils/googleCalendar.js`: previous hex values did not match the actual `EVENT_COLORS` used in the frontend, so almost every event fell back to blueberry "9"; map now keyed by the real event color hex values (`#3b82f6`, `#10b981`, `#f59e0b`, `#ef4444`, `#8b5cf6`, `#ec4899`, `#14b8a6`, `#f97316`)
- fixed `GOOGLE_COLOR_TO_HEX` reverse map in `routes/googleWebhook.js` to match, so colors round-trip correctly when Google-side changes are pulled back in
- fixed timestamp race in webhook handler: when we push an edit to Google, Google fires a webhook back almost immediately with `item.updated` slightly after our `updated_at`; the old `<=` comparison treated this echo as a real inbound change and wrote Google's version back, flipping `sync_source` to `'google'`; now uses a 10-second buffer (`SYNC_BUFFER_MS = 10_000`) so only genuine Google-side changes (made more than 10s after our last write) are applied