### PR TITLE
Webhook concurrency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2026-03-12 - version 1.2.7
+
+- fixed concurrent webhook processing race condition in `routes/googleWebhook.js`: when Google fires multiple push notifications in rapid succession (e.g. during initial sync flood), two handlers for the same user would both read the same `sync_token`, the second fetch would get a 410 Gone (token already consumed), trigger a full re-sync, and any deletions in the batch would be lost; added `enqueueForUser` — a per-user promise chain that ensures only one webhook handler runs at a time per user while different users still process concurrently
+
 ## 2026-03-12 - version 1.2.6
 
 - fixed Railway cron job conflicting with main server: both services share the same `railway.json`, so setting `startCommand` to `node utils/renewWatchChannels.js` broke the main server (502 on all routes); replaced with a `start.js` entry point that checks `RUN_CRON=true` env var — cron service gets that variable set in Railway dashboard, main server runs `server.js` as before

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portfolio_api",
-  "version": "1.2.6",
+  "version": "1.2.7",
   "description": "Portfolio API with Node.js and Python",
   "main": "server.js",
   "scripts": {

--- a/routes/googleWebhook.js
+++ b/routes/googleWebhook.js
@@ -4,6 +4,27 @@ const { fetchIncrementalEvents } = require("../utils/googleCalendar");
 
 const router = express.Router();
 
+// Per-user webhook queue. Google can fire multiple push notifications in rapid
+// succession (e.g. during initial sync flood). Each notification reads and writes
+// the user's sync_token, so concurrent handlers for the same user collide: the
+// second fetch uses a token that was already consumed, triggers a 410 full re-sync,
+// and any deletions in the batch get lost. Chaining promises per-user ensures
+// only one handler runs at a time per user while still allowing different users
+// to process concurrently.
+const userQueues = new Map();
+
+function enqueueForUser(userId, fn) {
+  const prev = userQueues.get(userId) ?? Promise.resolve();
+  const curr = prev.then(() => fn()).catch((err) => {
+    console.error(`[googleWebhook] handler error for ${userId}:`, err.message);
+  });
+  userQueues.set(userId, curr);
+  curr.finally(() => {
+    if (userQueues.get(userId) === curr) userQueues.delete(userId);
+  });
+  return curr;
+}
+
 // reverse color map: Google colorId back to our EVENT_COLORS hex values.
 // "7" (peacock) maps back to blue since both blue and teal map to peacock on the way out.
 const GOOGLE_COLOR_TO_HEX = {
@@ -72,7 +93,7 @@ router.post("/webhook", async (req, res) => {
   // there are no actual changes to process, just acknowledge it.
   if (resourceState === "sync") return;
 
-  try {
+  enqueueForUser(userId, async () => {
     const auth = await db.getGoogleAuth(userId);
     if (!auth) return;
 
@@ -124,10 +145,7 @@ router.post("/webhook", async (req, res) => {
         await db.updateCalendarEventFromWebhook(existing.id, fields, userId);
       }
     }
-  } catch (err) {
-    // log but don't throw, the 200 is already sent
-    console.error("[googleWebhook] Error processing notification:", err.message);
-  }
+  });
 });
 
 module.exports = router;


### PR DESCRIPTION
# Changelog

## 2026-03-12 - version 1.2.7

- fixed concurrent webhook processing race condition in `routes/googleWebhook.js`: when Google fires multiple push notifications in rapid succession (e.g. during initial sync flood), two handlers for the same user would both read the same `sync_token`, the second fetch would get a 410 Gone (token already consumed), trigger a full re-sync, and any deletions in the batch would be lost; added `enqueueForUser` — a per-user promise chain that ensures only one webhook handler runs at a time per user while different users still process concurrently