### PR TITLE
Ps/feature/dedicated calendar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,5 @@ cache/fastf1/*
 # OS
 .DS_Store
 Thumbs.db
+
+/plan

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2026-03-12 - version 1.3.5
+
+- updated `POST /api/calendar/events` to fetch the event's calendar after insert and route the Google sync by `syncMode`: `push` targets `primary`, `two_way` targets `calendar.googleCalId`, `none` skips Google entirely
+- updated `PUT /api/calendar/events/:id` with the same calendar-aware sync routing for updates
+- updated `DELETE /api/calendar/events/:id` to fetch the event (including `calendarId`) before deletion, then route the Google delete to the correct calendar by `syncMode` after the DB row is gone
+
 ## 2026-03-12 - version 1.3.4
 
 - refactored `utils/googleToken.js`: renamed core logic to `getTokenAndCalId(userId)` which now returns `{ token, calId }` where `calId` is `google_auth.google_cal_id`; kept `getValidAccessToken(userId)` as a thin wrapper for callers that only need the token; both are exported

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 2026-03-13 - version 1.4.4
+
+- added `GET /api/calendar/calendars/:id/members`: accessible by owner or any member; synthesizes an owner entry from the calendars row and prepends it to the member list
+- added `POST /api/calendar/calendars/:id/members`: owner-only invite by email; rate-limited to 20 requests per minute per user sub; returns generic 404 when email is not found to avoid enumeration; returns 400 when owner tries to invite themselves
+- added `PUT /api/calendar/calendars/:id/members/:memberSub`: owner-only role update ('editor' or 'viewer')
+- added `DELETE /api/calendar/calendars/:id/members/:memberSub`: owner-only member removal
+
 ## 2026-03-13 - version 1.4.3
 
 - event create/update/delete: replaced `getCalendarById` with `getCalendarForMutation('editor')` for Google sync lookup so editors on shared calendars can write events and credentials always come from the owner's row

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2026-03-12 - version 1.3.9
+
+- added `POST /api/calendar/calendars/:id/connect-google` to `routes/calendar.js`: verifies calendar ownership, returns 200 as-is if already connected (idempotent), calls `createDedicatedCalendar` to create the Google Calendar, saves `googleCalId` and `googleCalName` to the calendar row, calls `registerWatch` to start the push channel (non-fatal on failure), returns the updated calendar
+
 ## 2026-03-12 - version 1.3.8
 
 - added `stopWatchByCalId(userId, calId)` to `utils/googleCalendar.js`: looks up the channel info from the `calendars` row via `getCalendarByGoogleCalId`, POSTs to the Google channels/stop endpoint, swallows all errors; exported alongside the existing `stopWatch`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2026-03-13 - version 1.4.5
+
+- added `addCalendarAclEntry(ownerUserId, googleCalId, memberEmail, role)` to `utils/googleCalendar.js`: maps 'editor' to 'writer' and 'viewer' to 'reader', POSTs to the Google ACL endpoint using the owner's token, throws on non-2xx
+- added `removeCalendarAclEntry(ownerUserId, googleCalId, memberEmail)` to `utils/googleCalendar.js`: DELETEs the user-scoped ACL rule, swallows 404, throws on other non-2xx responses
+
 ## 2026-03-13 - version 1.4.4
 
 - added `GET /api/calendar/calendars/:id/members`: accessible by owner or any member; synthesizes an owner entry from the calendars row and prepends it to the member list

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 2026-03-12 - version 1.3.4
+
+- refactored `utils/googleToken.js`: renamed core logic to `getTokenAndCalId(userId)` which now returns `{ token, calId }` where `calId` is `google_auth.google_cal_id`; kept `getValidAccessToken(userId)` as a thin wrapper for callers that only need the token; both are exported
+- removed `GCAL_BASE` constant from `utils/googleCalendar.js`; replaced with `calBase(calId)` helper that builds the per-calendar base URL with `encodeURIComponent`
+- updated `createGoogleEvent`, `updateGoogleEvent`, `deleteGoogleEvent`, `fetchIncrementalEvents`, and `registerWatch` to each accept an optional `calId` parameter; when omitted the function falls back to the user-level `calId` returned by `getTokenAndCalId`; the recursive full-sync call inside `fetchIncrementalEvents` now threads the original `calId` through
+- added `createDedicatedCalendar(token, name)` to `utils/googleCalendar.js`: POSTs to the Google Calendar API to create a new calendar, returns `{ calId, calName }`; takes a token directly to avoid double-fetching
+
 ## 2026-03-12 - version 1.3.3
 
 - updated `toCalendarEvent` in `utils/db.js` to include `calendarId` in the returned shape so route handlers and the frontend can read which calendar an event belongs to without a second query

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 2026-03-12 - version 1.3.11
+
+Multi-calendar + dedicated Google Calendar two-way sync release. Full breakdown across 1.3.0–1.3.10 below. Summary:
+
+- new `calendars` table with `sync_mode` (`none | push | two_way`), `google_cal_id`, and per-channel columns; `calendar_id` FK on `calendar_events` with cascade delete; migration at `scripts/calendar/migrate_calendars.js` backfills a "Personal" calendar per user and populates `calendar_id` on existing events
+- full calendar CRUD API (`GET`/`POST`/`PUT`/`DELETE /api/calendar/calendars`) with `POST /:id/connect-google` and `DELETE /:id/google` for linking and unlinking Google Calendars
+- per-calendar Google sync routing: event mutations look up the calendar's `syncMode` and target `primary` for push, the calendar's `google_cal_id` for two_way, or skip Google entirely for none
+- `createDedicatedCalendar`, `stopWatchByCalId`, per-calendar `registerWatch` with `userId:calId` channel tokens, and a webhook handler that routes notifications to the right calendar row by splitting the token on the colon
+- `renewWatchChannels` now queries `calendars` for `two_way` rows instead of `google_auth`
+- OAuth scope updated from `calendar.events` to `calendar` to allow creating and managing calendars
+
 ## 2026-03-12 - version 1.3.10
 
 - added `DELETE /api/calendar/calendars/:id/google` to `routes/calendar.js`: stops the Google push channel via `stopWatchByCalId` (called before the update so the google_cal_id is still available for lookup), then sets `google_cal_id=null`, `google_cal_name=null`, `sync_mode='push'`; returns the updated calendar; the Google Calendar itself is not deleted

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2026-03-13 - version 1.4.1
+
+- added `middleware/upsertUser.js`: reads `sub` and `email` from the Auth0 JWT payload and upserts a `users` row; skips the write when the sub+email pair is already cached in a module-level Map (avoids a DB write on every request); guards against missing email claim (logs warning, calls next without upserting); DB errors are non-fatal
+- wired `upsertUser` into `routes/calendar.js` immediately after `checkJwt` so all calendar routes populate the user record automatically
+
 ## 2026-03-13 - version 1.4.0
 
 - added `scripts/calendar/migrate_sharing.js`: creates `users` table (`sub PK`, `email UNIQUE`) with `idx_users_email`; creates `calendar_members` table (`id PK`, `calendar_id FK → calendars ON DELETE CASCADE`, `user_sub FK → users ON DELETE CASCADE`, `role CHECK('editor'|'viewer')`, `invited_by FK → users ON DELETE SET NULL`) with `idx_calendar_members_user` and `idx_calendar_members_calendar`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 2026-03-13 - version 1.4.3
+
+- event create/update/delete: replaced `getCalendarById` with `getCalendarForMutation('editor')` for Google sync lookup so editors on shared calendars can write events and credentials always come from the owner's row
+- calendar update (`PUT /calendars/:id`): added `getCalendarForMutation('owner')` preflight, returns 403 if not owner
+- calendar delete (`DELETE /calendars/:id`): same preflight; also removes `getCalendarById` duplicate lookup
+- `POST /calendars/:id/connect-google`: owner preflight, returns 403 if not owner
+- `DELETE /calendars/:id/google`: owner preflight, returns 403 if not owner
+
 ## 2026-03-13 - version 1.4.2
 
 - added `upsertUser`, `getUserBySub`, `getUserByEmail` to `utils/db.js`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2026-03-13 - version 1.4.7
+
+- fixed `ValidationError: ERR_ERL_KEY_GEN_IPV6` in `routes/calendar.js`: custom `keyGenerator` was falling back to `req.ip` directly, which `express-rate-limit` v7+ rejects because raw IPv6 addresses can be used to bypass limits; replaced with `ipKeyGenerator(req)` from `express-rate-limit` which normalizes IPv6 correctly; also switched from `const rateLimit = require(...)` to named import `{ rateLimit, ipKeyGenerator }`
+- `DELETE /calendars/:id/members/:memberSub`: added self-removal path — any member can remove themselves using `"me"` or their own sub as `:memberSub`; performs best-effort Google ACL removal using the owner's credentials and returns `{ googleAclRemoved }` consistent with the owner-removal path
+
 ## 2026-03-13 - version 1.4.6
 
 - `POST /calendars/:id/members`: fires `addCalendarAclEntry` as fire-and-forget after the DB insert so ACL latency never delays the HTTP response

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2026-03-13 - version 1.4.8
+
+- `middleware/upsertUser.js`: reads `X-User-Email` header as fallback when `email` is absent from the access token JWT — fixes sharing not working when Auth0 doesn't include email in the access token by default; primary fix is an Auth0 post-login Action that sets `email` as a custom claim, header is belt-and-suspenders
+- `GET /calendars/:id/members`: owner entry email now falls back to `req.auth.payload.email` (from the JWT) when `getUserBySub` returns null (e.g. first request after the sharing migration before the users table is populated)
+
 ## 2026-03-13 - version 1.4.7
 
 - fixed `ValidationError: ERR_ERL_KEY_GEN_IPV6` in `routes/calendar.js`: custom `keyGenerator` was falling back to `req.ip` directly, which `express-rate-limit` v7+ rejects because raw IPv6 addresses can be used to bypass limits; replaced with `ipKeyGenerator(req)` from `express-rate-limit` which normalizes IPv6 correctly; also switched from `const rateLimit = require(...)` to named import `{ rateLimit, ipKeyGenerator }`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2026-03-13 - version 1.4.6
+
+- `POST /calendars/:id/members`: fires `addCalendarAclEntry` as fire-and-forget after the DB insert so ACL latency never delays the HTTP response
+- `DELETE /calendars/:id/members/:memberSub`: awaits `removeCalendarAclEntry` and returns `{ googleAclRemoved: boolean }` (200) instead of 204 so the frontend can warn the user when Google access was not revoked
+- `DELETE /calendars/:id`: before the DB delete, calls `removeCalendarAclEntry` for all members via `Promise.allSettled` so one failure doesn't block the rest; runs before `stopWatchByCalId` so the channel is still alive for any retries
+
 ## 2026-03-13 - version 1.4.5
 
 - added `addCalendarAclEntry(ownerUserId, googleCalId, memberEmail, role)` to `utils/googleCalendar.js`: maps 'editor' to 'writer' and 'viewer' to 'reader', POSTs to the Google ACL endpoint using the owner's token, throws on non-2xx

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2026-03-12 - version 1.3.1
+
+- added calendar DB helpers to `utils/db.js`: `toCalendar` mapper, `getCalendars`, `getCalendarById`, `getCalendarByGoogleCalId`, `createCalendar`, `updateCalendar`, `deleteCalendar`; `updateCalendar` uses the same dynamic SET clause pattern as `updateCalendarEvent` and always bumps `updated_at`
+- added `createCalendarEventFromWebhook` helper: inserts a new `calendar_events` row with `sync_source='google'`, defaults title to `''` and color to `#3b82f6` so the webhook handler does not need to sanitize Google event fields before calling it
+
 ## 2026-03-12 - version 1.3.0
 
 - added `calendars` table with `id`, `name`, `color`, `user_sub`, `google_cal_id`, `google_cal_name`, `sync_mode`, `channel_id`, `resource_id`, `channel_expiry`, `sync_token`; `sync_mode` is `none | push | two_way` -- this is the foundation for per-calendar Google sync config and eventual two-way dedicated calendar support

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2026-03-12 - version 1.3.0
+
+- added `calendars` table with `id`, `name`, `color`, `user_sub`, `google_cal_id`, `google_cal_name`, `sync_mode`, `channel_id`, `resource_id`, `channel_expiry`, `sync_token`; `sync_mode` is `none | push | two_way` -- this is the foundation for per-calendar Google sync config and eventual two-way dedicated calendar support
+- added `calendar_id` FK column on `calendar_events` referencing `calendars(id)` with cascade delete
+- migration script `scripts/calendar/migrate_calendars.js` creates a "Personal" calendar (`sync_mode='push'`) for every user that already has events and backfills `calendar_id` on all existing events, preserving current one-way sync behavior
+
 ## 2026-03-12 - version 1.2.10
 
 - fixed `FRONTEND_URL` being a single static env var in `routes/google.js`: the single API deployment at `api.paulsumido.com` serves both `paulsumido.com` and `develop.paulsumido.com`, so the OAuth callback always redirected to the same frontend regardless of which one initiated the flow; frontend now passes `?origin=` to `GET /api/google/auth/url`, the origin is embedded (signed) in the OAuth state param alongside the userId, and the callback reads it back to redirect to the correct frontend; unknown origins are rejected with 400; `FRONTEND_URL` kept as fallback for any in-flight old-format state params

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2026-03-12 - version 1.3.7
+
+- updated `registerWatch` in `utils/googleCalendar.js` to set the channel token as `userId:googleCalId` instead of just `userId`; after registering, looks up the corresponding `calendars` row via `getCalendarByGoogleCalId` and stores channel info and bootstrap sync token there; falls back to `google_auth` when no matching calendar row exists (legacy push channels where `googleCalId` is "primary")
+- updated `routes/googleWebhook.js` to parse the new `userId:googleCalId` channel token format; new path looks up the `calendars` row by `googleCalId`, uses its `syncToken`, and saves the next token back to the calendar row after fetching; events not yet in our DB are imported via `createCalendarEventFromWebhook` for `two_way` calendars and skipped for all others; old single-userId token format falls back to the original `google_auth`-based flow for backward compatibility
+- extracted `processExistingItem` helper to deduplicate the update/delete logic shared by both the new and legacy webhook paths; moved `SYNC_BUFFER_MS` to module scope
+
 ## 2026-03-12 - version 1.3.6
 
 - updated OAuth scope in `routes/google.js` from `calendar.events` to `calendar`; the broader scope is required to create and manage dedicated Google Calendars for two_way sync; users who already authorized with the old scope will need to reconnect

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2026-03-12 - version 1.3.6
+
+- updated OAuth scope in `routes/google.js` from `calendar.events` to `calendar`; the broader scope is required to create and manage dedicated Google Calendars for two_way sync; users who already authorized with the old scope will need to reconnect
+
 ## 2026-03-12 - version 1.3.5
 
 - updated `POST /api/calendar/events` to fetch the event's calendar after insert and route the Google sync by `syncMode`: `push` targets `primary`, `two_way` targets `calendar.googleCalId`, `none` skips Google entirely

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2026-03-13 - version 1.4.0
+
+- added `scripts/calendar/migrate_sharing.js`: creates `users` table (`sub PK`, `email UNIQUE`) with `idx_users_email`; creates `calendar_members` table (`id PK`, `calendar_id FK → calendars ON DELETE CASCADE`, `user_sub FK → users ON DELETE CASCADE`, `role CHECK('editor'|'viewer')`, `invited_by FK → users ON DELETE SET NULL`) with `idx_calendar_members_user` and `idx_calendar_members_calendar`
+
 ## 2026-03-12 - version 1.3.11
 
 Multi-calendar + dedicated Google Calendar two-way sync release. Full breakdown across 1.3.0–1.3.10 below. Summary:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 2026-03-12 - version 1.3.3
+
+- updated `toCalendarEvent` in `utils/db.js` to include `calendarId` in the returned shape so route handlers and the frontend can read which calendar an event belongs to without a second query
+- updated `createCalendarEvent` to accept `calendarId` in the fields object and include it in the INSERT; if no `calendarId` is provided it falls back to the user's oldest calendar (the "Personal" calendar from migration) so existing callers do not break
+- updated `getCalendarEvents` to accept an optional `calendarId` filter that adds `AND ce.calendar_id = $N` to the WHERE clause
+- updated `GET /api/calendar/events` to read `calendarId` from `req.query` and pass it through; updated `POST /api/calendar/events` to read `calendarId` from `req.body` and pass it through
+
 ## 2026-03-12 - version 1.3.2
 
 - added calendar CRUD routes to `routes/calendar.js` under `/api/calendar/calendars`: `GET` (list), `POST` (create, validates name), `PUT /:id` (partial update, strips undefined fields before passing to db helper), `DELETE /:id` (204, cascade via FK); delete calls `stopWatchByCalId` stub before removing the row and logs any failure without aborting the delete; the Google Calendar itself is intentionally not deleted on disconnect

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2026-03-12 - version 1.3.10
+
+- added `DELETE /api/calendar/calendars/:id/google` to `routes/calendar.js`: stops the Google push channel via `stopWatchByCalId` (called before the update so the google_cal_id is still available for lookup), then sets `google_cal_id=null`, `google_cal_name=null`, `sync_mode='push'`; returns the updated calendar; the Google Calendar itself is not deleted
+
 ## 2026-03-12 - version 1.3.9
 
 - added `POST /api/calendar/calendars/:id/connect-google` to `routes/calendar.js`: verifies calendar ownership, returns 200 as-is if already connected (idempotent), calls `createDedicatedCalendar` to create the Google Calendar, saves `googleCalId` and `googleCalName` to the calendar row, calls `registerWatch` to start the push channel (non-fatal on failure), returns the updated calendar

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2026-03-12 - version 1.3.2
+
+- added calendar CRUD routes to `routes/calendar.js` under `/api/calendar/calendars`: `GET` (list), `POST` (create, validates name), `PUT /:id` (partial update, strips undefined fields before passing to db helper), `DELETE /:id` (204, cascade via FK); delete calls `stopWatchByCalId` stub before removing the row and logs any failure without aborting the delete; the Google Calendar itself is intentionally not deleted on disconnect
+
 ## 2026-03-12 - version 1.3.1
 
 - added calendar DB helpers to `utils/db.js`: `toCalendar` mapper, `getCalendars`, `getCalendarById`, `getCalendarByGoogleCalId`, `createCalendar`, `updateCalendar`, `deleteCalendar`; `updateCalendar` uses the same dynamic SET clause pattern as `updateCalendarEvent` and always bumps `updated_at`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2026-03-12 - version 1.3.8
+
+- added `stopWatchByCalId(userId, calId)` to `utils/googleCalendar.js`: looks up the channel info from the `calendars` row via `getCalendarByGoogleCalId`, POSTs to the Google channels/stop endpoint, swallows all errors; exported alongside the existing `stopWatch`
+- updated `utils/renewWatchChannels.js` to query `calendars` instead of `google_auth`: selects `two_way` calendars with a `google_cal_id` and a `channel_expiry` within 24 hours; calls `stopWatchByCalId` then `registerWatch` per calendar; imports `stopWatchByCalId` instead of `stopWatch`
+- wired up the real `stopWatchByCalId` in `routes/calendar.js`: removed the local stub, imported from `utils/googleCalendar`, fixed the call to pass `calendar.googleCalId` (the Google Calendar ID) instead of the calendar UUID
+
 ## 2026-03-12 - version 1.3.7
 
 - updated `registerWatch` in `utils/googleCalendar.js` to set the channel token as `userId:googleCalId` instead of just `userId`; after registering, looks up the corresponding `calendars` row via `getCalendarByGoogleCalId` and stores channel info and bootstrap sync token there; falls back to `google_auth` when no matching calendar row exists (legacy push channels where `googleCalId` is "primary")

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 2026-03-13 - version 1.4.2
+
+- added `upsertUser`, `getUserBySub`, `getUserByEmail` to `utils/db.js`
+- added `toCalendarMember`, `getCalendarMembers`, `addCalendarMember` (single CTE, no N+1), `updateCalendarMemberRole`, `removeCalendarMember` to `utils/db.js`
+- updated `toCalendar` to include `role`, `ownerSub`, `ownerEmail` for the UNION query shape
+- replaced `getCalendars` with a UNION query returning owned and shared calendars; each row carries `role` ('owner'|'editor'|'viewer') and `ownerSub`/`ownerEmail` for shared rows
+- added `getCalendarForMutation(calendarId, userSub, requiredRole)` — single write-auth chokepoint; 'owner' checks `user_sub` only; 'editor' also accepts `calendar_members` rows with role='editor'
+- updated `getCalendarEvents` to use LEFT JOIN on `calendar_members` (replaces correlated subquery) so members see events on shared calendars
+- updated `getCalendarEventById` with same LEFT JOIN expansion
+- updated `updateCalendarEvent` to allow editors on shared calendars via subquery join
+- updated `deleteCalendarEvent` to allow editors on shared calendars
+
 ## 2026-03-13 - version 1.4.1
 
 - added `middleware/upsertUser.js`: reads `sub` and `email` from the Auth0 JWT payload and upserts a `users` row; skips the write when the sub+email pair is already cached in a module-level Map (avoids a DB write on every request); guards against missing email claim (logs warning, calls next without upserting); DB errors are non-fatal

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Backend REST API for [paulsumido.com](https://paulsumido.com). Built with Node.j
 | Medical Journal | Protected CRUD journal for medical rotations (Auth0-gated)                      |
 | Feedback        | Rotation feedback linked to journal entries (Auth0-gated)                       |
 | ChatGPT         | OpenAI-powered chat and journal entry summarization (Auth0-gated)               |
-| Calendar        | Personal calendar events with Pokémon TCG card associations, plus countdowns (Auth0-gated) |
+| Calendar        | Personal calendar events, countdowns, and calendar sharing with editor/viewer roles (Auth0-gated) |
 | Web Vitals      | Real-user Core Web Vitals collection, P75 aggregation, and per-version filtering |
 | Forum / Markers | Post forum and geolocation markers stored in PostgreSQL                         |
 
@@ -106,22 +106,32 @@ Backend REST API for [paulsumido.com](https://paulsumido.com). Built with Node.j
 
 ### Calendar — `/api/calendar` _(Auth Required)_
 
-| Method | Path                         | Description                                                                                         |
-| ------ | ---------------------------- | --------------------------------------------------------------------------------------------------- |
-| GET    | `/events`                    | List events for the authenticated user (supports `?start=`, `?end=`, `?cardId=`, `?cardName=`)      |
-| GET    | `/events/:id`                | Get a single event                                                                                  |
-| POST   | `/events`                    | Create an event                                                                                     |
-| PUT    | `/events/:id`                | Update an event                                                                                     |
-| DELETE | `/events/:id`                | Delete an event                                                                                     |
-| GET    | `/events/:id/cards`          | List all TCG cards linked to an event                                                               |
-| POST   | `/events/:id/cards`          | Add a card to an event (`cardId`, `cardName` required; metadata denormalized from TCGdex at insert) |
-| PUT    | `/events/:id/cards/:entryId` | Update `quantity` or `notes` on a card entry                                                        |
-| DELETE | `/events/:id/cards/:entryId` | Remove a card from an event                                                                         |
-| GET    | `/countdowns`                | List all countdowns for the authenticated user, sorted by target date ascending                     |
-| GET    | `/countdowns/:id`            | Get a single countdown                                                                              |
-| POST   | `/countdowns`                | Create a countdown (`title` and `targetDate` required, `targetDate` as `"YYYY-MM-DD"`)             |
-| PUT    | `/countdowns/:id`            | Partial update — send only the fields to change                                                     |
-| DELETE | `/countdowns/:id`            | Delete a countdown                                                                                  |
+| Method | Path                                  | Description                                                                                         |
+| ------ | ------------------------------------- | --------------------------------------------------------------------------------------------------- |
+| GET    | `/events`                             | List events for the authenticated user (supports `?start=`, `?end=`, `?cardId=`, `?cardName=`)      |
+| GET    | `/events/:id`                         | Get a single event                                                                                  |
+| POST   | `/events`                             | Create an event                                                                                     |
+| PUT    | `/events/:id`                         | Update an event                                                                                     |
+| DELETE | `/events/:id`                         | Delete an event                                                                                     |
+| GET    | `/events/:id/cards`                   | List all TCG cards linked to an event                                                               |
+| POST   | `/events/:id/cards`                   | Add a card to an event (`cardId`, `cardName` required; metadata denormalized from TCGdex at insert) |
+| PUT    | `/events/:id/cards/:entryId`          | Update `quantity` or `notes` on a card entry                                                        |
+| DELETE | `/events/:id/cards/:entryId`          | Remove a card from an event                                                                         |
+| GET    | `/countdowns`                         | List all countdowns for the authenticated user, sorted by target date ascending                     |
+| GET    | `/countdowns/:id`                     | Get a single countdown                                                                              |
+| POST   | `/countdowns`                         | Create a countdown (`title` and `targetDate` required, `targetDate` as `"YYYY-MM-DD"`)             |
+| PUT    | `/countdowns/:id`                     | Partial update — send only the fields to change                                                     |
+| DELETE | `/countdowns/:id`                     | Delete a countdown                                                                                  |
+| GET    | `/calendars`                          | List all calendars owned by or shared with the user; owned rows include `role: "owner"`, shared rows include `role`, `ownerSub`, `ownerEmail` |
+| POST   | `/calendars`                          | Create a calendar (`name`, `color`, `syncMode` required)                                            |
+| PUT    | `/calendars/:id`                      | Update calendar name/color/syncMode — owner only                                                    |
+| DELETE | `/calendars/:id`                      | Delete a calendar and all its events — owner only; removes Google ACL entries via `Promise.allSettled` before DB delete |
+| POST   | `/calendars/:id/connect-google`       | Create a Google Calendar and register a push watch channel — owner only                             |
+| DELETE | `/calendars/:id/google`               | Disconnect Google Calendar, stop watch channel — owner only                                         |
+| GET    | `/calendars/:id/members`             | List members (owner entry synthesized at top); accessible by owner or any member                    |
+| POST   | `/calendars/:id/members`             | Invite by email — owner only; rate-limited 20/min; generic 404 if email not found                  |
+| PUT    | `/calendars/:id/members/:memberSub`  | Update member role (`editor`\|`viewer`) — owner only                                               |
+| DELETE | `/calendars/:id/members/:memberSub`  | Remove member — owner only, or `"me"` for self-removal; awaits Google ACL revocation and returns `{ googleAclRemoved }` |
 
 ### Web Vitals — `/api/vitals`
 
@@ -268,7 +278,12 @@ node scripts/vitals/migrate.js
 
 # Create countdowns table
 node scripts/calendar/migrate_countdowns.js
+
+# Create users + calendar_members tables (required for calendar sharing)
+node scripts/calendar/migrate_sharing.js
 ```
+
+> **Auth0 setup for sharing**: add a post-login Action that sets `api.accessToken.setCustomClaim("email", event.user.email)` so the backend `upsertUser` middleware can populate the users table from the JWT email claim.
 
 ### Tests
 

--- a/middleware/upsertUser.js
+++ b/middleware/upsertUser.js
@@ -25,10 +25,12 @@ const _seenUsers = new Map();
  */
 async function upsertUser(req, res, next) {
   const sub = req.auth?.payload?.sub;
-  const email = req.auth?.payload?.email;
+  // prefer the JWT claim; fall back to X-User-Email forwarded by the BFF from
+  // the Auth0 session (handles cases where email is absent from the access token)
+  const email = req.auth?.payload?.email ?? req.headers['x-user-email'] ?? null;
 
   if (!email) {
-    console.warn('[upsertUser] JWT missing email claim — sharing will not work for this user until email is present');
+    console.warn('[upsertUser] email not available from JWT or BFF header — sharing will not work for this user');
     return next();
   }
 

--- a/middleware/upsertUser.js
+++ b/middleware/upsertUser.js
@@ -1,0 +1,55 @@
+const { pool } = require('../config/database');
+
+/**
+ * Module-level cache: sub -> email for subs seen in this process lifetime.
+ * Skips the DB upsert when the sub+email pair hasn't changed, avoiding an
+ * unnecessary write on every authenticated request. Cleared on process restart
+ * (deploy), which is fine — the DB row is always authoritative.
+ * @type {Map<string, string>}
+ */
+const _seenUsers = new Map();
+
+/**
+ * Express middleware that upserts a `users` row from the Auth0 JWT payload.
+ *
+ * Reads `req.auth.payload.sub` and `req.auth.payload.email`. If email is missing
+ * (e.g. the openid+email scope was not granted), logs a warning and calls next()
+ * without touching the DB. A DB error also just logs and calls next() so it never
+ * blocks a calendar request.
+ *
+ * Must be placed after checkJwt in the middleware chain so req.auth is populated.
+ *
+ * @param {import('express').Request} req
+ * @param {import('express').Response} res
+ * @param {import('express').NextFunction} next
+ */
+async function upsertUser(req, res, next) {
+  const sub = req.auth?.payload?.sub;
+  const email = req.auth?.payload?.email;
+
+  if (!email) {
+    console.warn('[upsertUser] JWT missing email claim — sharing will not work for this user until email is present');
+    return next();
+  }
+
+  // skip the write if we've already seen this sub+email pair this process lifetime
+  if (_seenUsers.get(sub) === email) {
+    return next();
+  }
+
+  try {
+    await pool.query(
+      `INSERT INTO users (sub, email, updated_at)
+       VALUES ($1, $2, NOW())
+       ON CONFLICT (sub) DO UPDATE SET email = EXCLUDED.email, updated_at = NOW()`,
+      [sub, email],
+    );
+    _seenUsers.set(sub, email);
+  } catch (err) {
+    console.error('[upsertUser] DB upsert failed (non-fatal):', err.message);
+  }
+
+  next();
+}
+
+module.exports = upsertUser;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portfolio_api",
-  "version": "1.4.5",
+  "version": "1.4.6",
   "description": "Portfolio API with Node.js and Python",
   "main": "server.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portfolio_api",
-  "version": "1.3.11",
+  "version": "1.4.0",
   "description": "Portfolio API with Node.js and Python",
   "main": "server.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portfolio_api",
-  "version": "1.3.9",
+  "version": "1.3.10",
   "description": "Portfolio API with Node.js and Python",
   "main": "server.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portfolio_api",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "Portfolio API with Node.js and Python",
   "main": "server.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portfolio_api",
-  "version": "1.3.7",
+  "version": "1.3.8",
   "description": "Portfolio API with Node.js and Python",
   "main": "server.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portfolio_api",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "description": "Portfolio API with Node.js and Python",
   "main": "server.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portfolio_api",
-  "version": "1.3.5",
+  "version": "1.3.6",
   "description": "Portfolio API with Node.js and Python",
   "main": "server.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portfolio_api",
-  "version": "1.3.10",
+  "version": "1.3.11",
   "description": "Portfolio API with Node.js and Python",
   "main": "server.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portfolio_api",
-  "version": "1.3.6",
+  "version": "1.3.7",
   "description": "Portfolio API with Node.js and Python",
   "main": "server.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portfolio_api",
-  "version": "1.4.4",
+  "version": "1.4.5",
   "description": "Portfolio API with Node.js and Python",
   "main": "server.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portfolio_api",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "description": "Portfolio API with Node.js and Python",
   "main": "server.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portfolio_api",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "description": "Portfolio API with Node.js and Python",
   "main": "server.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portfolio_api",
-  "version": "1.3.8",
+  "version": "1.3.9",
   "description": "Portfolio API with Node.js and Python",
   "main": "server.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portfolio_api",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "description": "Portfolio API with Node.js and Python",
   "main": "server.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portfolio_api",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "Portfolio API with Node.js and Python",
   "main": "server.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portfolio_api",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Portfolio API with Node.js and Python",
   "main": "server.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portfolio_api",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "description": "Portfolio API with Node.js and Python",
   "main": "server.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portfolio_api",
-  "version": "1.2.10",
+  "version": "1.3.0",
   "description": "Portfolio API with Node.js and Python",
   "main": "server.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portfolio_api",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Portfolio API with Node.js and Python",
   "main": "server.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portfolio_api",
-  "version": "1.4.6",
+  "version": "1.4.7",
   "description": "Portfolio API with Node.js and Python",
   "main": "server.js",
   "scripts": {

--- a/routes/calendar.js
+++ b/routes/calendar.js
@@ -158,6 +158,127 @@ router.delete("/events/:id", async (req, res) => {
 });
 
 // ---------------------------------------------------------------------------
+// Calendars — /api/calendar/calendars
+// ---------------------------------------------------------------------------
+
+/**
+ * Stub -- stopWatchByCalId will be wired up in Prompt 9 when the cron/watch
+ * renewal is refactored to track channels per calendar rather than per user.
+ * For now, logging the intent is enough so the delete route can call it safely.
+ *
+ * @param {string} _userId
+ * @param {string} _calId
+ */
+async function stopWatchByCalId(_userId, _calId) {
+  console.log(`[calendar] stopWatchByCalId stub called for calId=${_calId} -- will implement in Prompt 9`);
+}
+
+/**
+ * GET /api/calendar/calendars
+ * Returns all calendars for the authenticated user.
+ */
+router.get("/calendars", async (req, res) => {
+  const userSub = req.auth.payload.sub;
+
+  try {
+    const calendars = await db.getCalendars(userSub);
+    res.json({ calendars });
+  } catch (err) {
+    console.error("GET /calendar/calendars failed:", err.message);
+    res.status(500).json({ error: "Failed to fetch calendars" });
+  }
+});
+
+/**
+ * POST /api/calendar/calendars
+ * Creates a new calendar for the user.
+ * Body: { name, color?, syncMode? }
+ */
+router.post("/calendars", async (req, res) => {
+  const userSub = req.auth.payload.sub;
+  const { name, color, syncMode } = req.body;
+
+  if (!name) {
+    return res.status(400).json({ error: "name is required" });
+  }
+
+  try {
+    const calendar = await db.createCalendar({ name, color, syncMode }, userSub);
+    res.status(201).json({ calendar });
+  } catch (err) {
+    console.error("POST /calendar/calendars failed:", err.message);
+    res.status(500).json({ error: "Failed to create calendar" });
+  }
+});
+
+/**
+ * PUT /api/calendar/calendars/:id
+ * Partial update -- only send the fields you want to change.
+ * Accepted fields: name, color, syncMode, googleCalId, googleCalName.
+ */
+router.put("/calendars/:id", async (req, res) => {
+  const userSub = req.auth.payload.sub;
+  const { id } = req.params;
+  const { name, color, syncMode, googleCalId, googleCalName } = req.body;
+  const fields = { name, color, syncMode, googleCalId, googleCalName };
+
+  // strip undefined so updateCalendar's presence-check works correctly
+  Object.keys(fields).forEach((k) => fields[k] === undefined && delete fields[k]);
+
+  if (Object.keys(fields).length === 0) {
+    return res.status(400).json({ error: "No fields provided to update" });
+  }
+
+  try {
+    const calendar = await db.updateCalendar(id, fields, userSub);
+
+    if (!calendar) {
+      return res.status(404).json({ error: "Calendar not found" });
+    }
+
+    res.json({ calendar });
+  } catch (err) {
+    console.error("PUT /calendar/calendars/:id failed:", err.message);
+    res.status(500).json({ error: "Failed to update calendar" });
+  }
+});
+
+/**
+ * DELETE /api/calendar/calendars/:id
+ * Deletes the calendar and cascade-deletes its events (via FK).
+ * If the calendar had a linked Google Calendar, we stop the watch channel first.
+ * We do NOT delete the Google Calendar itself -- the user may want to keep it.
+ */
+router.delete("/calendars/:id", async (req, res) => {
+  const userSub = req.auth.payload.sub;
+  const { id } = req.params;
+
+  try {
+    const calendar = await db.getCalendarById(id, userSub);
+
+    if (!calendar) {
+      return res.status(404).json({ error: "Calendar not found" });
+    }
+
+    // stop the watch channel before deleting so Google stops sending notifications
+    // for an ID we no longer have a record for. non-fatal if it fails.
+    if (calendar.googleCalId) {
+      try {
+        await stopWatchByCalId(userSub, id);
+      } catch (watchErr) {
+        console.error("DELETE /calendar/calendars/:id -- stopWatchByCalId failed:", watchErr.message);
+      }
+    }
+
+    await db.deleteCalendar(id, userSub);
+    res.status(204).send();
+  } catch (err) {
+    console.error("DELETE /calendar/calendars/:id failed:", err.message);
+    res.status(500).json({ error: "Failed to delete calendar" });
+  }
+});
+
+// ---------------------------------------------------------------------------
 // Card sub-routes — /api/calendar/events/:id/cards
 // :id      = calendar_events UUID
 // :entryId = event_cards UUID (the row, not the TCGdex card_id string)

--- a/routes/calendar.js
+++ b/routes/calendar.js
@@ -6,7 +6,10 @@ const {
   updateGoogleEvent,
   deleteGoogleEvent,
   stopWatchByCalId,
+  createDedicatedCalendar,
+  registerWatch,
 } = require("../utils/googleCalendar");
+const { getValidAccessToken } = require("../utils/googleToken");
 
 const router = express.Router();
 
@@ -283,6 +286,50 @@ router.delete("/calendars/:id", async (req, res) => {
   } catch (err) {
     console.error("DELETE /calendar/calendars/:id failed:", err.message);
     res.status(500).json({ error: "Failed to delete calendar" });
+  }
+});
+
+/**
+ * POST /api/calendar/calendars/:id/connect-google
+ * Creates a dedicated Google Calendar for the calendar row and registers a
+ * push notification channel. Idempotent: if googleCalId is already set, returns
+ * the existing calendar without creating a duplicate.
+ */
+router.post("/calendars/:id/connect-google", async (req, res) => {
+  const userSub = req.auth.payload.sub;
+  const { id } = req.params;
+
+  try {
+    const calendar = await db.getCalendarById(id, userSub);
+
+    if (!calendar) {
+      return res.status(404).json({ error: "Calendar not found" });
+    }
+
+    // already connected -- return as-is so the frontend can call this safely
+    if (calendar.googleCalId) {
+      return res.json({ calendar });
+    }
+
+    const token = await getValidAccessToken(userSub);
+    const { calId, calName } = await createDedicatedCalendar(token, calendar.name);
+
+    const updated = await db.updateCalendar(id, { googleCalId: calId, googleCalName: calName }, userSub);
+
+    // register the watch channel after saving the calId so registerWatch can
+    // look up the calendar row by google_cal_id to store channel info
+    try {
+      await registerWatch(userSub, calId);
+    } catch (watchErr) {
+      console.error("POST /calendar/calendars/:id/connect-google -- registerWatch failed:", watchErr.message);
+      // non-fatal: the calendar is linked to Google, sync just won't push until
+      // the cron renewal next runs or the user triggers a reconnect
+    }
+
+    res.json({ calendar: updated });
+  } catch (err) {
+    console.error("POST /calendar/calendars/:id/connect-google failed:", err.message);
+    res.status(500).json({ error: "Failed to connect Google Calendar" });
   }
 });
 

--- a/routes/calendar.js
+++ b/routes/calendar.js
@@ -333,6 +333,46 @@ router.post("/calendars/:id/connect-google", async (req, res) => {
   }
 });
 
