### PR TITLE
add support for video posts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2026-03-24 - version 1.5.5
+
+- video upload support, photos and videos can be mixed in a single post
+- video: thumbnail extracted via ffmpeg, dimensions and duration probed automatically
+- post_media queries updated to return media_type, thumbnail_url, and duration across all endpoints
+
 ## 2026-03-24 - version 1.5.4
 
 - fix buffer causing server crash

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "portfolio_api",
-  "version": "1.5.0",
+  "version": "1.5.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "portfolio_api",
-      "version": "1.5.0",
+      "version": "1.5.4",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.995.0",
         "@aws-sdk/lib-storage": "^3.995.0",
@@ -17,7 +17,10 @@
         "express": "^4.18.2",
         "express-oauth2-jwt-bearer": "^1.6.1",
         "express-rate-limit": "^8.2.1",
+        "ffmpeg-static": "^5.3.0",
+        "ffprobe-static": "^3.1.0",
         "file-type": "^16.5.4",
+        "fluent-ffmpeg": "^2.1.3",
         "helmet": "^7.0.0",
         "jwks-rsa": "^3.2.0",
         "morgan": "^1.10.0",
@@ -1573,6 +1576,50 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@derhuerst/http-basic": {
+      "version": "8.2.4",
+      "resolved": "https://registry.npmjs.org/@derhuerst/http-basic/-/http-basic-8.2.4.tgz",
+      "integrity": "sha512-F9rL9k9Xjf5blCz8HsJRO4diy111cayL2vkY2XE4r4t3n0yPXVYy3KD3nJ1qbrSn9743UWSXH4IwuCa/HWlGFw==",
+      "license": "MIT",
+      "dependencies": {
+        "caseless": "^0.12.0",
+        "concat-stream": "^2.0.0",
+        "http-response-object": "^3.0.1",
+        "parse-cache-control": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@derhuerst/http-basic/node_modules/concat-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
+      "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
+      "engines": [
+        "node >= 6.0"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.0.2",
+        "typedarray": "^0.0.6"
+      }
+    },
+    "node_modules/@derhuerst/http-basic/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
     },
     "node_modules/@emnapi/core": {
       "version": "1.8.1",
@@ -3763,6 +3810,35 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/agent-base/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/agentkeepalive": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.6.0.tgz",
@@ -3864,6 +3940,11 @@
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
       "license": "MIT"
+    },
+    "node_modules/async": {
+      "version": "0.2.10",
+      "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+      "integrity": "sha512-eAkdoKxU6/LkKDBzLpT+t6Ff5EtfSF4wx1WfJiPEEV7WNLnDaRXk0oVysiEPm262roaachGexwUv94WhSgN5TQ=="
     },
     "node_modules/asynckit": {
       "version": "0.4.0",
@@ -4238,6 +4319,12 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/caseless": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+      "integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==",
+      "license": "Apache-2.0"
     },
     "node_modules/chalk": {
       "version": "4.1.2",
@@ -4817,6 +4904,15 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/env-paths": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/error-ex": {
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
@@ -5136,6 +5232,28 @@
         "bser": "2.1.1"
       }
     },
