### PR TITLE
fix all day event conversion between google calendar and our frontend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2026-03-12 - version 1.2.9
+
+- fixed all-day event end date in `utils/googleCalendar.js`: Google Calendar treats all-day end dates as exclusive (the day after the last day), but our DB stores them as inclusive; added `exclusiveEndDate` helper in `toGoogleEvent` that adds one UTC day before sending to Google, so a single-day event no longer appears to end the day before in Google Calendar
+
 ## 2026-03-12 - version 1.2.8
 
 - fixed `fetchIncrementalEvents` in `utils/googleCalendar.js` not handling pagination: full syncs on calendars with many events return multiple pages via `nextPageToken`; only the final page carries `nextSyncToken`, so without pagination the stored sync token was always `null`/`undefined`, causing every subsequent webhook to trigger another full re-sync — deletions and updates from Google Calendar were never seen; now follows `nextPageToken` in a loop until `nextSyncToken` is returned, accumulating all items across pages

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portfolio_api",
-  "version": "1.2.8",
+  "version": "1.2.9",
   "description": "Portfolio API with Node.js and Python",
   "main": "server.js",
   "scripts": {

--- a/routes/googleWebhook.js
+++ b/routes/googleWebhook.js
@@ -55,10 +55,18 @@ function fromGoogleEvent(item) {
   if (item.start) {
     const allDay = Boolean(item.start.date && !item.start.dateTime);
     fields.allDay = allDay;
-    fields.startDate = allDay ? item.start.date : item.start.dateTime;
-    fields.endDate = allDay
-      ? item.end.date
-      : item.end.dateTime;
+    if (allDay) {
+      // Store as noon UTC so timezone conversion never shifts the date backward.
+      // Google's all-day end is exclusive (the day after the last day), so
+      // subtract one day to get our inclusive end date.
+      fields.startDate = `${item.start.date}T12:00:00.000Z`;
+      const exclusiveEnd = new Date(`${item.end.date}T12:00:00.000Z`);
+      exclusiveEnd.setUTCDate(exclusiveEnd.getUTCDate() - 1);
+      fields.endDate = exclusiveEnd.toISOString();
+    } else {
+      fields.startDate = item.start.dateTime;
+      fields.endDate = item.end.dateTime;
+    }
   }
 
   if (item.colorId !== undefined) {

--- a/utils/googleCalendar.js
+++ b/utils/googleCalendar.js
@@ -34,12 +34,20 @@ function toGoogleEvent(event) {
   // whether startDate is already a date string or a full ISO datetime.
   const dateOnly = (iso) => iso.slice(0, 10);
 
+  // Google's all-day end date is exclusive (the day after the last day).
+  // Add one UTC day to our inclusive endDate before sending.
+  const exclusiveEndDate = (iso) => {
+    const d = new Date(`${dateOnly(iso)}T12:00:00.000Z`);
+    d.setUTCDate(d.getUTCDate() + 1);
+    return d.toISOString().slice(0, 10);
+  };
+
   const start = allDay
     ? { date: dateOnly(startDate) }
     : { dateTime: startDate, timeZone: "UTC" };
 
   const end = allDay
-    ? { date: dateOnly(endDate) }
+    ? { date: exclusiveEndDate(endDate) }
     : { dateTime: endDate, timeZone: "UTC" };
 
   const body = {


### PR DESCRIPTION
# Changelog

## 2026-03-12 - version 1.2.9

- fixed all-day event end date in `utils/googleCalendar.js`: Google Calendar treats all-day end dates as exclusive (the day after the last day), but our DB stores them as inclusive; added `exclusiveEndDate` helper in `toGoogleEvent` that adds one UTC day before sending to Google, so a single-day event no longer appears to end the day before in Google Calendar