+/**
+ * DELETE /api/calendar/calendars/:id/google
+ * Stops the Google Calendar push channel and unlinks the Google Calendar from
+ * this row. Resets sync_mode to 'push' so events keep syncing to Google primary.
+ * Does not delete the Google Calendar itself -- the user may want to keep it.
+ */
+router.delete("/calendars/:id/google", async (req, res) => {
+  const userSub = req.auth.payload.sub;
+  const { id } = req.params;
+
+  try {
+    const calendar = await db.getCalendarById(id, userSub);
+
+    if (!calendar) {
+      return res.status(404).json({ error: "Calendar not found" });
+    }
+
+    // stop the watch channel before we null out the google_cal_id, since
+    // stopWatchByCalId looks up the channel by google_cal_id
+    if (calendar.googleCalId) {
+      try {
+        await stopWatchByCalId(userSub, calendar.googleCalId);
+      } catch (watchErr) {
+        console.error("DELETE /calendar/calendars/:id/google -- stopWatchByCalId failed:", watchErr.message);
+      }
+    }
+
+    const updated = await db.updateCalendar(
+      id,
+      { googleCalId: null, googleCalName: null, syncMode: "push" },
+      userSub,
+    );
+
+    res.json({ calendar: updated });
+  } catch (err) {
+    console.error("DELETE /calendar/calendars/:id/google failed:", err.message);
+    res.status(500).json({ error: "Failed to disconnect Google Calendar" });
+  }
+});
+
 // ---------------------------------------------------------------------------
 // Card sub-routes — /api/calendar/events/:id/cards
 // :id      = calendar_events UUID

