### PR TITLE
allow for public

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2026-03-16 - version 1.5.2
+
+- add migration script for public accounts
+- add optionalCheckJwt in middleware (try jwt validation, but allow failire so public routes can have req.auth)
+- add is_public to schema and routes (profile, follow, posts)
+
 ## 2026-03-16 - version 1.5.1
 
 - actually count follows,following, and posts for ketsup :username endpoint

--- a/middleware/auth.js
+++ b/middleware/auth.js
@@ -30,7 +30,16 @@ const checkPermissions = (requiredPermissions) => {
   };
 };
 
+// Optional variant — populates req.auth if a valid token is present, but never blocks the request
+const optionalCheckJwt = (req, res, next) => {
+  checkJwt(req, res, (err) => {
+    // Ignore auth errors — just continue without req.auth populated
+    next();
+  });
+};
+
 module.exports = {
   checkJwt,
-  checkPermissions
+  checkPermissions,
+  optionalCheckJwt,
 }; 

--- a/migrations/005_public_accounts.sql
+++ b/migrations/005_public_accounts.sql
@@ -1,0 +1,5 @@
+-- Migration: 005_public_accounts
+-- Adds is_public flag to user_profiles for public/private account visibility
+
+ALTER TABLE user_profiles
+  ADD COLUMN IF NOT EXISTS is_public BOOLEAN NOT NULL DEFAULT FALSE;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portfolio_api",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "Portfolio API with Node.js and Python",
   "main": "server.js",
   "scripts": {

--- a/routes/follows.js
+++ b/routes/follows.js
@@ -20,25 +20,28 @@ router.post('/:username', followsLimiter, validateParams(usernameParam), async (
   const { username } = req.params;
 
   try {
-    // Look up the target user's sub by username
+    // Look up the target user's sub and visibility setting by username
     const { rows: targetRows } = await pool.query(
-      `SELECT user_sub FROM user_profiles WHERE username = $1`,
+      `SELECT user_sub, is_public FROM user_profiles WHERE username = $1`,
       [username],
     );
     if (!targetRows.length) {
       return res.status(404).json({ error: 'User not found' });
     }
-    const followingSub = targetRows[0].user_sub;
+    const { user_sub: followingSub, is_public } = targetRows[0];
 
     if (followerSub === followingSub) {
       return res.status(400).json({ error: 'Cannot follow yourself' });
     }
 
+    // Public accounts auto-accept; private accounts start as pending
+    const status = is_public ? 'accepted' : 'pending';
+
     const { rows } = await pool.query(
-      `INSERT INTO follows (follower_sub, following_sub)
-       VALUES ($1, $2)
+      `INSERT INTO follows (follower_sub, following_sub, status)
+       VALUES ($1, $2, $3)
        RETURNING id, follower_sub, following_sub, status, created_at, updated_at`,
-      [followerSub, followingSub],
+      [followerSub, followingSub, status],
     );
     return res.status(201).json(rows[0]);
   } catch (err) {

--- a/routes/posts.js
+++ b/routes/posts.js
@@ -5,7 +5,7 @@ const { fromBuffer: fileTypeFromBuffer } = require('file-type');
 const { S3Client, DeleteObjectCommand } = require('@aws-sdk/client-s3');
 const { Upload } = require('@aws-sdk/lib-storage');
 const { pool } = require('../config/database');
-const { checkJwt } = require('../middleware/auth');
+const { checkJwt, optionalCheckJwt } = require('../middleware/auth');
 const upsertUser = require('../middleware/upsertUser');
 const { makeUserRateLimiter } = require('../utils/rateLimiter');
 const { validateBody } = require('../middleware/validateBody');
@@ -206,10 +206,11 @@ router.post('/', checkJwt, postsLimiter, upsertUser, async (req, res) => {
 });
 
 // ── GET /api/posts/user/:username ─────────────────────────────────────────────
-router.get('/user/:username', async (req, res) => {
+router.get('/user/:username', optionalCheckJwt, async (req, res) => {
   const { username } = req.params;
   const { cursor } = req.query;
   const LIMIT = 20;
+  const viewerSub = req.auth?.payload?.sub ?? null;
 
   let cursorDate = null;
   if (cursor) {
@@ -220,6 +221,32 @@ router.get('/user/:username', async (req, res) => {
   }
 
   try {
+    // Check visibility: private accounts only show posts to accepted followers
+    const { rows: profileRows } = await pool.query(
+      `SELECT user_sub, is_public FROM user_profiles WHERE username = $1`,
+      [username],
+    );
+    if (!profileRows.length) {
+      return res.status(404).json({ error: 'User not found' });
+    }
+    const { user_sub: targetSub, is_public } = profileRows[0];
+
+    if (!is_public && viewerSub !== targetSub) {
+      if (viewerSub) {
+        const { rowCount } = await pool.query(
+          `SELECT 1 FROM follows
+           WHERE follower_sub = $1 AND following_sub = $2 AND status = 'accepted'`,
+          [viewerSub, targetSub],
+        );
+        if (rowCount === 0) {
+          return res.json({ posts: [], nextCursor: null });
+        }
+      } else {
+        // Unauthenticated viewer cannot see private account posts
+        return res.json({ posts: [], nextCursor: null });
+      }
+    }
+
     const { rows } = await pool.query(
       `SELECT
          p.id,

--- a/routes/profiles.js
+++ b/routes/profiles.js
@@ -5,7 +5,7 @@ const { fileTypeFromBuffer } = require('file-type');
 const { S3Client } = require('@aws-sdk/client-s3');
 const { Upload } = require('@aws-sdk/lib-storage');
 const { pool } = require('../config/database');
-const { checkJwt } = require('../middleware/auth');
+const { checkJwt, optionalCheckJwt } = require('../middleware/auth');
 const upsertUser = require('../middleware/upsertUser');
 const { validateBody } = require('../middleware/validateBody');
 const { updateProfile, setupProfile } = require('../schemas');
@@ -109,7 +109,7 @@ router.get('/me', checkJwt, upsertUser, async (req, res) => {
   const sub = req.auth.payload.sub;
   try {
     const { rows } = await pool.query(
-      `SELECT user_sub, username, display_name, bio, avatar_url, created_at, updated_at
+      `SELECT user_sub, username, display_name, bio, avatar_url, is_public, created_at, updated_at
        FROM user_profiles
        WHERE user_sub = $1`,
       [sub],
@@ -125,17 +125,18 @@ router.get('/me', checkJwt, upsertUser, async (req, res) => {
 // PUT /api/profiles/me — update own profile fields
 router.put('/me', checkJwt, upsertUser, validateBody(updateProfile), async (req, res) => {
   const sub = req.auth.payload.sub;
-  const { display_name, bio, avatar_url } = req.body;
+  const { display_name, bio, avatar_url, is_public } = req.body;
 
   try {
     const { rows } = await pool.query(
       `UPDATE user_profiles
        SET display_name = COALESCE($2, display_name),
            bio          = COALESCE($3, bio),
-           avatar_url   = COALESCE($4, avatar_url)
+           avatar_url   = COALESCE($4, avatar_url),
+           is_public    = COALESCE($5, is_public)
        WHERE user_sub = $1
-       RETURNING user_sub, username, display_name, bio, avatar_url, created_at, updated_at`,
-      [sub, display_name ?? null, bio ?? null, avatar_url ?? null],
+       RETURNING user_sub, username, display_name, bio, avatar_url, is_public, created_at, updated_at`,
+      [sub, display_name ?? null, bio ?? null, avatar_url ?? null, is_public ?? null],
     );
     if (!rows.length) return res.status(404).json({ error: 'Profile not set up yet' });
     res.json(rows[0]);
@@ -173,11 +174,13 @@ router.post('/setup', checkJwt, upsertUser, validateBody(setupProfile), async (r
 });
 
 // GET /api/profiles/:username — public profile
-router.get('/:username', async (req, res) => {
+router.get('/:username', optionalCheckJwt, async (req, res) => {
   const { username } = req.params;
   if (!USERNAME_RE.test(username)) {
     return res.status(400).json({ error: 'Invalid username format' });
   }
+
+  const viewerSub = req.auth?.payload?.sub ?? null;
 
   try {
     const { rows } = await pool.query(
@@ -187,16 +190,29 @@ router.get('/:username', async (req, res) => {
          p.display_name,
          p.bio,
          p.avatar_url,
+         p.is_public,
          p.created_at,
          (SELECT COUNT(*) FROM posts WHERE user_sub = p.user_sub)::int AS post_count,
          (SELECT COUNT(*) FROM follows WHERE following_sub = p.user_sub AND status = 'accepted')::int AS follower_count,
-         (SELECT COUNT(*) FROM follows WHERE follower_sub = p.user_sub AND status = 'accepted')::int AS following_count
+         (SELECT COUNT(*) FROM follows WHERE follower_sub = p.user_sub AND status = 'accepted')::int AS following_count,
+         (
+           SELECT status FROM follows
+           WHERE follower_sub = $2 AND following_sub = p.user_sub
+         ) AS follow_status
        FROM user_profiles p
        WHERE p.username = $1`,
-      [username],
+      [username, viewerSub],
     );
     if (!rows.length) return res.status(404).json({ error: 'Profile not found' });
-    res.json(rows[0]);
+
+    const profile = rows[0];
+    const isOwn = viewerSub && viewerSub === profile.user_sub;
+
+    res.json({
+      ...profile,
+      // null for own profile or unauthenticated; 'none' if no follow row exists
+      follow_status: isOwn || !viewerSub ? null : (profile.follow_status ?? 'none'),
+    });
   } catch (err) {
     console.error('[profiles] GET /:username error:', err.message);
     res.status(500).json({ error: 'Failed to fetch profile' });

--- a/schemas/index.js
+++ b/schemas/index.js
@@ -47,6 +47,9 @@ const updateProfile = z.object({
   avatar_url: z
     .union([z.string().url('avatar_url must be a valid URL'), z.literal('')])
     .optional(),
+  is_public: z
+    .boolean()
+    .optional(),
 });
 
 const setupProfile = z.object({


### PR DESCRIPTION
# Changelog

## 2026-03-16 - version 1.5.2

- add migration script for public accounts
- add optionalCheckJwt in middleware (try jwt validation, but allow failire so public routes can have req.auth)
- add is_public to schema and routes (profile, follow, posts)