### PR TITLE
update google route for ui redesign

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2026-03-16 - version 1.4.9
+
+- `routes/google.js`: updated Google Calendar OAuth callback redirect URLs from `{origin}/protected/settings?gcal=*` to `{origin}/settings?gcal=*` to match the frontend route restructure that eliminated the `/protected` prefix
+
 ## 2026-03-13 - version 1.4.8
 
 - `middleware/upsertUser.js`: reads `X-User-Email` header as fallback when `email` is absent from the access token JWT — fixes sharing not working when Auth0 doesn't include email in the access token by default; primary fix is an Auth0 post-login Action that sets `email` as a custom claim, header is belt-and-suspenders

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portfolio_api",
-  "version": "1.4.7",
+  "version": "1.4.9",
   "description": "Portfolio API with Node.js and Python",
   "main": "server.js",
   "scripts": {

--- a/routes/google.js
+++ b/routes/google.js
@@ -160,7 +160,7 @@ router.get("/auth/callback", async (req, res) => {
   // user clicked "deny" on the Google consent screen
   if (error) {
     console.warn("[google] OAuth denied by user:", error);
-    return res.redirect(`${origin}/protected/settings?gcal=denied`);
+    return res.redirect(`${origin}/settings?gcal=denied`);
   }
 
   if (!parsed) {
@@ -187,7 +187,7 @@ router.get("/auth/callback", async (req, res) => {
     if (!tokenRes.ok) {
       const body = await tokenRes.text();
       console.error("[google] Token exchange failed:", body);
-      return res.redirect(`${origin}/protected/settings?gcal=error`);
+      return res.redirect(`${origin}/settings?gcal=error`);
     }
 
     const { access_token, refresh_token, expires_in } = await tokenRes.json();
@@ -208,10 +208,10 @@ router.get("/auth/callback", async (req, res) => {
       console.error("[google] registerWatch failed after connect:", watchErr.message);
     }
 
-    res.redirect(`${origin}/protected/settings?gcal=connected`);
+    res.redirect(`${origin}/settings?gcal=connected`);
   } catch (err) {
     console.error("[google] Callback error:", err.message);
-    res.redirect(`${origin}/protected/settings?gcal=error`);
+    res.redirect(`${origin}/settings?gcal=error`);
   }
 });
 


### PR DESCRIPTION
# Changelog

## 2026-03-16 - version 1.4.9

- `routes/google.js`: updated Google Calendar OAuth callback redirect URLs from `{origin}/protected/settings?gcal=*` to `{origin}/settings?gcal=*` to match the frontend route restructure that eliminated the `/protected` prefix