--- a/routes/calendar.js
+++ b/routes/calendar.js
@@ -26,14 +26,14 @@ router.use((err, req, res, next) => {
   next(err);
 });
 
-// GET /api/calendar/events?start=<ISO>&end=<ISO>&cardId=<id>&cardName=<name>
-// returns events for the authenticated user with optional date range and card filters
+// GET /api/calendar/events?start=<ISO>&end=<ISO>&cardId=<id>&cardName=<name>&calendarId=<uuid>
+// returns events for the authenticated user with optional date range, card, and calendar filters
 router.get("/events", async (req, res) => {
   const userSub = req.auth.payload.sub;
-  const { start, end, cardId, cardName } = req.query;
+  const { start, end, cardId, cardName, calendarId } = req.query;
 
   try {
-    const events = await db.getCalendarEvents(userSub, start, end, cardId, cardName);
+    const events = await db.getCalendarEvents(userSub, start, end, cardId, cardName, calendarId);
     res.json({ events });
   } catch (err) {
     console.error("GET /calendar/events failed:", err.message);
@@ -62,10 +62,10 @@ router.get("/events/:id", async (req, res) => {
 });
 
 // POST /api/calendar/events
-// body: { title, description?, startDate, endDate, allDay?, color? }
+// body: { title, description?, startDate, endDate, allDay?, color?, calendarId? }
 router.post("/events", async (req, res) => {
   const userSub = req.auth.payload.sub;
-  const { title, description, startDate, endDate, allDay, color } = req.body;
+  const { title, description, startDate, endDate, allDay, color, calendarId } = req.body;
 
   if (!title || !startDate || !endDate) {
     return res
@@ -75,7 +75,7 @@ router.post("/events", async (req, res) => {
 
   try {
     const event = await db.createCalendarEvent(
-      { title, description, startDate, endDate, allDay, color },
+      { title, description, startDate, endDate, allDay, color, calendarId },
       userSub,
     );
 

--- a/routes/calendar.js
+++ b/routes/calendar.js
@@ -10,6 +10,8 @@ const {
   stopWatchByCalId,
   createDedicatedCalendar,
   registerWatch,
+  addCalendarAclEntry,
+  removeCalendarAclEntry,
 } = require("../utils/googleCalendar");
 const { getValidAccessToken } = require("../utils/googleToken");
 
@@ -292,6 +294,15 @@ router.delete("/calendars/:id", async (req, res) => {
       return res.status(403).json({ error: "Not authorized" });
     }
 
+    // remove all member ACL entries from Google before deleting the calendar.
+    // allSettled so one failure doesn't block the others.
+    if (calendar.syncMode === "two_way" && calendar.googleCalId) {
+      const members = await db.getCalendarMembers(id);
+      await Promise.allSettled(
+        members.map((m) => removeCalendarAclEntry(userSub, calendar.googleCalId, m.email)),
+      );
+    }
+
     // stop the watch channel before deleting so Google stops sending notifications
     // for an ID we no longer have a record for. non-fatal if it fails.
     if (calendar.googleCalId) {
@@ -467,6 +478,13 @@ router.post("/calendars/:id/members", inviteRateLimit, async (req, res) => {
     }
 
     const member = await db.addCalendarMember(calendarId, target.sub, role, userSub);
+
+    // fire-and-forget so ACL latency never delays the HTTP response
+    if (cal.syncMode === "two_way" && cal.googleCalId) {
+      addCalendarAclEntry(userSub, cal.googleCalId, email, member.role)
+        .catch((err) => console.warn("[calendar] addCalendarAclEntry failed (non-fatal):", err.message));
+    }
+
     res.status(201).json({ member });
   } catch (err) {
     console.error("POST /calendar/calendars/:id/members failed:", err.message);
@@ -517,7 +535,21 @@ router.delete("/calendars/:id/members/:memberSub", async (req, res) => {
     const removed = await db.removeCalendarMember(calendarId, memberSub, userSub);
     if (!removed) return res.status(404).json({ error: "Member not found" });
 
-    res.status(204).send();
+    // attempt ACL removal and surface the result so the frontend can warn
+    // the user if Google access was not revoked (member removed from app but
+    // may still see the calendar in their Google Calendar)
+    let googleAclRemoved = true;
+    try {
+      const memberUser = await db.getUserBySub(memberSub);
+      if (cal.syncMode === "two_way" && cal.googleCalId && memberUser?.email) {
+        await removeCalendarAclEntry(userSub, cal.googleCalId, memberUser.email);
+      }
+    } catch (err) {
+      googleAclRemoved = false;
+      console.warn("[calendar] removeCalendarAclEntry failed:", err.message);
+    }
+
+    res.json({ googleAclRemoved });
   } catch (err) {
     console.error("DELETE /calendar/calendars/:id/members/:memberSub failed:", err.message);
     res.status(500).json({ error: "Failed to remove member" });

--- a/routes/calendar.js
+++ b/routes/calendar.js
@@ -436,10 +436,15 @@ router.get("/calendars/:id/members", async (req, res) => {
     if (!cal) return res.status(404).json({ error: "Calendar not found" });
 
     const ownerUser = await db.getUserBySub(cal.user_sub);
+    // fall back to the JWT email if the owner is the requester and the users
+    // table doesn't have their row yet (e.g. first request after migration)
+    const ownerEmail =
+      ownerUser?.email ??
+      (cal.user_sub === userSub ? (req.auth.payload.email ?? null) : null);
     const ownerEntry = {
       id: null,
       userSub: cal.user_sub,
-      email: ownerUser?.email ?? null,
+      email: ownerEmail,
       role: "owner",
     };
 

--- a/routes/calendar.js
+++ b/routes/calendar.js
@@ -5,6 +5,7 @@ const {
   createGoogleEvent,
   updateGoogleEvent,
   deleteGoogleEvent,
+  stopWatchByCalId,
 } = require("../utils/googleCalendar");
 
 const router = express.Router();
@@ -181,18 +182,6 @@ router.delete("/events/:id", async (req, res) => {
 // ---------------------------------------------------------------------------
 
 /**
- * Stub -- stopWatchByCalId will be wired up in Prompt 9 when the cron/watch
- * renewal is refactored to track channels per calendar rather than per user.
- * For now, logging the intent is enough so the delete route can call it safely.
- *
- * @param {string} _userId
- * @param {string} _calId
- */
-async function stopWatchByCalId(_userId, _calId) {
-  console.log(`[calendar] stopWatchByCalId stub called for calId=${_calId} -- will implement in Prompt 9`);
-}
-
-/**
  * GET /api/calendar/calendars
  * Returns all calendars for the authenticated user.
  */
@@ -283,7 +272,7 @@ router.delete("/calendars/:id", async (req, res) => {
     // for an ID we no longer have a record for. non-fatal if it fails.
     if (calendar.googleCalId) {
       try {
-        await stopWatchByCalId(userSub, id);
+        await stopWatchByCalId(userSub, calendar.googleCalId);
       } catch (watchErr) {
         console.error("DELETE /calendar/calendars/:id -- stopWatchByCalId failed:", watchErr.message);
       }

--- a/routes/calendar.js
+++ b/routes/calendar.js
@@ -79,13 +79,18 @@ router.post("/events", async (req, res) => {
       userSub,
     );
 
-    // push to Google after the DB write. if it fails the event is still saved
-    // here, the sync just won't have a Google counterpart yet.
+    // push to Google after the DB write. the calendar's syncMode determines
+    // which Google Calendar to target (or whether to skip entirely).
+    // if the sync fails the event is still saved -- the DB write is the source of truth.
     try {
-      const googleEventId = await createGoogleEvent(userSub, event);
-      if (googleEventId) {
-        await db.setEventGoogleId(event.id, googleEventId, userSub);
+      const calendar = await db.getCalendarById(event.calendarId, userSub);
+      let googleEventId;
+      if (calendar?.syncMode === "push") {
+        googleEventId = await createGoogleEvent(userSub, event, "primary");
+      } else if (calendar?.syncMode === "two_way" && calendar.googleCalId) {
+        googleEventId = await createGoogleEvent(userSub, event, calendar.googleCalId);
       }
+      if (googleEventId) await db.setEventGoogleId(event.id, googleEventId, userSub);
     } catch (syncErr) {
       console.error("POST /calendar/events Google sync failed:", syncErr.message);
     }
@@ -116,9 +121,15 @@ router.put("/events/:id", async (req, res) => {
     }
 
     // sync the change to Google if this event has been pushed there before.
-    // we pass the full updated event so Google gets the current state, not just the diff.
+    // pass the full updated event so Google gets the current state, not just the diff.
+    // the calendar's syncMode tells us which Google Calendar to target.
     try {
-      await updateGoogleEvent(userSub, event.googleEventId, event);
+      const calendar = await db.getCalendarById(event.calendarId, userSub);
+      if (calendar?.syncMode === "push") {
+        await updateGoogleEvent(userSub, event.googleEventId, event, "primary");
+      } else if (calendar?.syncMode === "two_way" && calendar.googleCalId) {
+        await updateGoogleEvent(userSub, event.googleEventId, event, calendar.googleCalId);
+      }
     } catch (syncErr) {
       console.error("PUT /calendar/events/:id Google sync failed:", syncErr.message);
     }
@@ -136,16 +147,24 @@ router.delete("/events/:id", async (req, res) => {
   const { id } = req.params;
 
   try {
-    // deleteCalendarEvent returns the deleted row including googleEventId,
-    // so we can clean up Google after the DB row is gone.
-    const deleted = await db.deleteCalendarEvent(id, userSub);
+    // fetch the event first so we have calendarId available after deletion
+    const existing = await db.getCalendarEventById(id, userSub);
 
-    if (!deleted) {
+    if (!existing) {
       return res.status(404).json({ error: "Event not found" });
     }
 
+    await db.deleteCalendarEvent(id, userSub);
+
+    // clean up Google after the DB row is gone. the calendar's syncMode tells
+    // us which Google Calendar to delete from.
     try {
-      await deleteGoogleEvent(userSub, deleted.googleEventId);
+      const calendar = await db.getCalendarById(existing.calendarId, userSub);
+      if (calendar?.syncMode === "push") {
+        await deleteGoogleEvent(userSub, existing.googleEventId, "primary");
+      } else if (calendar?.syncMode === "two_way" && calendar.googleCalId) {
+        await deleteGoogleEvent(userSub, existing.googleEventId, calendar.googleCalId);
+      }
     } catch (syncErr) {
       console.error("DELETE /calendar/events/:id Google sync failed:", syncErr.message);
     }

--- a/routes/calendar.js
+++ b/routes/calendar.js
@@ -1,6 +1,7 @@
 const express = require("express");
 const db = require("../utils/db");
 const { checkJwt } = require("../middleware/auth");
+const upsertUser = require("../middleware/upsertUser");
 const {
   createGoogleEvent,
   updateGoogleEvent,
@@ -15,6 +16,8 @@ const router = express.Router();
 
 // all calendar routes require a valid Auth0 token
 router.use(checkJwt);
+// seed the users table from the JWT so sharing invite-by-email lookup works
+router.use(upsertUser);
 
 // log JWT errors
 router.use((err, req, res, next) => {

--- a/routes/calendar.js
+++ b/routes/calendar.js
@@ -89,8 +89,10 @@ router.post("/events", async (req, res) => {
     // push to Google after the DB write. the calendar's syncMode determines
     // which Google Calendar to target (or whether to skip entirely).
     // if the sync fails the event is still saved -- the DB write is the source of truth.
+    // getCalendarForMutation returns the owner's calendar row regardless of whether
+    // the acting user is the owner or an editor, so Google credentials are always correct.
     try {
-      const calendar = await db.getCalendarById(event.calendarId, userSub);
+      const calendar = await db.getCalendarForMutation(event.calendarId, userSub, 'editor');
       let googleEventId;
       if (calendar?.syncMode === "push") {
         googleEventId = await createGoogleEvent(userSub, event, "primary");
@@ -131,7 +133,7 @@ router.put("/events/:id", async (req, res) => {
     // pass the full updated event so Google gets the current state, not just the diff.
     // the calendar's syncMode tells us which Google Calendar to target.
     try {
-      const calendar = await db.getCalendarById(event.calendarId, userSub);
+      const calendar = await db.getCalendarForMutation(event.calendarId, userSub, 'editor');
       if (calendar?.syncMode === "push") {
         await updateGoogleEvent(userSub, event.googleEventId, event, "primary");
       } else if (calendar?.syncMode === "two_way" && calendar.googleCalId) {
@@ -166,7 +168,7 @@ router.delete("/events/:id", async (req, res) => {
     // clean up Google after the DB row is gone. the calendar's syncMode tells
     // us which Google Calendar to delete from.
     try {
-      const calendar = await db.getCalendarById(existing.calendarId, userSub);
+      const calendar = await db.getCalendarForMutation(existing.calendarId, userSub, 'editor');
       if (calendar?.syncMode === "push") {
         await deleteGoogleEvent(userSub, existing.googleEventId, "primary");
       } else if (calendar?.syncMode === "two_way" && calendar.googleCalId) {
@@ -244,6 +246,9 @@ router.put("/calendars/:id", async (req, res) => {
   }
 
   try {
+    const owned = await db.getCalendarForMutation(id, userSub, 'owner');
+    if (!owned) return res.status(403).json({ error: 'Not authorized' });
+
     const calendar = await db.updateCalendar(id, fields, userSub);
 
     if (!calendar) {
@@ -268,10 +273,10 @@ router.delete("/calendars/:id", async (req, res) => {
   const { id } = req.params;
 
   try {
-    const calendar = await db.getCalendarById(id, userSub);
+    const calendar = await db.getCalendarForMutation(id, userSub, 'owner');
 
     if (!calendar) {
-      return res.status(404).json({ error: "Calendar not found" });
+      return res.status(403).json({ error: "Not authorized" });
     }
 
     // stop the watch channel before deleting so Google stops sending notifications
@@ -303,10 +308,10 @@ router.post("/calendars/:id/connect-google", async (req, res) => {
   const { id } = req.params;
 
   try {
-    const calendar = await db.getCalendarById(id, userSub);
+    const calendar = await db.getCalendarForMutation(id, userSub, 'owner');
 
     if (!calendar) {
-      return res.status(404).json({ error: "Calendar not found" });
+      return res.status(403).json({ error: "Not authorized" });
     }
 
     // already connected -- return as-is so the frontend can call this safely
@@ -347,10 +352,10 @@ router.delete("/calendars/:id/google", async (req, res) => {
   const { id } = req.params;
 
   try {
-    const calendar = await db.getCalendarById(id, userSub);
+    const calendar = await db.getCalendarForMutation(id, userSub, 'owner');
 
     if (!calendar) {
-      return res.status(404).json({ error: "Calendar not found" });
+      return res.status(403).json({ error: "Not authorized" });
     }
 
     // stop the watch channel before we null out the google_cal_id, since

--- a/routes/calendar.js
+++ b/routes/calendar.js
@@ -15,7 +15,7 @@ const {
 } = require("../utils/googleCalendar");
 const { getValidAccessToken } = require("../utils/googleToken");
 
-const rateLimit = require("express-rate-limit");
+const { rateLimit, ipKeyGenerator } = require("express-rate-limit");
 
 const router = express.Router();
 
@@ -23,7 +23,7 @@ const router = express.Router();
 const inviteRateLimit = rateLimit({
   windowMs: 60 * 1000,
   max: 20,
-  keyGenerator: (req) => req.auth?.payload?.sub ?? req.ip,
+  keyGenerator: (req) => req.auth?.payload?.sub ?? ipKeyGenerator(req),
   standardHeaders: true,
   legacyHeaders: false,
   message: { error: "Too many invite requests. Please wait a minute." },
@@ -522,13 +522,48 @@ router.put("/calendars/:id/members/:memberSub", async (req, res) => {
 
 /**
  * DELETE /api/calendar/calendars/:id/members/:memberSub
- * Removes a member. Owner-only.
+ * Owner can remove any member. Any member can remove themselves ("me" or their own sub).
  */
 router.delete("/calendars/:id/members/:memberSub", async (req, res) => {
   const userSub = req.auth.payload.sub;
-  const { id: calendarId, memberSub } = req.params;
+  const { id: calendarId, memberSub: rawMemberSub } = req.params;
+  // "me" is a convenience alias so the frontend doesn't need to know the sub
+  const memberSub = rawMemberSub === "me" ? userSub : rawMemberSub;
+  const isSelfRemoval = memberSub === userSub;
 
   try {
+    if (isSelfRemoval) {
+      // members can always leave their own shared calendars
+      const { rows } = await pool.query(
+        `DELETE FROM calendar_members
+         WHERE calendar_id = $1 AND user_sub = $2
+         RETURNING *`,
+        [calendarId, userSub],
+      );
+      if (!rows[0]) return res.status(404).json({ error: "Not a member of this calendar" });
+
+      // best-effort Google ACL removal; use the owner's credentials
+      let googleAclRemoved = true;
+      try {
+        const calRes = await pool.query(
+          `SELECT google_cal_id, sync_mode, user_sub AS owner_sub FROM calendars WHERE id = $1`,
+          [calendarId],
+        );
+        const calRow = calRes.rows[0];
+        if (calRow?.sync_mode === "two_way" && calRow?.google_cal_id) {
+          const memberUser = await db.getUserBySub(userSub);
+          if (memberUser?.email) {
+            await removeCalendarAclEntry(calRow.owner_sub, calRow.google_cal_id, memberUser.email);
+          }
+        }
+      } catch (err) {
+        googleAclRemoved = false;
+        console.warn("[calendar] removeCalendarAclEntry failed on leave:", err.message);
+      }
+      return res.json({ googleAclRemoved });
+    }
+
+    // owner removing someone else
     const cal = await db.getCalendarForMutation(calendarId, userSub, "owner");
     if (!cal) return res.status(403).json({ error: "Not authorized" });
 

--- a/routes/calendar.js
+++ b/routes/calendar.js
@@ -1,5 +1,6 @@
 const express = require("express");
 const db = require("../utils/db");
+const { pool } = require("../config/database");
 const { checkJwt } = require("../middleware/auth");
 const upsertUser = require("../middleware/upsertUser");
 const {
@@ -12,7 +13,19 @@ const {
 } = require("../utils/googleCalendar");
 const { getValidAccessToken } = require("../utils/googleToken");
 
+const rateLimit = require("express-rate-limit");
+
 const router = express.Router();
+
+// 20 invite attempts per minute per user sub (falls back to IP if sub is unavailable)
+const inviteRateLimit = rateLimit({
+  windowMs: 60 * 1000,
+  max: 20,
+  keyGenerator: (req) => req.auth?.payload?.sub ?? req.ip,
+  standardHeaders: true,
+  legacyHeaders: false,
+  message: { error: "Too many invite requests. Please wait a minute." },
+});
 
 // all calendar routes require a valid Auth0 token
 router.use(checkJwt);
@@ -378,6 +391,136 @@ router.delete("/calendars/:id/google", async (req, res) => {
   } catch (err) {
     console.error("DELETE /calendar/calendars/:id/google failed:", err.message);
     res.status(500).json({ error: "Failed to disconnect Google Calendar" });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Sharing — /api/calendar/calendars/:id/members
+// ---------------------------------------------------------------------------
+
+/**
+ * GET /api/calendar/calendars/:id/members
+ * Returns the owner entry (synthesized) plus all members.
+ * Accessible by the owner or any member.
+ */
+router.get("/calendars/:id/members", async (req, res) => {
+  const userSub = req.auth.payload.sub;
+  const { id: calendarId } = req.params;
+
+  try {
+    // allow owner or any member — a single union check
+    const { rows } = await pool.query(
+      `SELECT 1 FROM calendars        WHERE id = $1 AND user_sub = $2
+       UNION
+       SELECT 1 FROM calendar_members WHERE calendar_id = $1 AND user_sub = $2`,
+      [calendarId, userSub],
+    );
+    if (rows.length === 0) return res.status(403).json({ error: "Not authorized" });
+
+    const calRow = await pool.query(
+      "SELECT * FROM calendars WHERE id = $1",
+      [calendarId],
+    );
+    const cal = calRow.rows[0];
+    if (!cal) return res.status(404).json({ error: "Calendar not found" });
+
+    const ownerUser = await db.getUserBySub(cal.user_sub);
+    const ownerEntry = {
+      id: null,
+      userSub: cal.user_sub,
+      email: ownerUser?.email ?? null,
+      role: "owner",
+    };
+
+    const members = await db.getCalendarMembers(calendarId);
+    res.json({ members: [ownerEntry, ...members] });
+  } catch (err) {
+    console.error("GET /calendar/calendars/:id/members failed:", err.message);
+    res.status(500).json({ error: "Failed to fetch members" });
+  }
+});
+
+/**
+ * POST /api/calendar/calendars/:id/members
+ * Invites a user by email. Owner-only. Rate-limited to 20/min.
+ * Body: { email, role? }
+ */
+router.post("/calendars/:id/members", inviteRateLimit, async (req, res) => {
+  const userSub = req.auth.payload.sub;
+  const { id: calendarId } = req.params;
+  const { email, role = "editor" } = req.body;
+
+  if (!email) return res.status(400).json({ error: "email is required" });
+  if (!["editor", "viewer"].includes(role)) {
+    return res.status(400).json({ error: "role must be editor or viewer" });
+  }
+
+  try {
+    const cal = await db.getCalendarForMutation(calendarId, userSub, "owner");
+    if (!cal) return res.status(403).json({ error: "Not authorized" });
+
+    const target = await db.getUserByEmail(email);
+    // generic message — never reveal whether the email is registered or not
+    if (!target) return res.status(404).json({ error: "No account found for that email address." });
+    if (target.sub === userSub) {
+      return res.status(400).json({ error: "You cannot share a calendar with yourself." });
+    }
+
+    const member = await db.addCalendarMember(calendarId, target.sub, role, userSub);
+    res.status(201).json({ member });
+  } catch (err) {
+    console.error("POST /calendar/calendars/:id/members failed:", err.message);
+    res.status(500).json({ error: "Failed to invite member" });
+  }
+});
+
+/**
+ * PUT /api/calendar/calendars/:id/members/:memberSub
+ * Updates the role of an existing member. Owner-only.
+ * Body: { role }
+ */
+router.put("/calendars/:id/members/:memberSub", async (req, res) => {
+  const userSub = req.auth.payload.sub;
+  const { id: calendarId, memberSub } = req.params;
+  const { role } = req.body;
+
+  if (!["editor", "viewer"].includes(role)) {
+    return res.status(400).json({ error: "role must be editor or viewer" });
+  }
+
+  try {
+    const cal = await db.getCalendarForMutation(calendarId, userSub, "owner");
+    if (!cal) return res.status(403).json({ error: "Not authorized" });
+
+    const member = await db.updateCalendarMemberRole(calendarId, memberSub, role, userSub);
+    if (!member) return res.status(404).json({ error: "Member not found" });
+
+    res.json({ member });
+  } catch (err) {
+    console.error("PUT /calendar/calendars/:id/members/:memberSub failed:", err.message);
+    res.status(500).json({ error: "Failed to update member role" });
+  }
+});
+
+/**
+ * DELETE /api/calendar/calendars/:id/members/:memberSub
+ * Removes a member. Owner-only.
+ */
+router.delete("/calendars/:id/members/:memberSub", async (req, res) => {
+  const userSub = req.auth.payload.sub;
+  const { id: calendarId, memberSub } = req.params;
+
+  try {
+    const cal = await db.getCalendarForMutation(calendarId, userSub, "owner");
+    if (!cal) return res.status(403).json({ error: "Not authorized" });
+
+    const removed = await db.removeCalendarMember(calendarId, memberSub, userSub);
+    if (!removed) return res.status(404).json({ error: "Member not found" });
+
+    res.status(204).send();
+  } catch (err) {
+    console.error("DELETE /calendar/calendars/:id/members/:memberSub failed:", err.message);
+    res.status(500).json({ error: "Failed to remove member" });
   }
 });
 

--- a/routes/google.js
+++ b/routes/google.js
@@ -127,7 +127,7 @@ router.get("/auth/url", checkJwt, async (req, res) => {
       client_id: process.env.GOOGLE_CLIENT_ID,
       redirect_uri: process.env.GOOGLE_REDIRECT_URI,
       response_type: "code",
-      scope: "https://www.googleapis.com/auth/calendar.events",
+      scope: "https://www.googleapis.com/auth/calendar",
       access_type: "offline",
       prompt: "consent",
       state,

--- a/routes/googleWebhook.js
+++ b/routes/googleWebhook.js
@@ -76,81 +76,135 @@ function fromGoogleEvent(item) {
   return fields;
 }
 
+// last-write wins buffer: a Google-side change must be at least this many ms
+// newer than our last write to be treated as a real inbound change and not an
+// echo of our own push. see comment in processItem for the full explanation.
+const SYNC_BUFFER_MS = 10_000;
+
+/**
+ * Applies a single Google Calendar item to our DB for an event that already
+ * exists (identified by google_event_id). Handles deletes and updates.
+ *
+ * @param {Object} item - Google Calendar Event resource from the incremental feed
+ * @param {string} userId - Auth0 sub
+ * @param {Object} existing - our DB row (raw, with updated_at) from getEventByGoogleId
+ */
+async function processExistingItem(item, userId, existing) {
+  if (item.status === "cancelled") {
+    console.log(`[googleWebhook] deleting event ${existing.id} (google_event_id=${item.id})`);
+    await db.deleteCalendarEvent(existing.id, userId);
+    return;
+  }
+
+  // last-write wins, but with a 10-second buffer. when we push an edit to
+  // Google, Google fires a webhook back almost immediately and item.updated
+  // ends up slightly after our updated_at (Google processes it after we write
+  // to DB). without the buffer, that echo would trip the comparison and write
+  // Google's version back over ours, flipping sync_source to 'google'. the
+  // buffer means a Google-side change needs to be at least 10s newer than our
+  // last write to be treated as a real inbound change.
+  const googleUpdated = new Date(item.updated);
+  const ourUpdated = new Date(existing.updated_at);
+
+  if (googleUpdated <= new Date(ourUpdated.getTime() + SYNC_BUFFER_MS)) {
+    console.log(`[googleWebhook] skipping update for ${existing.id}: googleUpdated=${googleUpdated.toISOString()} ourUpdated=${ourUpdated.toISOString()} (within buffer)`);
+    return;
+  }
+
+  const fields = fromGoogleEvent(item);
+  if (Object.keys(fields).length > 0) {
+    console.log(`[googleWebhook] updating event ${existing.id} from Google`);
+    await db.updateCalendarEventFromWebhook(existing.id, fields, userId);
+  }
+}
+
 /**
  * POST /api/google/webhook
  *
- * Google pushes a notification here whenever something changes on the user's
- * primary calendar. The body is always empty -- everything useful is in the
- * headers. We respond 200 no matter what, because a 4xx or 5xx tells Google to
- * retry and eventually blacklist the channel.
+ * Google pushes a notification here whenever something changes on a watched
+ * calendar. The body is always empty -- everything useful is in the headers.
+ * We respond 200 immediately no matter what; a 4xx or 5xx tells Google to retry
+ * and eventually blacklist the channel.
  *
- * We only act on events that exist in our DB (identified by google_event_id).
- * Anything Google created on its own (Gmail RSVPs, events typed directly in
- * Google Calendar, etc.) is ignored -- we don't import foreign events.
+ * Channel token format:
+ *   New: "userId:googleCalId" -- routes to the calendars row for per-calendar sync.
+ *   Old: "userId"             -- legacy push channels, falls back to google_auth.
+ *
+ * For two_way calendars, new events created directly in Google Calendar are
+ * imported into our DB. For push calendars, only events we already track are
+ * updated or deleted.
  */
 router.post("/webhook", async (req, res) => {
   // respond immediately so Google doesn't time out waiting for us
   res.sendStatus(200);
 
-  const userId = req.headers["x-goog-channel-token"];
+  const channelToken = req.headers["x-goog-channel-token"];
   const resourceState = req.headers["x-goog-resource-state"];
 
-  if (!userId) return;
+  if (!channelToken) return;
 
   // "sync" is Google's initial handshake ping right after channel registration.
   // there are no actual changes to process, just acknowledge it.
   if (resourceState === "sync") return;
 
+  // parse userId and optional googleCalId from the channel token.
+  // new format: "userId:googleCalId", old format: just "userId"
+  const colonIdx = channelToken.indexOf(":");
+  const userId = colonIdx !== -1 ? channelToken.slice(0, colonIdx) : channelToken;
+  const googleCalId = colonIdx !== -1 ? channelToken.slice(colonIdx + 1) : null;
+
   enqueueForUser(userId, async () => {
-    const auth = await db.getGoogleAuth(userId);
-    if (!auth) return;
-
-    const { items, nextSyncToken } = await fetchIncrementalEvents(
-      userId,
-      auth.sync_token,
-    );
-
-    console.log(`[googleWebhook] ${items.length} item(s) from incremental fetch for ${userId}`);
-
-    // save the new sync token before processing items so if we crash partway
-    // through we don't re-process the same batch on the next notification.
-    await db.updateSyncToken(userId, nextSyncToken);
-
-    for (const item of items) {
-      // look up by google_event_id scoped to this user.
-      // if we don't have it, it's a foreign event and we skip it.
-      const existing = await db.getEventByGoogleId(item.id, userId);
-      if (!existing) {
-        console.log(`[googleWebhook] skipping item ${item.id} (status=${item.status}): not in our DB`);
-        continue;
+    if (googleCalId) {
+      // new per-calendar channel path
+      const calendar = await db.getCalendarByGoogleCalId(googleCalId, userId);
+      if (!calendar) {
+        console.log(`[googleWebhook] orphaned channel for googleCalId=${googleCalId} userId=${userId}`);
+        return;
       }
 
-      if (item.status === "cancelled") {
-        console.log(`[googleWebhook] deleting event ${existing.id} (google_event_id=${item.id})`);
-        await db.deleteCalendarEvent(existing.id, userId);
-        continue;
+      const { items, nextSyncToken } = await fetchIncrementalEvents(userId, calendar.syncToken, googleCalId);
+      console.log(`[googleWebhook] ${items.length} item(s) for ${userId} calId=${googleCalId}`);
+
+      // save token before processing so a mid-batch crash doesn't replay the same batch
+      await db.updateCalendar(calendar.id, { syncToken: nextSyncToken }, userId);
+
+      for (const item of items) {
+        const existing = await db.getEventByGoogleId(item.id, userId);
+
+        if (!existing) {
+          // new event created directly in Google Calendar -- only import for two_way
+          if (calendar.syncMode !== "two_way") {
+            console.log(`[googleWebhook] skipping ${item.id}: calendar is not two_way`);
+            continue;
+          }
+          if (item.status === "cancelled") continue;
+          const fields = fromGoogleEvent(item);
+          console.log(`[googleWebhook] importing new event ${item.id} into calendar ${calendar.id}`);
+          await db.createCalendarEventFromWebhook(fields, item.id, calendar.id, userId);
+          continue;
+        }
+
+        await processExistingItem(item, userId, existing);
       }
+    } else {
+      // legacy path: old-format channel token with no colon, userId only.
+      // uses google_auth.sync_token and does not import new foreign events.
+      const auth = await db.getGoogleAuth(userId);
+      if (!auth) return;
 
-      // last-write wins, but with a 10-second buffer. when we push an edit to
-      // Google, Google fires a webhook back almost immediately and item.updated
-      // ends up slightly after our updated_at (Google processes it after we write
-      // to DB). without the buffer, that echo would trip the comparison and write
-      // Google's version back over ours, flipping sync_source to 'google'. the
-      // buffer means a Google-side change needs to be at least 10s newer than our
-      // last write to be treated as a real inbound change.
-      const googleUpdated = new Date(item.updated);
-      const ourUpdated = new Date(existing.updated_at);
-      const SYNC_BUFFER_MS = 10_000;
+      const { items, nextSyncToken } = await fetchIncrementalEvents(userId, auth.sync_token);
+      console.log(`[googleWebhook] ${items.length} item(s) from incremental fetch for ${userId}`);
 
-      if (googleUpdated <= new Date(ourUpdated.getTime() + SYNC_BUFFER_MS)) {
-        console.log(`[googleWebhook] skipping update for ${existing.id}: googleUpdated=${googleUpdated.toISOString()} ourUpdated=${ourUpdated.toISOString()} (within buffer)`);
-        continue;
-      }
+      // save token before processing so a mid-batch crash doesn't replay the same batch
+      await db.updateSyncToken(userId, nextSyncToken);
 
-      const fields = fromGoogleEvent(item);
-      if (Object.keys(fields).length > 0) {
-        console.log(`[googleWebhook] updating event ${existing.id} from Google`);
-        await db.updateCalendarEventFromWebhook(existing.id, fields, userId);
+      for (const item of items) {
+        const existing = await db.getEventByGoogleId(item.id, userId);
+        if (!existing) {
+          console.log(`[googleWebhook] skipping item ${item.id} (status=${item.status}): not in our DB`);
+          continue;
+        }
+        await processExistingItem(item, userId, existing);
       }
     }
   });

--- a/scripts/calendar/migrate_calendars.js
+++ b/scripts/calendar/migrate_calendars.js
@@ -1,0 +1,91 @@
+require('dotenv').config();
+
+const { Pool } = require('pg');
+
+const pool = new Pool({
+    connectionString: process.env.DATABASE_URL,
+    ssl: process.env.NODE_ENV === 'production' ? { rejectUnauthorized: false } : false
+});
+
+async function migrate() {
+    const client = await pool.connect();
+    try {
+        console.log('Running calendars migration...');
+
+        // one row per named calendar per user. sync_mode controls whether events
+        // stay local, push one-way to Google primary, or sync two-way with a
+        // dedicated Google Calendar. channel_id and friends live here (not on
+        // google_auth) because each two_way calendar gets its own watch channel.
+        await client.query(`
+            CREATE TABLE IF NOT EXISTS calendars (
+              id              UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+              name            TEXT        NOT NULL,
+              color           TEXT        NOT NULL DEFAULT '#3b82f6',
+              user_sub        TEXT        NOT NULL,
+              google_cal_id   TEXT,
+              google_cal_name TEXT,
+              sync_mode       TEXT        NOT NULL DEFAULT 'none',
+              channel_id      TEXT,
+              resource_id     TEXT,
+              channel_expiry  TIMESTAMPTZ,
+              sync_token      TEXT,
+              created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+              updated_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
+            );
+        `);
+        console.log('Created table: calendars');
+
+        // fast lookup by user -- the most common query pattern
+        await client.query(`
+            CREATE INDEX IF NOT EXISTS idx_calendars_user
+              ON calendars(user_sub);
+        `);
+        console.log('Created index: idx_calendars_user');
+
+        // partial index for webhook routing -- only rows with a linked Google Calendar
+        await client.query(`
+            CREATE INDEX IF NOT EXISTS idx_calendars_google_cal
+              ON calendars(google_cal_id) WHERE google_cal_id IS NOT NULL;
+        `);
+        console.log('Created index: idx_calendars_google_cal');
+
+        // events now belong to a calendar; cascading delete keeps things tidy
+        await client.query(`
+            ALTER TABLE calendar_events
+              ADD COLUMN IF NOT EXISTS calendar_id UUID REFERENCES calendars(id) ON DELETE CASCADE;
+        `);
+        console.log('Added column: calendar_events.calendar_id');
+
+        // create a "Personal" calendar for every user that already has events.
+        // sync_mode='push' preserves the existing one-way Google sync they already had.
+        await client.query(`
+            INSERT INTO calendars (id, name, color, user_sub, sync_mode)
+            SELECT gen_random_uuid(), 'Personal', '#3b82f6', user_sub, 'push'
+            FROM   calendar_events
+            GROUP  BY user_sub
+            ON CONFLICT DO NOTHING;
+        `);
+        console.log('Inserted Personal calendar for each existing user');
+
+        // backfill calendar_id on existing events to point to their user's Personal calendar
+        await client.query(`
+            UPDATE calendar_events ce
+            SET    calendar_id = c.id
+            FROM   calendars c
+            WHERE  c.user_sub = ce.user_sub
+              AND  c.name = 'Personal'
+              AND  ce.calendar_id IS NULL;
+        `);
+        console.log('Backfilled calendar_id on existing events');
+
+        console.log('Migration complete.');
+    } catch (err) {
+        console.error('Migration failed:', err.message);
+        process.exit(1);
+    } finally {
+        client.release();
+        await pool.end();
+    }
+}
+
+migrate();

--- a/scripts/calendar/migrate_sharing.js
+++ b/scripts/calendar/migrate_sharing.js
@@ -1,0 +1,72 @@
+require('dotenv').config();
+
+const { Pool } = require('pg');
+
+const pool = new Pool({
+    connectionString: process.env.DATABASE_URL,
+    ssl: process.env.NODE_ENV === 'production' ? { rejectUnauthorized: false } : false
+});
+
+async function migrate() {
+    const client = await pool.connect();
+    try {
+        console.log('Running sharing migration...');
+
+        // one row per real user. populated on first API call via upsertUser middleware.
+        // sub is the Auth0 JWT sub claim. email comes from the JWT email claim.
+        await client.query(`
+            CREATE TABLE IF NOT EXISTS users (
+              sub        TEXT PRIMARY KEY,
+              email      TEXT NOT NULL UNIQUE,
+              created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+              updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+            );
+        `);
+        console.log('Created table: users');
+
+        // fast lookup when resolving an invite email to a sub
+        await client.query(`
+            CREATE INDEX IF NOT EXISTS idx_users_email ON users(email);
+        `);
+        console.log('Created index: idx_users_email');
+
+        // one row per (calendar, member) pair.
+        // role is 'editor' or 'viewer'. owner is not stored here; the
+        // calendar's user_sub IS the owner. invited_by tracks who sent the invite.
+        await client.query(`
+            CREATE TABLE IF NOT EXISTS calendar_members (
+              id           UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+              calendar_id  UUID        NOT NULL REFERENCES calendars(id) ON DELETE CASCADE,
+              user_sub     TEXT        NOT NULL REFERENCES users(sub)    ON DELETE CASCADE,
+              role         TEXT        NOT NULL DEFAULT 'editor' CHECK (role IN ('editor', 'viewer')),
+              invited_by   TEXT        REFERENCES users(sub) ON DELETE SET NULL,
+              created_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+              updated_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+              UNIQUE (calendar_id, user_sub)
+            );
+        `);
+        console.log('Created table: calendar_members');
+
+        await client.query(`
+            CREATE INDEX IF NOT EXISTS idx_calendar_members_user
+              ON calendar_members(user_sub);
+        `);
+        console.log('Created index: idx_calendar_members_user');
+
+        await client.query(`
+            CREATE INDEX IF NOT EXISTS idx_calendar_members_calendar
+              ON calendar_members(calendar_id);
+        `);
+        console.log('Created index: idx_calendar_members_calendar');
+
+        console.log('Migration complete.');
+    } catch (err) {
+        console.error('Migration failed:', err.message);
+        process.exit(1);
+    } finally {
+        client.release();
+        await pool.end();
+    }
+}
+
+migrate();

--- a/utils/db.js
+++ b/utils/db.js
@@ -490,12 +490,13 @@ function toCalendarEvent(row) {
     endDate: row.end_date instanceof Date ? row.end_date.toISOString() : row.end_date,
     allDay: row.all_day,
     color: row.color,
+    calendarId: row.calendar_id ?? undefined,
     // included so route handlers can read it for Google push sync without a second query
     googleEventId: row.google_event_id ?? undefined,
   };
 }
 
-async function getCalendarEvents(userSub, start, end, cardId, cardName) {
+async function getCalendarEvents(userSub, start, end, cardId, cardName, calendarId) {
   const values = [userSub];
   const needsCardJoin = cardId || cardName;
 
@@ -522,6 +523,10 @@ async function getCalendarEvents(userSub, start, end, cardId, cardName) {
     values.push(`%${cardName}%`);
     query += ` AND ec.card_name ILIKE $${values.length}`;
   }
+  if (calendarId) {
+    values.push(calendarId);
+    query += ` AND ce.calendar_id = $${values.length}`;
+  }
 
   query += " ORDER BY ce.start_date ASC";
 
@@ -547,21 +552,36 @@ async function getCalendarEventById(id, userSub) {
 /**
  * Creates a new calendar event for the authenticated user.
  *
- * @param {{ title: string, description?: string, startDate: string, endDate: string, allDay?: boolean, color?: string }} fields
+ * If calendarId is not provided we fall back to the user's oldest calendar
+ * (the "Personal" calendar created during migration) so existing callers
+ * don't need to be updated all at once.
+ *
+ * @param {{ title: string, description?: string, startDate: string, endDate: string, allDay?: boolean, color?: string, calendarId?: string }} fields
  * @param {string} userSub
  * @returns {Promise<Object>} the newly created row
  */
 async function createCalendarEvent(
-  { title, description, startDate, endDate, allDay = false, color = "#3b82f6" },
+  { title, description, startDate, endDate, allDay = false, color = "#3b82f6", calendarId },
   userSub,
 ) {
   const id = uuidv4();
 
+  // resolve the target calendar -- use the provided id or fall back to the
+  // user's first calendar so we always have a non-null calendar_id
+  let resolvedCalendarId = calendarId;
+  if (!resolvedCalendarId) {
+    const { rows: calRows } = await pool.query(
+      "SELECT id FROM calendars WHERE user_sub = $1 ORDER BY created_at ASC LIMIT 1",
+      [userSub],
+    );
+    resolvedCalendarId = calRows[0]?.id ?? null;
+  }
+
   const { rows } = await pool.query(
-    `INSERT INTO calendar_events (id, title, description, start_date, end_date, all_day, color, user_sub)
-     VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+    `INSERT INTO calendar_events (id, title, description, start_date, end_date, all_day, color, calendar_id, user_sub)
+     VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
      RETURNING *`,
-    [id, title, description || null, startDate, endDate, allDay, color, userSub],
+    [id, title, description || null, startDate, endDate, allDay, color, resolvedCalendarId, userSub],
   );
 
   return toCalendarEvent(rows[0]);

--- a/utils/db.js
+++ b/utils/db.js
@@ -837,6 +837,203 @@ async function clearEventGoogleId(googleEventId, userSub) {
 }
 
 // ---------------------------------------------------------------------------
+// Calendars
+// ---------------------------------------------------------------------------
+
+// maps a raw calendars row (snake_case) to the camelCase shape the frontend expects.
+// the watch channel fields (channelId etc.) live here because each two_way calendar
+// has its own dedicated channel, unlike the old setup where channels were per-user.
+function toCalendar(row) {
+  return {
+    id: row.id,
+    name: row.name,
+    color: row.color,
+    userSub: row.user_sub,
+    googleCalId: row.google_cal_id ?? undefined,
+    googleCalName: row.google_cal_name ?? undefined,
+    syncMode: row.sync_mode,
+    channelId: row.channel_id ?? undefined,
+    resourceId: row.resource_id ?? undefined,
+    channelExpiry: row.channel_expiry instanceof Date ? row.channel_expiry.toISOString() : (row.channel_expiry ?? undefined),
+    syncToken: row.sync_token ?? undefined,
+    createdAt: row.created_at instanceof Date ? row.created_at.toISOString() : row.created_at,
+    updatedAt: row.updated_at instanceof Date ? row.updated_at.toISOString() : row.updated_at,
+  };
+}
+
+/**
+ * Returns all calendars for a user in creation order (oldest first).
+ *
+ * @param {string} userSub
+ * @returns {Promise<Array>}
+ */
+async function getCalendars(userSub) {
+  const { rows } = await pool.query(
+    "SELECT * FROM calendars WHERE user_sub = $1 ORDER BY created_at ASC",
+    [userSub],
+  );
+  return rows.map(toCalendar);
+}
+
+/**
+ * Fetches a single calendar by its UUID. Returns null if it doesn't exist
+ * or belongs to a different user.
+ *
+ * @param {string} id
+ * @param {string} userSub
+ * @returns {Promise<Object|null>}
+ */
+async function getCalendarById(id, userSub) {
+  const { rows } = await pool.query(
+    "SELECT * FROM calendars WHERE id = $1 AND user_sub = $2",
+    [id, userSub],
+  );
+  return rows[0] ? toCalendar(rows[0]) : null;
+}
+
+/**
+ * Looks up a calendar by its Google Calendar ID. The webhook handler uses this
+ * to figure out which of our calendars a notification belongs to.
+ *
+ * @param {string} googleCalId
+ * @param {string} userSub
+ * @returns {Promise<Object|null>}
+ */
+async function getCalendarByGoogleCalId(googleCalId, userSub) {
+  const { rows } = await pool.query(
+    "SELECT * FROM calendars WHERE google_cal_id = $1 AND user_sub = $2",
+    [googleCalId, userSub],
+  );
+  return rows[0] ? toCalendar(rows[0]) : null;
+}
+
+/**
+ * Creates a new calendar for the authenticated user.
+ *
+ * @param {{ name: string, color?: string, syncMode?: string }} fields
+ * @param {string} userSub
+ * @returns {Promise<Object>} the newly created row
+ */
+async function createCalendar({ name, color = "#3b82f6", syncMode = "none" }, userSub) {
+  const id = uuidv4();
+  const { rows } = await pool.query(
+    `INSERT INTO calendars (id, name, color, user_sub, sync_mode)
+     VALUES ($1, $2, $3, $4, $5)
+     RETURNING *`,
+    [id, name, color, userSub, syncMode],
+  );
+  return toCalendar(rows[0]);
+}
+
+/**
+ * Partially updates a calendar. Only the owner can modify it.
+ * Pass only the fields you want to change -- everything else stays as-is.
+ * Always bumps updated_at.
+ *
+ * @param {string} id
+ * @param {{ name?: string, color?: string, syncMode?: string, googleCalId?: string,
+ *           googleCalName?: string, channelId?: string, resourceId?: string,
+ *           channelExpiry?: string, syncToken?: string }} fields
+ * @param {string} userSub
+ * @returns {Promise<Object|null>} updated row, or null if not found / not owned
+ */
+async function updateCalendar(id, fields, userSub) {
+  const colMap = {
+    name: "name",
+    color: "color",
+    syncMode: "sync_mode",
+    googleCalId: "google_cal_id",
+    googleCalName: "google_cal_name",
+    channelId: "channel_id",
+    resourceId: "resource_id",
+    channelExpiry: "channel_expiry",
+    syncToken: "sync_token",
+  };
+
+  const setClauses = [];
+  const values = [];
+
+  for (const [key, col] of Object.entries(colMap)) {
+    if (key in fields) {
+      values.push(fields[key]);
+      setClauses.push(`${col} = $${values.length}`);
+    }
+  }
+
+  if (setClauses.length === 0) return null;
+
+  // always bump updated_at so callers don't have to pass it explicitly
+  values.push(new Date());
+  setClauses.push(`updated_at = $${values.length}`);
+
+  values.push(id, userSub);
+
+  const { rows } = await pool.query(
+    `UPDATE calendars
+     SET ${setClauses.join(", ")}
+     WHERE id = $${values.length - 1} AND user_sub = $${values.length}
+     RETURNING *`,
+    values,
+  );
+
+  return rows[0] ? toCalendar(rows[0]) : null;
+}
+
+/**
+ * Deletes a calendar by ID. Only the owner can delete it.
+ * Events belonging to the calendar cascade-delete via the FK constraint.
+ *
+ * @param {string} id
+ * @param {string} userSub
+ * @returns {Promise<Object|null>} the deleted row, or null if not found
+ */
+async function deleteCalendar(id, userSub) {
+  const { rows } = await pool.query(
+    "DELETE FROM calendars WHERE id = $1 AND user_sub = $2 RETURNING *",
+    [id, userSub],
+  );
+  return rows[0] ? toCalendar(rows[0]) : null;
+}
+
+/**
+ * Inserts a calendar event that arrived from a Google webhook. Sets sync_source
+ * to 'google' so any subsequent user-driven mutation knows to push back out.
+ *
+ * Default color and title are applied here rather than in the webhook handler
+ * so this helper is safe to call without sanitizing the Google event first.
+ *
+ * @param {{ title?: string, description?: string, startDate: string, endDate: string, allDay?: boolean, color?: string }} fields
+ * @param {string} googleEventId
+ * @param {string} calendarId - UUID of our calendar row
+ * @param {string} userSub
+ * @returns {Promise<Object>} the newly created row
+ */
+async function createCalendarEventFromWebhook(fields, googleEventId, calendarId, userSub) {
+  const {
+    title = "",
+    description,
+    startDate,
+    endDate,
+    allDay = false,
+    color = "#3b82f6",
+  } = fields;
+
+  const id = uuidv4();
+
+  const { rows } = await pool.query(
+    `INSERT INTO calendar_events
+       (id, title, description, start_date, end_date, all_day, color,
+        calendar_id, user_sub, google_event_id, sync_source)
+     VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, 'google')
+     RETURNING *`,
+    [id, title, description || null, startDate, endDate, allDay, color,
+     calendarId, userSub, googleEventId],
+  );
+
+  return toCalendarEvent(rows[0]);
+}
+
+// ---------------------------------------------------------------------------
 // Event cards (TCG card ↔ calendar event junction)
 // ---------------------------------------------------------------------------
 
@@ -1140,6 +1337,13 @@ module.exports = {
   createCountdown,
   updateCountdown,
   deleteCountdown,
+  getCalendars,
+  getCalendarById,
+  getCalendarByGoogleCalId,
+  createCalendar,
+  updateCalendar,
+  deleteCalendar,
+  createCalendarEventFromWebhook,
   getEventByGoogleId,
   updateCalendarEventFromWebhook,
   getGoogleAuth,

--- a/utils/db.js
+++ b/utils/db.js
@@ -500,11 +500,16 @@ async function getCalendarEvents(userSub, start, end, cardId, cardName, calendar
   const values = [userSub];
   const needsCardJoin = cardId || cardName;
 
+  // LEFT JOIN calendar_members so members can see events on shared calendars.
+  // Using a join instead of a correlated subquery lets the planner use
+  // idx_calendar_members_calendar in a single pass.
   let query = `
     SELECT DISTINCT ce.*
     FROM calendar_events ce
     ${needsCardJoin ? "JOIN event_cards ec ON ec.event_id = ce.id" : ""}
-    WHERE ce.user_sub = $1
+    LEFT JOIN calendar_members cm
+      ON cm.calendar_id = ce.calendar_id AND cm.user_sub = $1
+    WHERE (ce.user_sub = $1 OR cm.user_sub IS NOT NULL)
   `;
 
   if (start) {
@@ -543,7 +548,11 @@ async function getCalendarEvents(userSub, start, end, cardId, cardName, calendar
  */
 async function getCalendarEventById(id, userSub) {
   const { rows } = await pool.query(
-    "SELECT * FROM calendar_events WHERE id = $1 AND user_sub = $2",
+    `SELECT ce.*
+     FROM   calendar_events ce
+     LEFT JOIN calendar_members cm
+       ON cm.calendar_id = ce.calendar_id AND cm.user_sub = $2
+     WHERE  ce.id = $1 AND (ce.user_sub = $2 OR cm.user_sub IS NOT NULL)`,
     [id, userSub],
   );
   return rows[0] ? toCalendarEvent(rows[0]) : null;
@@ -627,13 +636,24 @@ async function updateCalendarEvent(id, fields, userSub) {
   values.push(new Date());
   setClauses.push(`updated_at = $${values.length}`);
 
+  // editors on shared calendars can also update events — join membership
   values.push(id, userSub);
+  const idIdx = values.length - 1;
+  const subIdx = values.length;
 
   const { rows } = await pool.query(
-    `UPDATE calendar_events
+    `UPDATE calendar_events ce
      SET ${setClauses.join(", ")}
-     WHERE id = $${values.length - 1} AND user_sub = $${values.length}
-     RETURNING *`,
+     FROM (
+       SELECT ce2.id
+       FROM   calendar_events ce2
+       LEFT JOIN calendar_members cm
+         ON cm.calendar_id = ce2.calendar_id AND cm.user_sub = $${subIdx} AND cm.role = 'editor'
+       WHERE  ce2.id = $${idIdx}
+         AND  (ce2.user_sub = $${subIdx} OR cm.user_sub IS NOT NULL)
+     ) AS allowed
+     WHERE ce.id = allowed.id
+     RETURNING ce.*`,
     values,
   );
 
@@ -648,8 +668,19 @@ async function updateCalendarEvent(id, fields, userSub) {
  * @returns {Promise<Object|null>} the deleted row, or null if not found
  */
 async function deleteCalendarEvent(id, userSub) {
+  // editors on shared calendars can also delete events
   const { rows } = await pool.query(
-    "DELETE FROM calendar_events WHERE id = $1 AND user_sub = $2 RETURNING *",
+    `DELETE FROM calendar_events
+     WHERE id = $1
+       AND (
+         user_sub = $2
+         OR EXISTS (
+           SELECT 1 FROM calendar_members cm
+           JOIN calendar_events ce ON ce.id = $1
+           WHERE cm.calendar_id = ce.calendar_id AND cm.user_sub = $2 AND cm.role = 'editor'
+         )
+       )
+     RETURNING *`,
     [id, userSub],
   );
 
@@ -860,6 +891,162 @@ async function clearEventGoogleId(googleEventId, userSub) {
 // Calendars
 // ---------------------------------------------------------------------------
 
+// ---------------------------------------------------------------------------
+// Users
+// ---------------------------------------------------------------------------
+
+/**
+ * Upserts a users row from Auth0 JWT claims. Called by upsertUser middleware.
+ *
+ * @param {string} sub   - Auth0 sub claim
+ * @param {string} email - Auth0 email claim
+ */
+async function upsertUser(sub, email) {
+  await pool.query(
+    `INSERT INTO users (sub, email, updated_at)
+     VALUES ($1, $2, NOW())
+     ON CONFLICT (sub) DO UPDATE SET email = EXCLUDED.email, updated_at = NOW()`,
+    [sub, email],
+  );
+}
+
+/**
+ * Returns the users row for a given sub, or null.
+ *
+ * @param {string} sub
+ * @returns {Promise<Object|null>}
+ */
+async function getUserBySub(sub) {
+  const { rows } = await pool.query('SELECT * FROM users WHERE sub = $1', [sub]);
+  return rows[0] ?? null;
+}
+
+/**
+ * Returns the users row for a given email, or null.
+ * Used to resolve an invite email to a sub before inserting a calendar_members row.
+ *
+ * @param {string} email
+ * @returns {Promise<Object|null>}
+ */
+async function getUserByEmail(email) {
+  const { rows } = await pool.query('SELECT * FROM users WHERE email = $1', [email]);
+  return rows[0] ?? null;
+}
+
+// ---------------------------------------------------------------------------
+// Calendar members
+// ---------------------------------------------------------------------------
+
+/**
+ * Maps a raw calendar_members row (with a joined email column) to camelCase.
+ *
+ * @param {Object} row
+ * @returns {{ id: string, calendarId: string, userSub: string, email: string,
+ *             role: string, invitedBy: string|null, createdAt: string }}
+ */
+function toCalendarMember(row) {
+  return {
+    id: row.id,
+    calendarId: row.calendar_id,
+    userSub: row.user_sub,
+    email: row.email,
+    role: row.role,
+    invitedBy: row.invited_by ?? null,
+    createdAt: row.created_at instanceof Date ? row.created_at.toISOString() : row.created_at,
+  };
+}
+
+/**
+ * Returns all members of a calendar in creation order.
+ * Does NOT perform an ownership check — the route layer is responsible
+ * for verifying the caller is the owner or a member before calling this.
+ *
+ * @param {string} calendarId
+ * @returns {Promise<Array>}
+ */
+async function getCalendarMembers(calendarId) {
+  const { rows } = await pool.query(
+    `SELECT cm.*, u.email
+     FROM   calendar_members cm
+     JOIN   users u ON u.sub = cm.user_sub
+     WHERE  cm.calendar_id = $1
+     ORDER BY cm.created_at ASC`,
+    [calendarId],
+  );
+  return rows.map(toCalendarMember);
+}
+
+/**
+ * Adds (or updates the role of) a calendar member. Uses a single CTE to return
+ * the email without a second round-trip.
+ *
+ * @param {string} calendarId
+ * @param {string} userSub      - the sub of the user being invited
+ * @param {string} role         - 'editor' or 'viewer'
+ * @param {string} invitedBySub - the sub of the user sending the invite
+ * @returns {Promise<Object>} the inserted/updated toCalendarMember row
+ */
+async function addCalendarMember(calendarId, userSub, role, invitedBySub) {
+  const { rows } = await pool.query(
+    `WITH ins AS (
+       INSERT INTO calendar_members (id, calendar_id, user_sub, role, invited_by)
+       VALUES (gen_random_uuid(), $1, $2, $3, $4)
+       ON CONFLICT (calendar_id, user_sub) DO UPDATE
+         SET role = EXCLUDED.role, updated_at = NOW()
+       RETURNING *
+     )
+     SELECT ins.*, u.email
+     FROM   ins
+     JOIN   users u ON u.sub = ins.user_sub`,
+    [calendarId, userSub, role, invitedBySub],
+  );
+  return toCalendarMember(rows[0]);
+}
+
+/**
+ * Updates the role of an existing calendar member. Owner-gated via EXISTS.
+ *
+ * @param {string} calendarId
+ * @param {string} memberSub
+ * @param {string} role     - 'editor' or 'viewer'
+ * @param {string} ownerSub
+ * @returns {Promise<Object|null>}
+ */
+async function updateCalendarMemberRole(calendarId, memberSub, role, ownerSub) {
+  const { rows } = await pool.query(
+    `UPDATE calendar_members SET role = $1, updated_at = NOW()
+     WHERE  calendar_id = $2 AND user_sub = $3
+     AND EXISTS (SELECT 1 FROM calendars WHERE id = $2 AND user_sub = $4)
+     RETURNING *`,
+    [role, calendarId, memberSub, ownerSub],
+  );
+  if (!rows[0]) return null;
+  // fetch email for the mapper
+  const user = await getUserBySub(memberSub);
+  return toCalendarMember({ ...rows[0], email: user?.email ?? null });
+}
+
+/**
+ * Removes a calendar member. Owner-gated via EXISTS.
+ *
+ * @param {string} calendarId
+ * @param {string} memberSub
+ * @param {string} ownerSub
+ * @returns {Promise<Object|null>}
+ */
+async function removeCalendarMember(calendarId, memberSub, ownerSub) {
+  const { rows } = await pool.query(
+    `DELETE FROM calendar_members
+     WHERE  calendar_id = $1 AND user_sub = $2
+     AND EXISTS (SELECT 1 FROM calendars WHERE id = $1 AND user_sub = $3)
+     RETURNING *`,
+    [calendarId, memberSub, ownerSub],
+  );
+  if (!rows[0]) return null;
+  const user = await getUserBySub(memberSub);
+  return toCalendarMember({ ...rows[0], email: user?.email ?? null });
+}
+
 // maps a raw calendars row (snake_case) to the camelCase shape the frontend expects.
 // the watch channel fields (channelId etc.) live here because each two_way calendar
 // has its own dedicated channel, unlike the old setup where channels were per-user.
@@ -878,6 +1065,10 @@ function toCalendar(row) {
     syncToken: row.sync_token ?? undefined,
     createdAt: row.created_at instanceof Date ? row.created_at.toISOString() : row.created_at,
     updatedAt: row.updated_at instanceof Date ? row.updated_at.toISOString() : row.updated_at,
+    // sharing fields — present when the UNION query is used (getCalendars)
+    role: row.role ?? undefined,
+    ownerSub: row.owner_sub ?? undefined,
+    ownerEmail: row.owner_email ?? undefined,
   };
 }
 
@@ -887,9 +1078,25 @@ function toCalendar(row) {
  * @param {string} userSub
  * @returns {Promise<Array>}
  */
+/**
+ * Returns all calendars the user owns or is a member of, in creation order.
+ * Each row carries a `role` field ('owner' | 'editor' | 'viewer'). Shared
+ * calendars also include `ownerSub` and `ownerEmail` from the owner's users row.
+ *
+ * @param {string} userSub
+ * @returns {Promise<Array>}
+ */
 async function getCalendars(userSub) {
   const { rows } = await pool.query(
-    "SELECT * FROM calendars WHERE user_sub = $1 ORDER BY created_at ASC",
+    `SELECT c.*, 'owner' AS role, NULL AS owner_sub, NULL AS owner_email
+     FROM   calendars c
+     WHERE  c.user_sub = $1
+     UNION ALL
+     SELECT c.*, cm.role, c.user_sub AS owner_sub, u.email AS owner_email
+     FROM   calendars c
+     JOIN   calendar_members cm ON cm.calendar_id = c.id AND cm.user_sub = $1
+     JOIN   users u ON u.sub = c.user_sub
+     ORDER  BY created_at ASC`,
     [userSub],
   );
   return rows.map(toCalendar);
@@ -924,6 +1131,42 @@ async function getCalendarByGoogleCalId(googleCalId, userSub) {
     "SELECT * FROM calendars WHERE google_cal_id = $1 AND user_sub = $2",
     [googleCalId, userSub],
   );
+  return rows[0] ? toCalendar(rows[0]) : null;
+}
+
+/**
+ * Single choke-point for write authorization on calendars and their events.
+ *
+ * requiredRole:
+ *   'owner'  — calendar settings, sharing management, delete calendar.
+ *              Only the calendar's user_sub passes.
+ *   'editor' — event create/update/delete.
+ *              The owner and any calendar_members row with role='editor' pass.
+ *
+ * Returns the calendar row (via toCalendar, without role/ownerSub/ownerEmail)
+ * or null when the caller is not authorized. Route handlers treat null as 403/404.
+ *
+ * @param {string} calendarId
+ * @param {string} userSub
+ * @param {'owner'|'editor'} requiredRole
+ * @returns {Promise<Object|null>}
+ */
+async function getCalendarForMutation(calendarId, userSub, requiredRole) {
+  let query;
+  if (requiredRole === 'owner') {
+    query = 'SELECT * FROM calendars WHERE id = $1 AND user_sub = $2';
+  } else {
+    query = `SELECT c.* FROM calendars c
+             WHERE  c.id = $1
+             AND (
+               c.user_sub = $2
+               OR EXISTS (
+                 SELECT 1 FROM calendar_members
+                 WHERE calendar_id = $1 AND user_sub = $2 AND role = 'editor'
+               )
+             )`;
+  }
+  const { rows } = await pool.query(query, [calendarId, userSub]);
   return rows[0] ? toCalendar(rows[0]) : null;
 }
 
@@ -1357,9 +1600,17 @@ module.exports = {
   createCountdown,
   updateCountdown,
   deleteCountdown,
+  upsertUser,
+  getUserBySub,
+  getUserByEmail,
+  getCalendarMembers,
+  addCalendarMember,
+  updateCalendarMemberRole,
+  removeCalendarMember,
   getCalendars,
   getCalendarById,
   getCalendarByGoogleCalId,
+  getCalendarForMutation,
   createCalendar,
   updateCalendar,
   deleteCalendar,

--- a/utils/googleCalendar.js
+++ b/utils/googleCalendar.js
@@ -325,9 +325,44 @@ async function createDedicatedCalendar(token, name) {
 }
 
 /**
- * Stops an existing watch channel. Called on disconnect and before re-registering
- * during renewal. Swallows errors since Google returns 404 for already-expired
- * channels, which is fine.
+ * Stops the watch channel for a specific Google Calendar. Used by the cron job
+ * and the calendar delete route before re-registering or removing a two_way calendar.
+ * Looks up the channel info from the calendars row rather than google_auth, since
+ * per-calendar channels are stored there.
+ * Swallows errors -- a 404 from Google just means the channel already expired.
+ *
+ * @param {string} userId - Auth0 sub
+ * @param {string} calId - Google Calendar ID (google_cal_id column)
+ */
+async function stopWatchByCalId(userId, calId) {
+  try {
+    const calendar = await db.getCalendarByGoogleCalId(calId, userId);
+    if (!calendar?.channelId || !calendar?.resourceId) return;
+
+    const token = await getValidAccessToken(userId);
+
+    await fetch("https://www.googleapis.com/calendar/v3/channels/stop", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        id: calendar.channelId,
+        resourceId: calendar.resourceId,
+      }),
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+    });
+    // we don't check res.ok here, a 404 just means the channel already expired
+  } catch (err) {
+    console.warn(`[googleCalendar] stopWatchByCalId failed for ${userId} calId=${calId}:`, err.message);
+  }
+}
+
+/**
+ * Stops an existing watch channel for the user's legacy primary calendar.
+ * Called on disconnect and before re-registering during renewal.
+ * Swallows errors since Google returns 404 for already-expired channels.
  *
  * @param {string} userId - Auth0 sub
  */
@@ -363,5 +398,6 @@ module.exports = {
   fetchIncrementalEvents,
   registerWatch,
   stopWatch,
+  stopWatchByCalId,
   createDedicatedCalendar,
 };

--- a/utils/googleCalendar.js
+++ b/utils/googleCalendar.js
@@ -252,7 +252,9 @@ async function registerWatch(userId, calId) {
       id: channelId,
       type: "web_hook",
       address: process.env.GOOGLE_WEBHOOK_URL,
-      token: userId,           // echoed back as X-Goog-Channel-Token on each ping
+      // "userId:googleCalId" format lets the webhook handler route the
+      // notification to the right calendar row. old channels used just userId.
+      token: `${userId}:${resolvedCalId}`,
       expiration,
     }),
     signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
@@ -264,17 +266,31 @@ async function registerWatch(userId, calId) {
   }
 
   const data = await res.json();
-  await db.updateChannelInfo(userId, {
+  const channelInfo = {
     channelId: data.id,
     resourceId: data.resourceId,
     channelExpiry: new Date(parseInt(data.expiration, 10)),
-  });
+  };
+
+  // store channel info on the calendars row when one matches the googleCalId.
+  // fall back to google_auth for legacy push channels where there is no
+  // corresponding calendars row (e.g. resolvedCalId is "primary").
+  const calendarRow = await db.getCalendarByGoogleCalId(resolvedCalId, userId);
+  if (calendarRow) {
+    await db.updateCalendar(calendarRow.id, channelInfo, userId);
+  } else {
+    await db.updateChannelInfo(userId, channelInfo);
+  }
 
   // bootstrap the sync token with a full sync so future incremental fetches
   // have a valid cursor to start from.
   try {
     const { nextSyncToken } = await fetchIncrementalEvents(userId, null, resolvedCalId);
-    await db.updateSyncToken(userId, nextSyncToken);
+    if (calendarRow) {
+      await db.updateCalendar(calendarRow.id, { syncToken: nextSyncToken }, userId);
+    } else {
+      await db.updateSyncToken(userId, nextSyncToken);
+    }
   } catch (syncErr) {
     console.warn(`[googleCalendar] initial sync after registerWatch failed for ${userId}:`, syncErr.message);
   }

--- a/utils/googleCalendar.js
+++ b/utils/googleCalendar.js
@@ -391,6 +391,72 @@ async function stopWatch(userId) {
   }
 }
 
+/**
+ * Adds a user email to the Google Calendar ACL so the calendar appears in
+ * their Google Calendar app. Uses the calendar owner's OAuth token.
+ *
+ * @param {string} ownerUserId  - Auth0 sub of the calendar owner
+ * @param {string} googleCalId  - Google Calendar ID
+ * @param {string} memberEmail  - email address to grant access
+ * @param {'editor'|'viewer'} role
+ * @returns {Promise<Object>} parsed response body from Google
+ */
+async function addCalendarAclEntry(ownerUserId, googleCalId, memberEmail, role) {
+  const googleRole = role === "editor" ? "writer" : "reader";
+  const token = await getValidAccessToken(ownerUserId);
+
+  const res = await fetch(
+    `https://www.googleapis.com/calendar/v3/calendars/${encodeURIComponent(googleCalId)}/acl`,
+    {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        role: googleRole,
+        scope: { type: "user", value: memberEmail },
+      }),
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+    },
+  );
+
+  if (!res.ok) {
+    const body = await res.text();
+    throw new Error(`addCalendarAclEntry ${res.status}: ${body}`);
+  }
+
+  return res.json();
+}
+
+/**
+ * Removes a user email from the Google Calendar ACL.
+ * Swallows 404 since the member may have already been removed from Google's side.
+ *
+ * @param {string} ownerUserId  - Auth0 sub of the calendar owner
+ * @param {string} googleCalId  - Google Calendar ID
+ * @param {string} memberEmail  - email address to revoke
+ */
+async function removeCalendarAclEntry(ownerUserId, googleCalId, memberEmail) {
+  const token = await getValidAccessToken(ownerUserId);
+  const ruleId = `user:${memberEmail}`;
+
+  const res = await fetch(
+    `https://www.googleapis.com/calendar/v3/calendars/${encodeURIComponent(googleCalId)}/acl/${encodeURIComponent(ruleId)}`,
+    {
+      method: "DELETE",
+      headers: { Authorization: `Bearer ${token}` },
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+    },
+  );
+
+  if (res.status === 404) return; // already gone, nothing to do
+  if (!res.ok) {
+    const body = await res.text();
+    throw new Error(`removeCalendarAclEntry ${res.status}: ${body}`);
+  }
+}
+
 module.exports = {
   createGoogleEvent,
   updateGoogleEvent,
@@ -400,4 +466,6 @@ module.exports = {
   stopWatch,
   stopWatchByCalId,
   createDedicatedCalendar,
+  addCalendarAclEntry,
+  removeCalendarAclEntry,
 };

--- a/utils/googleCalendar.js
+++ b/utils/googleCalendar.js
@@ -1,9 +1,13 @@
 const { v4: uuidv4 } = require("uuid");
-const { getValidAccessToken } = require("./googleToken");
+const { getTokenAndCalId, getValidAccessToken } = require("./googleToken");
 const db = require("./db");
 
-const GCAL_BASE = "https://www.googleapis.com/calendar/v3/calendars/primary";
 const FETCH_TIMEOUT_MS = 30_000;
+
+// builds the base URL for a given calendar. encodeURIComponent handles
+// "primary" (no change) and real calendar IDs (may contain @, spaces, etc.).
+const calBase = (calId) =>
+  `https://www.googleapis.com/calendar/v3/calendars/${encodeURIComponent(calId)}`;
 
 // maps our EVENT_COLORS hex values to the closest Google Calendar colorId.
 // these match the actual EVENT_COLORS array in src/lib/calendar.ts exactly.
@@ -69,18 +73,21 @@ function toGoogleEvent(event) {
  *
  * @param {string} userId - Auth0 sub
  * @param {{ title: string, description?: string, startDate: string, endDate: string, allDay: boolean, color?: string }} event
+ * @param {string} [calId] - Google Calendar ID; defaults to the user-level calId from google_auth
  * @returns {Promise<string|null>} Google event ID, or null if user is not connected
  */
-async function createGoogleEvent(userId, event) {
-  let token;
+async function createGoogleEvent(userId, event, calId) {
+  let token, resolvedCalId;
   try {
-    token = await getValidAccessToken(userId);
+    const result = await getTokenAndCalId(userId);
+    token = result.token;
+    resolvedCalId = calId ?? result.calId;
   } catch {
     // user is not connected, nothing to do
     return null;
   }
 
-  const res = await fetch(`${GCAL_BASE}/events`, {
+  const res = await fetch(`${calBase(resolvedCalId)}/events`, {
     method: "POST",
     headers: {
       Authorization: `Bearer ${token}`,
@@ -106,18 +113,21 @@ async function createGoogleEvent(userId, event) {
  * @param {string} userId - Auth0 sub
  * @param {string|null} googleEventId
  * @param {{ title?: string, description?: string, startDate?: string, endDate?: string, allDay?: boolean, color?: string }} fields
+ * @param {string} [calId] - Google Calendar ID; defaults to the user-level calId from google_auth
  */
-async function updateGoogleEvent(userId, googleEventId, fields) {
+async function updateGoogleEvent(userId, googleEventId, fields, calId) {
   if (!googleEventId) return;
 
-  let token;
+  let token, resolvedCalId;
   try {
-    token = await getValidAccessToken(userId);
+    const result = await getTokenAndCalId(userId);
+    token = result.token;
+    resolvedCalId = calId ?? result.calId;
   } catch {
     return;
   }
 
-  const res = await fetch(`${GCAL_BASE}/events/${googleEventId}`, {
+  const res = await fetch(`${calBase(resolvedCalId)}/events/${googleEventId}`, {
     method: "PATCH",
     headers: {
       Authorization: `Bearer ${token}`,
@@ -139,18 +149,21 @@ async function updateGoogleEvent(userId, googleEventId, fields) {
  *
  * @param {string} userId - Auth0 sub
  * @param {string} googleEventId
+ * @param {string} [calId] - Google Calendar ID; defaults to the user-level calId from google_auth
  */
-async function deleteGoogleEvent(userId, googleEventId) {
+async function deleteGoogleEvent(userId, googleEventId, calId) {
   if (!googleEventId) return;
 
-  let token;
+  let token, resolvedCalId;
   try {
-    token = await getValidAccessToken(userId);
+    const result = await getTokenAndCalId(userId);
+    token = result.token;
+    resolvedCalId = calId ?? result.calId;
   } catch {
     return;
   }
 
-  const res = await fetch(`${GCAL_BASE}/events/${googleEventId}`, {
+  const res = await fetch(`${calBase(resolvedCalId)}/events/${googleEventId}`, {
     method: "DELETE",
     headers: { Authorization: `Bearer ${token}` },
     signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
@@ -170,10 +183,12 @@ async function deleteGoogleEvent(userId, googleEventId) {
  *
  * @param {string} userId - Auth0 sub
  * @param {string|null} syncToken
+ * @param {string} [calId] - Google Calendar ID; defaults to the user-level calId from google_auth
  * @returns {Promise<{ items: Array, nextSyncToken: string }>}
  */
-async function fetchIncrementalEvents(userId, syncToken) {
-  const token = await getValidAccessToken(userId);
+async function fetchIncrementalEvents(userId, syncToken, calId) {
+  const { token, calId: authCalId } = await getTokenAndCalId(userId);
+  const resolvedCalId = calId ?? authCalId;
 
   const allItems = [];
   let pageToken = null;
@@ -185,14 +200,14 @@ async function fetchIncrementalEvents(userId, syncToken) {
     if (pageToken) params.set("pageToken", pageToken);
 
     const res = await fetch(
-      `${GCAL_BASE}/events?${params}`,
+      `${calBase(resolvedCalId)}/events?${params}`,
       { headers: { Authorization: `Bearer ${token}` }, signal: AbortSignal.timeout(FETCH_TIMEOUT_MS) },
     );
 
     // 410 Gone means the sync token is stale, do a full re-sync
     if (res.status === 410) {
       console.log(`[googleCalendar] sync token expired for ${userId}, doing full sync`);
-      return fetchIncrementalEvents(userId, null);
+      return fetchIncrementalEvents(userId, null, calId);
     }
 
     if (!res.ok) {
@@ -211,21 +226,23 @@ async function fetchIncrementalEvents(userId, syncToken) {
 
 /**
  * Registers a Google Calendar push notification channel for the user.
- * Google will POST to GOOGLE_WEBHOOK_URL whenever something changes on their
- * primary calendar. The channel lives for 6.5 days, the Railway cron job
+ * Google will POST to GOOGLE_WEBHOOK_URL whenever something changes on the
+ * target calendar. The channel lives for 6.5 days, the Railway cron job
  * (utils/renewWatchChannels.js) renews it before it expires.
  *
  * Also kicks off an initial full sync so we bootstrap our sync token and
  * pick up any events the user may have already synced in the past.
  *
  * @param {string} userId - Auth0 sub
+ * @param {string} [calId] - Google Calendar ID; defaults to the user-level calId from google_auth
  */
-async function registerWatch(userId) {
-  const token = await getValidAccessToken(userId);
+async function registerWatch(userId, calId) {
+  const { token, calId: authCalId } = await getTokenAndCalId(userId);
+  const resolvedCalId = calId ?? authCalId;
   const channelId = uuidv4();
   const expiration = Date.now() + 6.5 * 24 * 60 * 60 * 1000;
 
-  const res = await fetch(`${GCAL_BASE}/events/watch`, {
+  const res = await fetch(`${calBase(resolvedCalId)}/events/watch`, {
     method: "POST",
     headers: {
       Authorization: `Bearer ${token}`,
@@ -256,11 +273,39 @@ async function registerWatch(userId) {
   // bootstrap the sync token with a full sync so future incremental fetches
   // have a valid cursor to start from.
   try {
-    const { nextSyncToken } = await fetchIncrementalEvents(userId, null);
+    const { nextSyncToken } = await fetchIncrementalEvents(userId, null, resolvedCalId);
     await db.updateSyncToken(userId, nextSyncToken);
   } catch (syncErr) {
     console.warn(`[googleCalendar] initial sync after registerWatch failed for ${userId}:`, syncErr.message);
   }
+}
+
+/**
+ * Creates a new Google Calendar on the user's account and returns the calendar's
+ * ID and display name. The token is passed directly here (not userId) because
+ * the caller already has a fresh token from getTokenAndCalId and we don't want
+ * to fetch it twice.
+ *
+ * @param {string} token - valid Google access token
+ * @param {string} name - display name for the new calendar
+ * @returns {Promise<{ calId: string, calName: string }>}
+ */
+async function createDedicatedCalendar(token, name) {
+  const res = await fetch("https://www.googleapis.com/calendar/v3/calendars", {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ summary: name, timeZone: "UTC" }),
+    signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+  });
+  if (!res.ok) {
+    const body = await res.text();
+    throw new Error(`createDedicatedCalendar failed (${res.status}): ${body}`);
+  }
+  const data = await res.json();
+  return { calId: data.id, calName: data.summary };
 }
 
 /**
@@ -302,4 +347,5 @@ module.exports = {
   fetchIncrementalEvents,
   registerWatch,
   stopWatch,
+  createDedicatedCalendar,
 };

--- a/utils/googleToken.js
+++ b/utils/googleToken.js
@@ -1,14 +1,20 @@
 const db = require("./db");
 
 /**
- * Returns a valid access token for the user, refreshing it from Google if it's
- * going to expire within the next 5 minutes. Throws if the user hasn't connected
- * their Google Calendar or if the refresh request fails.
+ * Returns a valid access token and the user-level Google Calendar ID stored in
+ * google_auth. Refreshes the token if it expires within the next 5 minutes.
+ * Throws if the user hasn't connected their Google Calendar or if the refresh
+ * request fails.
+ *
+ * The returned calId is the legacy user-level calendar (google_auth.google_cal_id,
+ * defaults to "primary"). Per-calendar calIds for two_way calendars come from the
+ * calendars table -- callers that have those IDs should pass them in directly and
+ * only use this function for the token.
  *
  * @param {string} userId - Auth0 sub
- * @returns {Promise<string>} a non-expired access token
+ * @returns {Promise<{ token: string, calId: string }>}
  */
-async function getValidAccessToken(userId) {
+async function getTokenAndCalId(userId) {
   const auth = await db.getGoogleAuth(userId);
   if (!auth) throw new Error("Google Calendar not connected");
 
@@ -17,7 +23,7 @@ async function getValidAccessToken(userId) {
 
   // still good for at least 5 minutes, use it as-is
   if (expiresAt > fiveMinFromNow) {
-    return auth.access_token;
+    return { token: auth.access_token, calId: auth.google_cal_id };
   }
 
   // access token is stale, use the refresh token to get a new one
@@ -48,7 +54,18 @@ async function getValidAccessToken(userId) {
     tokenExpiry: newExpiry,
   });
 
-  return access_token;
+  return { token: access_token, calId: auth.google_cal_id };
 }
 
-module.exports = { getValidAccessToken };
+/**
+ * Convenience wrapper for callers that only need the token and not the calId.
+ *
+ * @param {string} userId - Auth0 sub
+ * @returns {Promise<string>} a non-expired access token
+ */
+async function getValidAccessToken(userId) {
+  const { token } = await getTokenAndCalId(userId);
+  return token;
+}
+
+module.exports = { getTokenAndCalId, getValidAccessToken };

--- a/utils/renewWatchChannels.js
+++ b/utils/renewWatchChannels.js
@@ -1,22 +1,23 @@
 require("dotenv").config();
 
 const { pool } = require("../config/database");
-const { registerWatch, stopWatch } = require("./googleCalendar");
+const { registerWatch, stopWatchByCalId } = require("./googleCalendar");
 
 /**
- * Finds all connected users whose watch channel expires within the next 24 hours
+ * Finds all two_way calendars whose watch channel expires within the next 24 hours
  * and renews them. Runs as a Railway cron job daily at 6am UTC so channels never
  * lapse -- Google stops sending webhooks as soon as a channel expires.
  *
- * Each user is renewed independently so one failure doesn't block the rest.
+ * Each calendar is renewed independently so one failure doesn't block the rest.
  */
 async function renewExpiringChannels() {
   console.log("[renewWatchChannels] starting");
   const { rows } = await pool.query({ text: `
-    SELECT user_id
-    FROM google_auth
-    WHERE channel_expiry < NOW() + INTERVAL '24 hours'
-      AND channel_id IS NOT NULL
+    SELECT c.id, c.google_cal_id, c.user_sub
+    FROM   calendars c
+    WHERE  c.sync_mode = 'two_way'
+      AND  c.google_cal_id IS NOT NULL
+      AND  c.channel_expiry < NOW() + INTERVAL '24 hours'
   `, query_timeout: 10_000 });
 
   if (rows.length === 0) {
@@ -26,15 +27,15 @@ async function renewExpiringChannels() {
 
   console.log(`[renewWatchChannels] renewing ${rows.length} channel(s)`);
 
-  for (const { user_id } of rows) {
+  for (const calendar of rows) {
     try {
       // stop first so Google doesn't end up with two active channels for the same calendar
-      await stopWatch(user_id);
-      await registerWatch(user_id);
-      console.log(`[renewWatchChannels] renewed channel for ${user_id}`);
+      await stopWatchByCalId(calendar.user_sub, calendar.google_cal_id);
+      await registerWatch(calendar.user_sub, calendar.google_cal_id);
+      console.log(`[renewWatchChannels] renewed channel for ${calendar.user_sub} calId=${calendar.google_cal_id}`);
     } catch (err) {
-      // log and keep going, one bad token shouldn't block everyone else
-      console.error(`[renewWatchChannels] failed for ${user_id}:`, err.message);
+      // log and keep going, one bad calendar shouldn't block the rest
+      console.error(`[renewWatchChannels] failed for ${calendar.user_sub} calId=${calendar.google_cal_id}:`, err.message);
     }
   }
 


### PR DESCRIPTION
# Changelog

## 2026-03-13 - version 0.4.18

- created `src/lib/backendFetch.ts`: `getBackendAuth()` fetches the Auth0 access token, `buildHeaders()` assembles the Authorization header; all 12 calendar BFF routes migrated to use it — removes duplicated `getAccessToken()` boilerplate from every route
- added `InfoTip` component to `src/components/ui`: ⓘ badge that shows a rich multi-line popover on hover using `position: fixed` + `getBoundingClientRect` to punch through `overflow: hidden` containers; supports `side="top"` (default) and `side="bottom"`
- info tips added in `CalendarModal`: sync mode explainer (Local only / Push / Two-way) and invite explainer (account requirement + Editor vs Viewer role descriptions)
- info tips added in `CalendarHeader`: calendar explainer next to the "+" button (pops below), countdowns explainer next to the Countdowns link (pops below)
- fixed owner email not showing in Sharing tab: `upsertUser` middleware now reads `X-User-Email` header as fallback; Auth0 post-login Action is the primary fix (adds `email` claim to the access token); owner member row shows "You" when email is still null as a final fallback
- updated `CalendarAboutContent.tsx`: added thread covering the Auth0 email claim problem, why it silently broke sharing, the JWT custom claim fix, the BFF header approach and why the signed claim is safer on a public backend, and the `backendFetch` utility extraction

## 2026-03-13 - version 0.4.16

- added pencil icon (hover-reveal) to owned calendars in the header dropdown and single-calendar label; clicking opens `CalendarModal` in edit mode wired to `updateCalendar` and `deleteCalendar` — this is how you access the Sharing tab
- added leave icon (hover-reveal) to shared calendars in the header dropdown and single-calendar label; clicking calls `DELETE /members/me` and shows an 8-second warning banner if Google ACL cleanup failed
- non-owners now default to the Sharing tab when the edit modal opens; Details tab fields are disabled with an explanatory note and the Save button is hidden
- `useCalendars` now exposes `isCreating`, `isUpdating`, `isDeleting` loading states; create and edit modals both use them so save/delete buttons show proper loading state

## 2026-03-13 - version 0.4.15

- added sharing chat thread to `src/app/thoughts/calendar/CalendarAboutContent.tsx`: covers why we store a `users` table locally instead of calling the Auth0 Management API, how the membership model works (ownership lives on `calendars.user_sub`, members live in `calendar_members`), editor vs viewer access via `getCalendarForMutation`, and how Google ACL entries are written on invite (fire-and-forget) and revoked on remove (awaited with `googleAclRemoved` flag)

## 2026-03-13 - version 0.4.14

- replaced the native `<select>` in `CalendarHeader` with a custom dropdown so shared calendars can show a person icon next to their name; dropdown closes on outside click via `mousedown` listener; chevron indicates it is interactive; single-calendar static label also gets a person icon when the calendar is shared
- added `PersonIcon` component (head circle + shoulder arc SVG)

## 2026-03-13 - version 0.4.13

- added Sharing tab to `CalendarModal` (edit mode only): tab strip switches between Details and Sharing; owners can invite by email with editor/viewer role selector, change existing member roles via inline tab strip, and remove members; removal checks `googleAclRemoved` and shows an 8-second amber warning when Google access was not revoked; non-owners see a read-only member list with "Shared by [owner email]" header; `SharingTabSkeleton` shows 3 pulsed rows while the member list loads; Save button hidden on Sharing tab

## 2026-03-13 - version 0.4.12

- added `CalendarMember` type to `src/types/calendar.ts`
- updated `Calendar` type to include `role`, `ownerSub`, `ownerEmail` fields returned by the UNION query
- added `calendarMembers(calendarId)` key factory to `src/lib/queryKeys.ts`
- updated `useCalendars` to expose `inviteMember`, `updateMemberRole`, `removeMember` mutations; each invalidates `calendars` and `calendarMembers` on settled
- added `useCalendarMembers(calendarId)` hook for fetching the member list; enabled only when calendarId is non-null; 30s stale time

## 2026-03-13 - version 0.4.11

- added BFF route `src/app/api/calendar/calendars/[id]/members/route.ts`: GET proxies member list (accessible by owner or any member), POST proxies invite-by-email and returns 201
- added BFF route `src/app/api/calendar/calendars/[id]/members/[memberSub]/route.ts`: PUT proxies role update, DELETE proxies member removal and forwards `{ googleAclRemoved }` body so the frontend can warn when Google access was not revoked; memberSub is re-encoded with encodeURIComponent when forwarding to the backend since Auth0 subs contain pipe characters

## 2026-03-12 - version 0.4.10

- added multi-calendar thread to `src/app/thoughts/calendar/CalendarAboutContent.tsx`: covers why a `calendars` table was needed over per-event sync config, the three sync modes (`none`/`push`/`two_way`) and when to use each, how two_way automatically creates the Google Calendar and registers a per-calendar watch channel, the `userId:calId` channel token format for routing webhook notifications to the right calendar, and the import-vs-filter difference between push and two_way

## 2026-03-12 - version 0.4.9

- updated `CalendarModal`: when syncMode is `two_way` and the saved calendar has no `googleCalId`, replaces the modal body with `CalendarModalSkeleton` + "Connecting to Google Calendar…" message while the `POST connect-google` request is in-flight; on success calls `onBanner` with a success message then closes; on failure calls `onBanner` with a warning (calendar is already saved, user can retry by editing) then closes; same flow applies in edit mode when changing syncMode to `two_way`; added `onBanner` prop
- updated `CalendarHeader`: added `banner` state (`success | warning`), auto-dismissed after 5 s with a manual dismiss button; passes `onBanner` to `CalendarModal`

## 2026-03-13 - version 1.4.8

- `middleware/upsertUser.js`: reads `X-User-Email` header as fallback when `email` is absent from the access token JWT — fixes sharing not working when Auth0 doesn't include email in the access token by default; primary fix is an Auth0 post-login Action that sets `email` as a custom claim, header is belt-and-suspenders
- `GET /calendars/:id/members`: owner entry email now falls back to `req.auth.payload.email` (from the JWT) when `getUserBySub` returns null (e.g. first request after the sharing migration before the users table is populated)

## 2026-03-13 - version 1.4.7

- fixed `ValidationError: ERR_ERL_KEY_GEN_IPV6` in `routes/calendar.js`: custom `keyGenerator` was falling back to `req.ip` directly, which `express-rate-limit` v7+ rejects because raw IPv6 addresses can be used to bypass limits; replaced with `ipKeyGenerator(req)` from `express-rate-limit` which normalizes IPv6 correctly; also switched from `const rateLimit = require(...)` to named import `{ rateLimit, ipKeyGenerator }`
- `DELETE /calendars/:id/members/:memberSub`: added self-removal path — any member can remove themselves using `"me"` or their own sub as `:memberSub`; performs best-effort Google ACL removal using the owner's credentials and returns `{ googleAclRemoved }` consistent with the owner-removal path

## 2026-03-13 - version 1.4.6

- `POST /calendars/:id/members`: fires `addCalendarAclEntry` as fire-and-forget after the DB insert so ACL latency never delays the HTTP response
- `DELETE /calendars/:id/members/:memberSub`: awaits `removeCalendarAclEntry` and returns `{ googleAclRemoved: boolean }` (200) instead of 204 so the frontend can warn the user when Google access was not revoked
- `DELETE /calendars/:id`: before the DB delete, calls `removeCalendarAclEntry` for all members via `Promise.allSettled` so one failure doesn't block the rest; runs before `stopWatchByCalId` so the channel is still alive for any retries

## 2026-03-13 - version 1.4.5

- added `addCalendarAclEntry(ownerUserId, googleCalId, memberEmail, role)` to `utils/googleCalendar.js`: maps 'editor' to 'writer' and 'viewer' to 'reader', POSTs to the Google ACL endpoint using the owner's token, throws on non-2xx
- added `removeCalendarAclEntry(ownerUserId, googleCalId, memberEmail)` to `utils/googleCalendar.js`: DELETEs the user-scoped ACL rule, swallows 404, throws on other non-2xx responses

## 2026-03-13 - version 1.4.4

- added `GET /api/calendar/calendars/:id/members`: accessible by owner or any member; synthesizes an owner entry from the calendars row and prepends it to the member list
- added `POST /api/calendar/calendars/:id/members`: owner-only invite by email; rate-limited to 20 requests per minute per user sub; returns generic 404 when email is not found to avoid enumeration; returns 400 when owner tries to invite themselves
- added `PUT /api/calendar/calendars/:id/members/:memberSub`: owner-only role update ('editor' or 'viewer')
- added `DELETE /api/calendar/calendars/:id/members/:memberSub`: owner-only member removal

## 2026-03-13 - version 1.4.3

- event create/update/delete: replaced `getCalendarById` with `getCalendarForMutation('editor')` for Google sync lookup so editors on shared calendars can write events and credentials always come from the owner's row
- calendar update (`PUT /calendars/:id`): added `getCalendarForMutation('owner')` preflight, returns 403 if not owner
- calendar delete (`DELETE /calendars/:id`): same preflight; also removes `getCalendarById` duplicate lookup
- `POST /calendars/:id/connect-google`: owner preflight, returns 403 if not owner
- `DELETE /calendars/:id/google`: owner preflight, returns 403 if not owner

## 2026-03-13 - version 1.4.2

- added `upsertUser`, `getUserBySub`, `getUserByEmail` to `utils/db.js`
- added `toCalendarMember`, `getCalendarMembers`, `addCalendarMember` (single CTE, no N+1), `updateCalendarMemberRole`, `removeCalendarMember` to `utils/db.js`
- updated `toCalendar` to include `role`, `ownerSub`, `ownerEmail` for the UNION query shape
- replaced `getCalendars` with a UNION query returning owned and shared calendars; each row carries `role` ('owner'|'editor'|'viewer') and `ownerSub`/`ownerEmail` for shared rows
- added `getCalendarForMutation(calendarId, userSub, requiredRole)` — single write-auth chokepoint; 'owner' checks `user_sub` only; 'editor' also accepts `calendar_members` rows with role='editor'
- updated `getCalendarEvents` to use LEFT JOIN on `calendar_members` (replaces correlated subquery) so members see events on shared calendars
- updated `getCalendarEventById` with same LEFT JOIN expansion
- updated `updateCalendarEvent` to allow editors on shared calendars via subquery join
- updated `deleteCalendarEvent` to allow editors on shared calendars

## 2026-03-13 - version 1.4.1

- added `middleware/upsertUser.js`: reads `sub` and `email` from the Auth0 JWT payload and upserts a `users` row; skips the write when the sub+email pair is already cached in a module-level Map (avoids a DB write on every request); guards against missing email claim (logs warning, calls next without upserting); DB errors are non-fatal
- wired `upsertUser` into `routes/calendar.js` immediately after `checkJwt` so all calendar routes populate the user record automatically

## 2026-03-13 - version 1.4.0

- added `scripts/calendar/migrate_sharing.js`: creates `users` table (`sub PK`, `email UNIQUE`) with `idx_users_email`; creates `calendar_members` table (`id PK`, `calendar_id FK → calendars ON DELETE CASCADE`, `user_sub FK → users ON DELETE CASCADE`, `role CHECK('editor'|'viewer')`, `invited_by FK → users ON DELETE SET NULL`) with `idx_calendar_members_user` and `idx_calendar_members_calendar`


## 2026-03-12 - version 1.3.11

Multi-calendar + dedicated Google Calendar two-way sync release. Full breakdown across 1.3.0–1.3.10 below. Summary:

- new `calendars` table with `sync_mode` (`none | push | two_way`), `google_cal_id`, and per-channel columns; `calendar_id` FK on `calendar_events` with cascade delete; migration at `scripts/calendar/migrate_calendars.js` backfills a "Personal" calendar per user and populates `calendar_id` on existing events
- full calendar CRUD API (`GET`/`POST`/`PUT`/`DELETE /api/calendar/calendars`) with `POST /:id/connect-google` and `DELETE /:id/google` for linking and unlinking Google Calendars
- per-calendar Google sync routing: event mutations look up the calendar's `syncMode` and target `primary` for push, the calendar's `google_cal_id` for two_way, or skip Google entirely for none
- `createDedicatedCalendar`, `stopWatchByCalId`, per-calendar `registerWatch` with `userId:calId` channel tokens, and a webhook handler that routes notifications to the right calendar row by splitting the token on the colon
- `renewWatchChannels` now queries `calendars` for `two_way` rows instead of `google_auth`
- OAuth scope updated from `calendar.events` to `calendar` to allow creating and managing calendars

## 2026-03-12 - version 1.3.10

- added `DELETE /api/calendar/calendars/:id/google` to `routes/calendar.js`: stops the Google push channel via `stopWatchByCalId` (called before the update so the google_cal_id is still available for lookup), then sets `google_cal_id=null`, `google_cal_name=null`, `sync_mode='push'`; returns the updated calendar; the Google Calendar itself is not deleted

## 2026-03-12 - version 1.3.9

- added `POST /api/calendar/calendars/:id/connect-google` to `routes/calendar.js`: verifies calendar ownership, returns 200 as-is if already connected (idempotent), calls `createDedicatedCalendar` to create the Google Calendar, saves `googleCalId` and `googleCalName` to the calendar row, calls `registerWatch` to start the push channel (non-fatal on failure), returns the updated calendar
## 2026-03-12 - version 1.3.8

- added `stopWatchByCalId(userId, calId)` to `utils/googleCalendar.js`: looks up the channel info from the `calendars` row via `getCalendarByGoogleCalId`, POSTs to the Google channels/stop endpoint, swallows all errors; exported alongside the existing `stopWatch`
- updated `utils/renewWatchChannels.js` to query `calendars` instead of `google_auth`: selects `two_way` calendars with a `google_cal_id` and a `channel_expiry` within 24 hours; calls `stopWatchByCalId` then `registerWatch` per calendar; imports `stopWatchByCalId` instead of `stopWatch`
- wired up the real `stopWatchByCalId` in `routes/calendar.js`: removed the local stub, imported from `utils/googleCalendar`, fixed the call to pass `calendar.googleCalId` (the Google Calendar ID) instead of the calendar UUID

## 2026-03-12 - version 1.3.7

- updated `registerWatch` in `utils/googleCalendar.js` to set the channel token as `userId:googleCalId` instead of just `userId`; after registering, looks up the corresponding `calendars` row via `getCalendarByGoogleCalId` and stores channel info and bootstrap sync token there; falls back to `google_auth` when no matching calendar row exists (legacy push channels where `googleCalId` is "primary")
- updated `routes/googleWebhook.js` to parse the new `userId:googleCalId` channel token format; new path looks up the `calendars` row by `googleCalId`, uses its `syncToken`, and saves the next token back to the calendar row after fetching; events not yet in our DB are imported via `createCalendarEventFromWebhook` for `two_way` calendars and skipped for all others; old single-userId token format falls back to the original `google_auth`-based flow for backward compatibility
- extracted `processExistingItem` helper to deduplicate the update/delete logic shared by both the new and legacy webhook paths; moved `SYNC_BUFFER_MS` to module scope

## 2026-03-12 - version 1.3.6

- updated OAuth scope in `routes/google.js` from `calendar.events` to `calendar`; the broader scope is required to create and manage dedicated Google Calendars for two_way sync; users who already authorized with the old scope will need to reconnect

## 2026-03-12 - version 1.3.5

- updated `POST /api/calendar/events` to fetch the event's calendar after insert and route the Google sync by `syncMode`: `push` targets `primary`, `two_way` targets `calendar.googleCalId`, `none` skips Google entirely
- updated `PUT /api/calendar/events/:id` with the same calendar-aware sync routing for updates
- updated `DELETE /api/calendar/events/:id` to fetch the event (including `calendarId`) before deletion, then route the Google delete to the correct calendar by `syncMode` after the DB row is gone

## 2026-03-12 - version 1.3.4

- refactored `utils/googleToken.js`: renamed core logic to `getTokenAndCalId(userId)` which now returns `{ token, calId }` where `calId` is `google_auth.google_cal_id`; kept `getValidAccessToken(userId)` as a thin wrapper for callers that only need the token; both are exported
- removed `GCAL_BASE` constant from `utils/googleCalendar.js`; replaced with `calBase(calId)` helper that builds the per-calendar base URL with `encodeURIComponent`
- updated `createGoogleEvent`, `updateGoogleEvent`, `deleteGoogleEvent`, `fetchIncrementalEvents`, and `registerWatch` to each accept an optional `calId` parameter; when omitted the function falls back to the user-level `calId` returned by `getTokenAndCalId`; the recursive full-sync call inside `fetchIncrementalEvents` now threads the original `calId` through
- added `createDedicatedCalendar(token, name)` to `utils/googleCalendar.js`: POSTs to the Google Calendar API to create a new calendar, returns `{ calId, calName }`; takes a token directly to avoid double-fetching

## 2026-03-12 - version 1.3.3

- updated `toCalendarEvent` in `utils/db.js` to include `calendarId` in the returned shape so route handlers and the frontend can read which calendar an event belongs to without a second query
- updated `createCalendarEvent` to accept `calendarId` in the fields object and include it in the INSERT; if no `calendarId` is provided it falls back to the user's oldest calendar (the "Personal" calendar from migration) so existing callers do not break
- updated `getCalendarEvents` to accept an optional `calendarId` filter that adds `AND ce.calendar_id = $N` to the WHERE clause
- updated `GET /api/calendar/events` to read `calendarId` from `req.query` and pass it through; updated `POST /api/calendar/events` to read `calendarId` from `req.body` and pass it through

## 2026-03-12 - version 1.3.2

- added calendar CRUD routes to `routes/calendar.js` under `/api/calendar/calendars`: `GET` (list), `POST` (create, validates name), `PUT /:id` (partial update, strips undefined fields before passing to db helper), `DELETE /:id` (204, cascade via FK); delete calls `stopWatchByCalId` stub before removing the row and logs any failure without aborting the delete; the Google Calendar itself is intentionally not deleted on disconnect

## 2026-03-12 - version 1.3.1

- added calendar DB helpers to `utils/db.js`: `toCalendar` mapper, `getCalendars`, `getCalendarById`, `getCalendarByGoogleCalId`, `createCalendar`, `updateCalendar`, `deleteCalendar`; `updateCalendar` uses the same dynamic SET clause pattern as `updateCalendarEvent` and always bumps `updated_at`
- added `createCalendarEventFromWebhook` helper: inserts a new `calendar_events` row with `sync_source='google'`, defaults title to `''` and color to `#3b82f6` so the webhook handler does not need to sanitize Google event fields before calling it

## 2026-03-12 - version 1.3.0

- added `calendars` table with `id`, `name`, `color`, `user_sub`, `google_cal_id`, `google_cal_name`, `sync_mode`, `channel_id`, `resource_id`, `channel_expiry`, `sync_token`; `sync_mode` is `none | push | two_way` -- this is the foundation for per-calendar Google sync config and eventual two-way dedicated calendar support
- added `calendar_id` FK column on `calendar_events` referencing `calendars(id)` with cascade delete
- migration script `scripts/calendar/migrate_calendars.js` creates a "Personal" calendar (`sync_mode='push'`) for every user that already has events and backfills `calendar_id` on all existing events, preserving current one-way sync behavior