+    "node_modules/ffmpeg-static": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/ffmpeg-static/-/ffmpeg-static-5.3.0.tgz",
+      "integrity": "sha512-H+K6sW6TiIX6VGend0KQwthe+kaceeH/luE8dIZyOP35ik7ahYojDuqlTV1bOrtEwl01sy2HFNGQfi5IDJvotg==",
+      "hasInstallScript": true,
+      "license": "GPL-3.0-or-later",
+      "dependencies": {
+        "@derhuerst/http-basic": "^8.2.0",
+        "env-paths": "^2.2.0",
+        "https-proxy-agent": "^5.0.0",
+        "progress": "^2.0.3"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/ffprobe-static": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/ffprobe-static/-/ffprobe-static-3.1.0.tgz",
+      "integrity": "sha512-Dvpa9uhVMOYivhHKWLGDoa512J751qN1WZAIO+Xw4L/mrUSPxS4DApzSUDbCFE/LUq2+xYnznEahTd63AqBSpA==",
+      "license": "MIT"
+    },
     "node_modules/file-type": {
       "version": "16.5.4",
       "resolved": "https://registry.npmjs.org/file-type/-/file-type-16.5.4.tgz",
@@ -5196,6 +5314,32 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/fluent-ffmpeg": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/fluent-ffmpeg/-/fluent-ffmpeg-2.1.3.tgz",
+      "integrity": "sha512-Be3narBNt2s6bsaqP6Jzq91heDgOEaDCJAXcE3qcma/EJBSy5FB4cvO31XBInuAuKBx8Kptf8dkhjK0IOru39Q==",
+      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+      "license": "MIT",
+      "dependencies": {
+        "async": "^0.2.9",
+        "which": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/fluent-ffmpeg/node_modules/which": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "which": "bin/which"
       }
     },
     "node_modules/foreground-child": {
@@ -5539,6 +5683,51 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/http-response-object": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/http-response-object/-/http-response-object-3.0.2.tgz",
+      "integrity": "sha512-bqX0XTF6fnXSQcEJ2Iuyr75yVakyjIDCqroJQ/aHfSdlM743Cwqoi2nDYMzLGWUcuTWGWy8AAvOKXTfiv6q9RA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^10.0.3"
+      }
+    },
+    "node_modules/http-response-object/node_modules/@types/node": {
+      "version": "10.17.60",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.60.tgz",
+      "integrity": "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw==",
+      "license": "MIT"
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/https-proxy-agent/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/human-signals": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
@@ -5758,7 +5947,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/istanbul-lib-coverage": {
@@ -7248,6 +7436,11 @@
       "dev": true,
       "license": "BlueOak-1.0.0"
     },
+    "node_modules/parse-cache-control": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parse-cache-control/-/parse-cache-control-1.0.1.tgz",
+      "integrity": "sha512-60zvsJReQPX5/QP0Kzfd/VrpjScIQ7SHBW6bFCYfEP+fp0Eppr1SHhIO5nd1PjZtvclzSzES9D/p5nFJurwfWg=="
+    },
     "node_modules/parse-json": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
@@ -7562,6 +7755,15 @@
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
       "license": "MIT"
