### PR TITLE
add geo route for location

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2026-03-30 - version 1.5.7
+
+- endpoint `/api/nba/shots/:playerId` with deterministic mock data per player
+
 ## 2026-03-30 - version 1.5.6
 
 - add geo route for getting client ip address and location

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2026-03-30 - version 1.5.6
+
+- add geo route for getting client ip address and location
+
 ## 2026-03-24 - version 1.5.5
 
 - video upload support, photos and videos can be mixed in a single post

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portfolio_api",
-  "version": "1.5.6",
+  "version": "1.5.7",
   "description": "Portfolio API with Node.js and Python",
   "main": "server.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portfolio_api",
-  "version": "1.5.5",
+  "version": "1.5.6",
   "description": "Portfolio API with Node.js and Python",
   "main": "server.js",
   "scripts": {

--- a/routes/geo.js
+++ b/routes/geo.js
@@ -1,0 +1,85 @@
+const express = require("express");
+const { getCachedData, CACHE_TTL } = require("../utils/cache");
+
+const router = express.Router();
+
+/**
+ * Returns the real client IP from common proxy headers, falling back to
+ * the socket remote address. Railway and most cloud providers set
+ * x-forwarded-for.
+ *
+ * @param {import("express").Request} req
+ * @returns {string}
+ */
+function clientIp(req) {
+  return (
+    (req.headers["x-forwarded-for"] ?? "").split(",")[0].trim() ||
+    req.headers["x-real-ip"] ||
+    req.socket?.remoteAddress ||
+    "unknown"
+  );
+}
+
+/**
+ * GET /api/geo
+ *
+ * Looks up approximate lat/lon/city for the requesting IP via ip-api.com
+ * (free tier, HTTP, no key required — does not block server IPs).
+ * Results are cached per IP for 5 minutes.
+ *
+ * Response shape (normalised to match the frontend's expectations):
+ *   { latitude, longitude, city, country }
+ */
+router.get("/", async (req, res, next) => {
+  const ip = clientIp(req);
+
+  try {
+    const data = await getCachedData(
+      `geo:${ip}`,
+      async () => {
+        // ip-api.com free tier is HTTP-only — fine for server-to-server.
+        const target =
+          ip === "unknown" || ip === "::1" || ip === "127.0.0.1"
+            ? "http://ip-api.com/json/?fields=status,message,lat,lon,city,country,regionName"
+            : `http://ip-api.com/json/${encodeURIComponent(ip)}?fields=status,message,lat,lon,city,country,regionName`;
+
+        const upstream = await fetch(target, {
+          signal: AbortSignal.timeout(6_000),
+          headers: { Accept: "application/json" },
+        });
+
+        if (!upstream.ok) {
+          throw Object.assign(
+            new Error(`ip-api.com responded with ${upstream.status}`),
+            { status: 502 },
+          );
+        }
+
+        const raw = await upstream.json();
+
+        if (raw.status !== "success") {
+          throw Object.assign(
+            new Error(`ip-api.com lookup failed: ${raw.message ?? "unknown"}`),
+            { status: 502 },
+          );
+        }
+
+        // Normalise field names to match frontend expectations (latitude/longitude).
+        return {
+          latitude: raw.lat,
+          longitude: raw.lon,
+          city: raw.city,
+          country: raw.country,
+          regionName: raw.regionName,
+        };
+      },
+      CACHE_TTL.SHORT,
+    );
+
+    res.json(data);
+  } catch (err) {
+    next(err);
+  }
+});
+
+module.exports = router;

--- a/routes/nba.js
+++ b/routes/nba.js
@@ -30,8 +30,7 @@ router.get("/teams", nbaIpLimiter, async (req, res, next) => {
     const data = await getCachedData("teams", async () => {
       const startTime = Date.now();
       const season = getCurrentSeason();
-      const url =
-        `https://stats.nba.com/stats/leaguestandingsv3?LeagueID=00&Season=${season}&SeasonType=Regular+Season`;
+      const url = `https://stats.nba.com/stats/leaguestandingsv3?LeagueID=00&Season=${season}&SeasonType=Regular+Season`;
       const response = await throttledFetch(url, {
         headers: NBA_API.HEADERS,
       });
@@ -296,6 +295,72 @@ router.get("/stats/:playerId", nbaIpLimiter, async (req, res, next) => {
         },
       };
     });
+
+    res.status(200).json(data);
+  } catch (error) {
+    next(error);
+  }
+});
+
+// Shot chart endpoint
+// TODO: Replace mock data with real shotchartdetail API call once endpoint
+// access is confirmed. The NBA Stats API blocks shotchartdetail from some
+// environments. When switching to live data, aggregate individual shots into
+// the 6 zone buckets below and keep the same response shape.
+router.get("/shots/:playerId", nbaIpLimiter, async (req, res, next) => {
+  try {
+    const playerId = parseInt(req.params.playerId);
+
+    if (isNaN(playerId)) {
+      return res.status(400).json({ error: "Invalid player ID" });
+    }
+
+    const data = await getCachedData(
+      `shots-${playerId}`,
+      async () => {
+        // Seed a deterministic random from the playerId so each player gets
+        // consistent but varied mock data across requests.
+        const seed = (n) => {
+          const x = Math.sin(playerId * 1000 + n) * 10000;
+          return x - Math.floor(x);
+        };
+
+        const gp = 60 + Math.floor(seed(0) * 22);
+        const zones = [
+          { zone: "paint", base: 0.58, att: 6.2 },
+          { zone: "mid-left", base: 0.42, att: 2.8 },
+          { zone: "mid-right", base: 0.44, att: 2.6 },
+          { zone: "corner-3-left", base: 0.38, att: 1.8 },
+          { zone: "corner-3-right", base: 0.37, att: 1.9 },
+          { zone: "above-break-3", base: 0.36, att: 4.5 },
+        ].map((z, i) => {
+          const variance = (seed(i + 1) - 0.5) * 0.12;
+          const fgPct = Math.max(0.2, Math.min(0.7, z.base + variance));
+          const attVariance = (seed(i + 10) - 0.5) * 2;
+          const attPerGame = Math.max(0.5, z.att + attVariance);
+          const makesPerGame = attPerGame * fgPct;
+          const fga = Math.round(attPerGame * gp);
+          const fgm = Math.round(makesPerGame * gp);
+          return {
+            zone: z.zone,
+            fgPct: parseFloat(fgPct.toFixed(3)),
+            fgm,
+            fga,
+            attPerGame: parseFloat(attPerGame.toFixed(1)),
+            makesPerGame: parseFloat(makesPerGame.toFixed(1)),
+          };
+        });
+
+        return {
+          data: {
+            playerId,
+            season: getCurrentSeason(),
+            zones,
+          },
+        };
+      },
+      86400,
+    );
 
     res.status(200).json(data);
   } catch (error) {

--- a/server.js
+++ b/server.js
@@ -26,6 +26,7 @@ const profilesRoutes = require("./routes/profiles");
 const postsRoutes = require("./routes/posts");
 const followsRoutes = require("./routes/follows");
 const timelineRoutes = require("./routes/timeline");
+const geoRoutes = require("./routes/geo");
 // watch channel renewal runs as a Railway cron job (utils/renewWatchChannels.js)
 // not as a setInterval here, since deploys restart the process and would reset the timer
 
@@ -81,6 +82,7 @@ app.use("/api/profiles", profilesRoutes);
 app.use("/api/posts", postsRoutes);
 app.use("/api/follows", followsRoutes);
 app.use("/api/timeline", timelineRoutes);
+app.use("/api/geo", geoRoutes);
 app.use("/api", dbRoutes);
 
 // Error handling middleware


### PR DESCRIPTION
# Changelog

## 2026-03-30 - version 1.5.7

- endpoint `/api/nba/shots/:playerId` with deterministic mock data per player

## 2026-03-30 - version 1.5.6

- add geo route for getting client ip address and location