+    },
+    "node_modules/progress": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
     },
     "node_modules/proxy-addr": {
       "version": "2.0.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portfolio_api",
-  "version": "1.5.4",
+  "version": "1.5.5",
   "description": "Portfolio API with Node.js and Python",
   "main": "server.js",
   "scripts": {
@@ -18,7 +18,10 @@
     "express": "^4.18.2",
     "express-oauth2-jwt-bearer": "^1.6.1",
     "express-rate-limit": "^8.2.1",
+    "ffmpeg-static": "^5.3.0",
+    "ffprobe-static": "^3.1.0",
     "file-type": "^16.5.4",
+    "fluent-ffmpeg": "^2.1.3",
     "helmet": "^7.0.0",
     "jwks-rsa": "^3.2.0",
     "morgan": "^1.10.0",

--- a/routes/posts.js
+++ b/routes/posts.js
@@ -1,6 +1,13 @@
 const express = require("express");
 const multer = require("multer");
 const sharp = require("sharp");
+const ffmpeg = require("fluent-ffmpeg");
+const ffmpegPath = require("ffmpeg-static");
+const ffprobePath = require("ffprobe-static").path;
+const os = require("os");
+const path = require("path");
+const fs = require("fs");
+const crypto = require("crypto");
 const { fromBuffer: fileTypeFromBuffer } = require("file-type");
 const { S3Client, DeleteObjectCommand } = require("@aws-sdk/client-s3");
 const { Upload } = require("@aws-sdk/lib-storage");
@@ -10,6 +17,9 @@ const upsertUser = require("../middleware/upsertUser");
 const { makeUserRateLimiter } = require("../utils/rateLimiter");
 const { validateBody } = require("../middleware/validateBody");
 const { createPost } = require("../schemas");
+
+ffmpeg.setFfmpegPath(ffmpegPath);
+ffmpeg.setFfprobePath(ffprobePath);
 
 const postsLimiter = makeUserRateLimiter(20, 60 * 60 * 1000); // 20/hr
 
@@ -39,14 +49,21 @@ async function s3Upload(buffer, key, contentType) {
 }
 
 // ── Multer ────────────────────────────────────────────────────────────────────
-const ALLOWED_MIME = new Set([
+const ALLOWED_IMAGE_MIME = new Set([
   "image/jpeg",
   "image/png",
   "image/webp",
   "image/gif",
 ]);
+const ALLOWED_VIDEO_MIME = new Set([
+  "video/mp4",
+  "video/quicktime",
+  "video/webm",
+  "video/x-matroska",
+]);
 const MAX_FILES = 10;
-const MAX_FILE_BYTES = 10 * 1024 * 1024; // 10 MB
+// 200 MB limit covers both images (10 MB validated per-file in handler) and videos
+const MAX_FILE_BYTES = 200 * 1024 * 1024;
 
 const upload = multer({
   storage: multer.memoryStorage(),
@@ -64,8 +81,14 @@ function runMulter(req, res) {
 async function processImage(buffer) {
   // 1. Validate MIME from magic bytes (not the header)
   const detected = await fileTypeFromBuffer(buffer);
-  if (!detected || !ALLOWED_MIME.has(detected.mime)) {
+  if (!detected || !ALLOWED_IMAGE_MIME.has(detected.mime)) {
     throw Object.assign(new Error("Unsupported image type"), { status: 400 });
+  }
+
+  if (buffer.length > 10 * 1024 * 1024) {
+    throw Object.assign(new Error("Each image must be 10 MB or smaller"), {
+      status: 400,
+    });
   }
 
   // 2. Full-size: max 1080px wide, WebP, strip EXIF via .rotate() then withMetadata(false)
@@ -95,6 +118,57 @@ async function processImage(buffer) {
   return { fullBuffer, thumbBuffer, blurDataUrl, width, height };
 }
 
+// ── Video processing ──────────────────────────────────────────────────────────
+async function processVideo(buffer) {
+  const tmpId = crypto.randomBytes(8).toString("hex");
+  const inputPath = path.join(os.tmpdir(), `${tmpId}_input`);
+  const thumbPath = path.join(os.tmpdir(), `${tmpId}_thumb.jpg`);
+
+  await fs.promises.writeFile(inputPath, buffer);
+
+  try {
+    // Probe for dimensions and duration
+    const metadata = await new Promise((resolve, reject) => {
+      ffmpeg.ffprobe(inputPath, (err, data) => {
+        if (err) reject(err);
+        else resolve(data);
+      });
+    });
+
+    const videoStream = metadata.streams.find((s) => s.codec_type === "video");
+    const width = videoStream?.width ?? 0;
+    const height = videoStream?.height ?? 0;
+    const duration = parseFloat(metadata.format?.duration ?? 0);
+
+    // Extract a thumbnail frame at 1s (or halfway through for very short clips)
+    const seekTime = Math.min(1, duration / 2);
+    await new Promise((resolve, reject) => {
+      ffmpeg(inputPath)
+        .seekInput(seekTime)
+        .frames(1)
+        .output(thumbPath)
+        .on("end", resolve)
+        .on("error", reject)
+        .run();
+    });
+
+    const thumbJpeg = await fs.promises.readFile(thumbPath);
+
+    // Resize thumbnail to 640px wide WebP
+    const thumbBuffer = await sharp(thumbJpeg)
+      .resize({ width: 640, withoutEnlargement: true })
+      .webp({ quality: 80 })
+      .toBuffer();
+
+    return { thumbBuffer, width, height, duration };
+  } finally {
+    await Promise.allSettled([
+      fs.promises.unlink(inputPath),
+      fs.promises.unlink(thumbPath).catch(() => {}),
+    ]);
+  }
+}
+
 // ── POST /api/posts ───────────────────────────────────────────────────────────
 router.post("/", checkJwt, postsLimiter, upsertUser, async (req, res) => {
   // Run multer first so req.body and req.files are populated for both types
@@ -102,9 +176,7 @@ router.post("/", checkJwt, postsLimiter, upsertUser, async (req, res) => {
     await runMulter(req, res);
   } catch (err) {
     if (err.code === "LIMIT_FILE_SIZE") {
-      return res
-        .status(400)
-        .json({ error: "Each file must be 10 MB or smaller" });
+      return res.status(400).json({ error: "File too large" });
     }
     if (err.code === "LIMIT_FILE_COUNT") {
       return res
@@ -145,13 +217,13 @@ router.post("/", checkJwt, postsLimiter, upsertUser, async (req, res) => {
     }
   }
 
-  // ── photo post ─────────────────────────────────────────────────────────────
+  // ── photo post (photos and/or videos mixed) ───────────────────────────────
   if (type === "photo") {
     const files = req.files || [];
     if (files.length === 0) {
       return res
         .status(400)
-        .json({ error: "At least one file is required for a photo post" });
+        .json({ error: "At least one file is required for a media post" });
     }
     if (files.length > 10) {
       return res.status(400).json({ error: "Maximum 10 files allowed" });
@@ -171,42 +243,71 @@ router.post("/", checkJwt, postsLimiter, upsertUser, async (req, res) => {
       const post = postRows[0];
       const postId = post.id;
 
-      // Process and upload each file in order
+      // Process and upload each file — images through processImage, videos through processVideo
       const mediaRows = [];
       for (let i = 0; i < files.length; i++) {
-        let processed;
-        try {
-          processed = await processImage(files[i].buffer);
-        } catch (imgErr) {
-          await db.query("ROLLBACK");
-          return res
-            .status(imgErr.status || 400)
-            .json({ error: imgErr.message });
+        const fileBuffer = files[i].buffer;
+        const detected = await fileTypeFromBuffer(fileBuffer.slice(0, 4100));
+
+        if (detected && ALLOWED_VIDEO_MIME.has(detected.mime)) {
+          // ── video file ────────────────────────────────────────────────────
+          let vidProcessed;
+          try {
+            vidProcessed = await processVideo(fileBuffer);
+          } catch (vidErr) {
+            await db.query("ROLLBACK");
+            console.error("[posts] video processing error:", vidErr.message);
+            return res.status(400).json({ error: "Failed to process video" });
+          }
+
+          const { thumbBuffer, width, height, duration } = vidProcessed;
+          const videoKey = `posts/${postId}/${i}_video${path.extname(files[i].originalname) || ".mp4"}`;
+          const thumbKey = `posts/${postId}/${i}_thumb.webp`;
+
+          const [videoUrl, thumbUrl] = await Promise.all([
+            s3Upload(fileBuffer, videoKey, detected.mime),
+            s3Upload(thumbBuffer, thumbKey, "image/webp"),
+          ]);
+
+          const { rows: mediaInsert } = await db.query(
+            `INSERT INTO post_media
+               (post_id, s3_key, url, width, height, position, blur_data_url, media_type, thumbnail_url, duration)
+             VALUES ($1, $2, $3, $4, $5, $6, '', 'video', $7, $8)
+             RETURNING id, s3_key, url, width, height, position, blur_data_url, media_type, thumbnail_url, duration, created_at`,
+            [postId, videoKey, videoUrl, width, height, i, thumbUrl, duration],
+          );
+          mediaRows.push(mediaInsert[0]);
+        } else {
+          // ── image file ────────────────────────────────────────────────────
+          let processed;
+          try {
+            processed = await processImage(fileBuffer);
+          } catch (imgErr) {
+            await db.query("ROLLBACK");
+            return res
+              .status(imgErr.status || 400)
+              .json({ error: imgErr.message });
+          }
+
+          const { fullBuffer, thumbBuffer, blurDataUrl, width, height } =
+            processed;
+          const fullKey = `posts/${postId}/${i}_full.webp`;
+          const thumbKey = `posts/${postId}/${i}_thumb.webp`;
+
+          const [fullUrl, thumbUrl] = await Promise.all([
+            s3Upload(fullBuffer, fullKey, "image/webp"),
+            s3Upload(thumbBuffer, thumbKey, "image/webp"),
+          ]);
+
+          const { rows: mediaInsert } = await db.query(
+            `INSERT INTO post_media
+               (post_id, s3_key, url, width, height, position, blur_data_url, media_type, thumbnail_url)
+             VALUES ($1, $2, $3, $4, $5, $6, $7, 'image', $8)
+             RETURNING id, s3_key, url, width, height, position, blur_data_url, media_type, thumbnail_url, duration, created_at`,
+            [postId, fullKey, fullUrl, width, height, i, blurDataUrl, thumbUrl],
+          );
+          mediaRows.push(mediaInsert[0]);
         }
-
-        const { fullBuffer, thumbBuffer, blurDataUrl, width, height } =
-          processed;
-        const fullKey = `posts/${postId}/${i}_full.webp`;
-        const thumbKey = `posts/${postId}/${i}_thumb.webp`;
-
-        const [fullUrl, thumbUrl] = await Promise.all([
-          s3Upload(fullBuffer, fullKey, "image/webp"),
-          s3Upload(thumbBuffer, thumbKey, "image/webp"),
-        ]);
-
-        const { rows: mediaInsert } = await db.query(
-          `INSERT INTO post_media (post_id, s3_key, url, width, height, position, blur_data_url)
-           VALUES ($1, $2, $3, $4, $5, $6, $7)
-           RETURNING id, s3_key, url, width, height, position, blur_data_url, created_at`,
-          [postId, fullKey, fullUrl, width, height, i, blurDataUrl],
-        );
-
-        // Store thumb info as extra fields (not persisted separately — no thumb table yet)
-        mediaRows.push({
-          ...mediaInsert[0],
-          thumb_url: thumbUrl,
-          thumb_s3_key: thumbKey,
-        });
       }
 
       await db.query("COMMIT");
@@ -287,6 +388,9 @@ router.get("/user/:username", optionalCheckJwt, async (req, res) => {
                'height',        pm.height,
                'position',      pm.position,
                'blur_data_url', pm.blur_data_url,
+               'media_type',    pm.media_type,
+               'thumbnail_url', pm.thumbnail_url,
+               'duration',      pm.duration,
                'created_at',    pm.created_at
              ) ORDER BY pm.position ASC
            ) FILTER (WHERE pm.id IS NOT NULL),
@@ -346,7 +450,10 @@ router.get("/discover", optionalCheckJwt, async (req, res) => {
                'width',         pm.width,
                'height',        pm.height,
                'position',      pm.position,
-               'blur_data_url', pm.blur_data_url
+               'blur_data_url', pm.blur_data_url,
+               'media_type',    pm.media_type,
+               'thumbnail_url', pm.thumbnail_url,
+               'duration',      pm.duration
              ) ORDER BY pm.position ASC
            ) FILTER (WHERE pm.id IS NOT NULL),
            '[]'
@@ -401,7 +508,8 @@ router.get("/:id", async (req, res) => {
       return res.status(404).json({ error: "Post not found" });
 
     const { rows: mediaRows } = await pool.query(
-      `SELECT id, s3_key, url, width, height, position, blur_data_url, created_at
+      `SELECT id, s3_key, url, width, height, position, blur_data_url,
+              media_type, thumbnail_url, duration, created_at
        FROM post_media
        WHERE post_id = $1
        ORDER BY position ASC`,

--- a/routes/timeline.js
+++ b/routes/timeline.js
@@ -1,8 +1,8 @@
-const express = require('express');
-const { pool } = require('../config/database');
-const { checkJwt } = require('../middleware/auth');
-const upsertUser = require('../middleware/upsertUser');
-const { makeUserRateLimiter } = require('../utils/rateLimiter');
+const express = require("express");
+const { pool } = require("../config/database");
+const { checkJwt } = require("../middleware/auth");
+const upsertUser = require("../middleware/upsertUser");
+const { makeUserRateLimiter } = require("../utils/rateLimiter");
 
 const timelineLimiter = makeUserRateLimiter(120, 60 * 1000); // 120/min
 
@@ -69,6 +69,9 @@ const TIMELINE_QUERY = `
           'height',        pm.height,
           'position',      pm.position,
           'blur_data_url', pm.blur_data_url,
+          'media_type',    pm.media_type,
+          'thumbnail_url', pm.thumbnail_url,
+          'duration',      pm.duration,
           'created_at',    pm.created_at
         ) ORDER BY pm.position ASC
       ) FILTER (WHERE pm.id IS NOT NULL),
@@ -92,7 +95,7 @@ const TIMELINE_QUERY = `
 `;
 
 // ── GET /api/timeline ─────────────────────────────────────────────────────────
-router.get('/', checkJwt, timelineLimiter, upsertUser, async (req, res) => {
+router.get("/", checkJwt, timelineLimiter, upsertUser, async (req, res) => {
   const sub = req.auth.payload.sub;
   const { cursor } = req.query;
 
@@ -100,7 +103,7 @@ router.get('/', checkJwt, timelineLimiter, upsertUser, async (req, res) => {
   if (cursor) {
     cursorDate = new Date(cursor);
     if (isNaN(cursorDate.getTime())) {
-      return res.status(400).json({ error: 'Invalid cursor' });
+      return res.status(400).json({ error: "Invalid cursor" });
     }
   } else {
     cursorDate = new Date();
@@ -115,16 +118,20 @@ router.get('/', checkJwt, timelineLimiter, upsertUser, async (req, res) => {
 
     const hasMore = rows.length > LIMIT;
     const rawPosts = hasMore ? rows.slice(0, LIMIT) : rows;
-    const nextCursor = hasMore ? rawPosts[rawPosts.length - 1].created_at.toISOString() : null;
-    const posts = rawPosts.map(({ sub, username, display_name, avatar_url, ...post }) => ({
-      ...post,
-      author: { sub, username, display_name, avatar_url },
-    }));
+    const nextCursor = hasMore
+      ? rawPosts[rawPosts.length - 1].created_at.toISOString()
+      : null;
+    const posts = rawPosts.map(
+      ({ sub, username, display_name, avatar_url, ...post }) => ({
+        ...post,
+        author: { sub, username, display_name, avatar_url },
+      }),
+    );
 
     return res.json({ posts, nextCursor });
   } catch (err) {
-    console.error('[timeline] GET / error:', err.message);
-    return res.status(500).json({ error: 'Failed to fetch timeline' });
+    console.error("[timeline] GET / error:", err.message);
+    return res.status(500).json({ error: "Failed to fetch timeline" });
   }
 });
 

--- a/schemas/index.js
+++ b/schemas/index.js
@@ -1,33 +1,36 @@
-const { z } = require('zod');
+const { z } = require("zod");
 
 const USERNAME_REGEX = /^[a-z0-9_]{3,30}$/;
 
 const usernameParam = z.object({
   username: z
     .string()
-    .regex(USERNAME_REGEX, 'username must be 3–30 characters: lowercase letters, numbers, and underscores only'),
+    .regex(
+      USERNAME_REGEX,
+      "username must be 3–30 characters: lowercase letters, numbers, and underscores only",
+    ),
 });
 
-const createPost = z.discriminatedUnion('type', [
+const createPost = z.discriminatedUnion("type", [
   z.object({
-    type: z.literal('text'),
+    type: z.literal("text"),
     content: z
-      .string({ required_error: 'content is required' })
+      .string({ required_error: "content is required" })
       .trim()
-      .min(1, 'content must be at least 1 character')
-      .max(500, 'content must be 500 characters or fewer'),
+      .min(1, "content must be at least 1 character")
+      .max(500, "content must be 500 characters or fewer"),
     caption: z
       .string()
       .trim()
-      .max(2200, 'caption must be 2200 characters or fewer')
+      .max(2200, "caption must be 2200 characters or fewer")
       .optional(),
   }),
   z.object({
-    type: z.literal('photo'),
+    type: z.literal("photo"),
     caption: z
       .string()
       .trim()
-      .max(2200, 'caption must be 2200 characters or fewer')
+      .max(2200, "caption must be 2200 characters or fewer")
       .optional(),
     // file count validated separately after multer runs
   }),
@@ -37,37 +40,38 @@ const updateProfile = z.object({
   display_name: z
     .string()
     .trim()
-    .max(50, 'display_name must be 50 characters or fewer')
+    .max(50, "display_name must be 50 characters or fewer")
     .optional(),
   bio: z
     .string()
     .trim()
-    .max(160, 'bio must be 160 characters or fewer')
+    .max(160, "bio must be 160 characters or fewer")
     .optional(),
   avatar_url: z
-    .union([z.string().url('avatar_url must be a valid URL'), z.literal('')])
+    .union([z.string().url("avatar_url must be a valid URL"), z.literal("")])
     .optional(),
-  is_public: z
-    .boolean()
-    .optional(),
+  is_public: z.boolean().optional(),
 });
 
 const setupProfile = z.object({
   username: z
-    .string({ required_error: 'username is required' })
-    .regex(USERNAME_REGEX, 'username must be 3–30 characters: lowercase letters, numbers, and underscores only'),
+    .string({ required_error: "username is required" })
+    .regex(
+      USERNAME_REGEX,
+      "username must be 3–30 characters: lowercase letters, numbers, and underscores only",
+    ),
   display_name: z
     .string()
     .trim()
-    .max(50, 'display_name must be 50 characters or fewer')
+    .max(50, "display_name must be 50 characters or fewer")
     .optional(),
   bio: z
     .string()
     .trim()
-    .max(160, 'bio must be 160 characters or fewer')
+    .max(160, "bio must be 160 characters or fewer")
     .optional(),
   avatar_url: z
-    .union([z.string().url('avatar_url must be a valid URL'), z.literal('')])
+    .union([z.string().url("avatar_url must be a valid URL"), z.literal("")])
     .optional(),
 });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -884,6 +884,16 @@
   resolved "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
+"@derhuerst/http-basic@^8.2.0":
+  version "8.2.4"
+  resolved "https://registry.npmjs.org/@derhuerst/http-basic/-/http-basic-8.2.4.tgz"
+  integrity sha512-F9rL9k9Xjf5blCz8HsJRO4diy111cayL2vkY2XE4r4t3n0yPXVYy3KD3nJ1qbrSn9743UWSXH4IwuCa/HWlGFw==
+  dependencies:
+    caseless "^0.12.0"
+    concat-stream "^2.0.0"
+    http-response-object "^3.0.1"
+    parse-cache-control "^1.0.1"
+
 "@img/sharp-darwin-arm64@0.34.1":
   version "0.34.1"
   resolved "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.1.tgz"
@@ -1837,6 +1847,11 @@
   dependencies:
     undici-types "~6.21.0"
 
+"@types/node@^10.0.3":
+  version "10.17.60"
+  resolved "https://registry.npmjs.org/@types/node/-/node-10.17.60.tgz"
+  integrity sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw==
+
 "@types/node@^18.11.18":
   version "18.19.130"
   resolved "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz"
@@ -1913,6 +1928,13 @@ accepts@~1.3.8:
     mime-types "~2.1.34"
     negotiator "0.6.3"
 
+agent-base@6:
+  version "6.0.2"
+  resolved "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz"
+  integrity sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==
+  dependencies:
+    debug "4"
+
 agentkeepalive@^4.2.1:
   version "4.6.0"
   resolved "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.6.0.tgz"
@@ -1983,6 +2005,11 @@ array-flatten@1.1.1:
   version "1.1.1"
   resolved "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz"
   integrity sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==
+
+async@^0.2.9:
+  version "0.2.10"
+  resolved "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
+  integrity sha512-eAkdoKxU6/LkKDBzLpT+t6Ff5EtfSF4wx1WfJiPEEV7WNLnDaRXk0oVysiEPm262roaachGexwUv94WhSgN5TQ==
 
 asynckit@^0.4.0:
   version "0.4.0"
@@ -2208,6 +2235,11 @@ caniuse-lite@^1.0.30001759:
   resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001770.tgz"
   integrity sha512-x/2CLQ1jHENRbHg5PSId2sXq1CIO1CISvwWAj027ltMVG2UNgW+w9oH2+HzgEIRFembL8bUlXtfbBHR1fCg2xw==
 
+caseless@^0.12.0:
+  version "0.12.0"
+  resolved "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz"
+  integrity sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==
+
 chalk@^4.1.2:
   version "4.1.2"
   resolved "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz"
@@ -2335,6 +2367,16 @@ concat-stream@^1.5.2:
     readable-stream "^2.2.2"
     typedarray "^0.0.6"
 
+concat-stream@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz"
+  integrity sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==
+  dependencies:
+    buffer-from "^1.0.0"
+    inherits "^2.0.3"
+    readable-stream "^3.0.2"
+    typedarray "^0.0.6"
+
 content-disposition@0.5.4:
   version "0.5.4"
   resolved "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz"
@@ -2426,6 +2468,13 @@ debug@2.6.9:
   dependencies:
     ms "2.0.0"
 
+debug@4:
+  version "4.4.3"
+  resolved "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz"
+  integrity sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==
+  dependencies:
+    ms "^2.1.3"
+
 dedent@^1.6.0:
   version "1.7.1"
   resolved "https://registry.npmjs.org/dedent/-/dedent-1.7.1.tgz"
@@ -2514,6 +2563,11 @@ encodeurl@~2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz"
   integrity sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==
+
+env-paths@^2.2.0:
+  version "2.2.1"
+  resolved "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz"
+  integrity sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==
 
 error-ex@^1.3.1:
   version "1.3.4"
@@ -2686,6 +2740,21 @@ fb-watchman@^2.0.2:
   dependencies:
     bser "2.1.1"
 
+ffmpeg-static@^5.3.0:
+  version "5.3.0"
+  resolved "https://registry.npmjs.org/ffmpeg-static/-/ffmpeg-static-5.3.0.tgz"
+  integrity sha512-H+K6sW6TiIX6VGend0KQwthe+kaceeH/luE8dIZyOP35ik7ahYojDuqlTV1bOrtEwl01sy2HFNGQfi5IDJvotg==
+  dependencies:
+    "@derhuerst/http-basic" "^8.2.0"
+    env-paths "^2.2.0"
+    https-proxy-agent "^5.0.0"
+    progress "^2.0.3"
+
+ffprobe-static@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.npmjs.org/ffprobe-static/-/ffprobe-static-3.1.0.tgz"
+  integrity sha512-Dvpa9uhVMOYivhHKWLGDoa512J751qN1WZAIO+Xw4L/mrUSPxS4DApzSUDbCFE/LUq2+xYnznEahTd63AqBSpA==
+
 file-type@^16.5.4:
   version "16.5.4"
   resolved "https://registry.npmjs.org/file-type/-/file-type-16.5.4.tgz"
@@ -2722,6 +2791,14 @@ find-up@^4.0.0, find-up@^4.1.0:
   dependencies:
     locate-path "^5.0.0"
     path-exists "^4.0.0"
+
+fluent-ffmpeg@^2.1.3:
+  version "2.1.3"
+  resolved "https://registry.npmjs.org/fluent-ffmpeg/-/fluent-ffmpeg-2.1.3.tgz"
+  integrity sha512-Be3narBNt2s6bsaqP6Jzq91heDgOEaDCJAXcE3qcma/EJBSy5FB4cvO31XBInuAuKBx8Kptf8dkhjK0IOru39Q==
+  dependencies:
+    async "^0.2.9"
+    which "^1.1.1"
 
 foreground-child@^3.1.0:
   version "3.3.1"
@@ -2914,6 +2991,21 @@ http-errors@2.0.0:
     setprototypeof "1.2.0"
     statuses "2.0.1"
     toidentifier "1.0.1"
+
+http-response-object@^3.0.1:
+  version "3.0.2"
+  resolved "https://registry.npmjs.org/http-response-object/-/http-response-object-3.0.2.tgz"
+  integrity sha512-bqX0XTF6fnXSQcEJ2Iuyr75yVakyjIDCqroJQ/aHfSdlM743Cwqoi2nDYMzLGWUcuTWGWy8AAvOKXTfiv6q9RA==
+  dependencies:
+    "@types/node" "^10.0.3"
+
+https-proxy-agent@^5.0.0:
+  version "5.0.1"
+  resolved "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz"
+  integrity sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==
+  dependencies:
+    agent-base "6"
+    debug "4"
 
 human-signals@^2.1.0:
   version "2.1.0"
@@ -3841,6 +3933,11 @@ package-json-from-dist@^1.0.0:
   resolved "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz"
   integrity sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==
 
+parse-cache-control@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.npmjs.org/parse-cache-control/-/parse-cache-control-1.0.1.tgz"
+  integrity sha512-60zvsJReQPX5/QP0Kzfd/VrpjScIQ7SHBW6bFCYfEP+fp0Eppr1SHhIO5nd1PjZtvclzSzES9D/p5nFJurwfWg==
+
 parse-json@^5.2.0:
   version "5.2.0"
   resolved "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz"
@@ -4013,6 +4110,11 @@ process@^0.11.10:
   resolved "https://registry.npmjs.org/process/-/process-0.11.10.tgz"
   integrity sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==
 
+progress@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz"
+  integrity sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==
+
 proxy-addr@~2.0.7:
   version "2.0.7"
   resolved "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz"
@@ -4070,6 +4172,15 @@ readable-stream@^2.2.2:
     safe-buffer "~5.1.1"
     string_decoder "~1.1.1"
     util-deprecate "~1.0.1"
+
+readable-stream@^3.0.2:
+  version "3.6.2"
+  resolved "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz"
+  integrity sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==
+  dependencies:
+    inherits "^2.0.3"
+    string_decoder "^1.1.1"
+    util-deprecate "^1.0.1"
 
 readable-stream@^3.5.0:
   version "3.6.2"
@@ -4690,6 +4801,13 @@ whatwg-url@^5.0.0:
   dependencies:
     tr46 "~0.0.3"
     webidl-conversions "^3.0.0"
+
+which@^1.1.1:
+  version "1.3.1"
+  resolved "https://registry.npmjs.org/which/-/which-1.3.1.tgz"
+  integrity sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==
+  dependencies:
+    isexe "^2.0.0"
 
 which@^2.0.1:
   version "2.0.2"


### PR DESCRIPTION
# Changelog

## 2026-03-24 - version 1.5.5

- video upload support, photos and videos can be mixed in a single post
- video: thumbnail extracted via ffmpeg, dimensions and duration probed automatically
- post_media queries updated to return media_type, thumbnail_url, and duration across all endpoints
