### PR TITLE
Ps/update/nba playoffs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 2026-04-16 - version 1.5.8
+
+- `routes/nba-playoffs.js`: NBA playoff bracket API — `GET /api/nba/playoffs/picks/:season` and `PUT /api/nba/playoffs/picks/:season` for authenticated users to read/save picks; `GET /api/nba/playoffs/leaderboard/:season` (public) scores all brackets against the official results row and returns ranked entries with max-possible score
+- `utils/playoffScoring.js`: playoff bracket scoring engine (`scoreBracket`, `MAX_POSSIBLE`)
+- `migrations/006_nba_playoffs.sql`: `nba_playoff_brackets` table with `(user_sub, season)` unique constraint; official results stored as a reserved `OFFICIAL_RESULTS` row
+- `scripts/run-migration.js`: generic migration runner — `node scripts/run-migration.js <sql-file>`
+- `server.js`: moved `express.json()` before route registration (fixes body parsing for all routes); mounted `/api/nba/playoffs` before the NBA 1-hour cache so picks endpoints are never cached
+
 ## 2026-03-30 - version 1.5.7
 
 - endpoint `/api/nba/shots/:playerId` with deterministic mock data per player

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Backend REST API for [paulsumido.com](https://paulsumido.com). Built with Node.j
 
 | Feature         | Description                                                                     |
 | --------------- | ------------------------------------------------------------------------------- |
-| NBA             | Live standings, team rosters, and player stats via NBA Stats API                |
+| NBA             | Live standings, team rosters, player stats, shot charts, and playoff bracket picks/leaderboard |
 | F1              | Race schedules, results, telemetry, weather, and championship points via FastF1 |
 | Fantasy F1      | Custom fantasy scoring engine based on qualifying, race results, and overtakes  |
 | YouTube         | Recent videos from a YouTube channel via RSS feed                               |
@@ -37,6 +37,15 @@ Backend REST API for [paulsumido.com](https://paulsumido.com). Built with Node.j
 | GET    | `/teams`           | Current season standings            |
 | GET    | `/players/:teamId` | Roster for a team                   |
 | GET    | `/stats/:playerId` | Player stats for the current season |
+| GET    | `/shots/:playerId` | Deterministic mock shot chart data  |
+
+### NBA Playoffs — `/api/nba/playoffs`
+
+| Method | Path                    | Auth     | Description                                                             |
+| ------ | ----------------------- | -------- | ----------------------------------------------------------------------- |
+| GET    | `/picks/:season`        | Required | Fetch the authenticated user's bracket picks for a season               |
+| PUT    | `/picks/:season`        | Required | Save (upsert) the authenticated user's bracket picks for a season       |
+| GET    | `/leaderboard/:season`  | —        | Score all user brackets against official results; returns ranked entries |
 
 ### F1 — `/api/f1`
 
@@ -281,6 +290,9 @@ node scripts/calendar/migrate_countdowns.js
 
 # Create users + calendar_members tables (required for calendar sharing)
 node scripts/calendar/migrate_sharing.js
+
+# Create nba_playoff_brackets table
+node scripts/run-migration.js migrations/006_nba_playoffs.sql
 ```
 
 > **Auth0 setup for sharing**: add a post-login Action that sets `api.accessToken.setCustomClaim("email", event.user.email)` so the backend `upsertUser` middleware can populate the users table from the JWT email claim.

--- a/migrations/006_nba_playoffs.sql
+++ b/migrations/006_nba_playoffs.sql
@@ -1,0 +1,14 @@
+-- Migration: 006_nba_playoffs
+-- Adds nba_playoff_brackets table for storing user playoff bracket picks
+
+CREATE TABLE IF NOT EXISTS nba_playoff_brackets (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_sub TEXT NOT NULL,
+    season INT NOT NULL,
+    picks JSONB NOT NULL DEFAULT '{}',
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE (user_sub, season)
+);
+
+CREATE INDEX IF NOT EXISTS idx_nba_playoff_brackets_user_sub ON nba_playoff_brackets(user_sub);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portfolio_api",
-  "version": "1.5.7",
+  "version": "1.5.8",
   "description": "Portfolio API with Node.js and Python",
   "main": "server.js",
   "scripts": {

--- a/routes/nba-playoffs.js
+++ b/routes/nba-playoffs.js
@@ -1,51 +1,51 @@
-const express = require('express');
-const { pool } = require('../config/database');
-const { checkJwt } = require('../middleware/auth');
-const { scoreBracket, MAX_POSSIBLE } = require('../utils/playoffScoring');
+const express = require("express");
+const { pool } = require("../config/database");
+const { checkJwt } = require("../middleware/auth");
+const { scoreBracket, MAX_POSSIBLE } = require("../utils/playoffScoring");
 
 const router = express.Router();
 
-const OFFICIAL_RESULTS_SUB = 'OFFICIAL_RESULTS';
+const OFFICIAL_RESULTS_SUB = "OFFICIAL_RESULTS";
 const SEASON_RE = /^\d{4}$/;
 
 function isPlainObject(val) {
-  return val !== null && typeof val === 'object' && !Array.isArray(val);
+  return val !== null && typeof val === "object" && !Array.isArray(val);
 }
 
 // GET /api/nba/playoffs/picks/:season
 // Returns the authenticated user's picks for the season.
-router.get('/picks/:season', checkJwt, async (req, res) => {
+router.get("/picks/:season", checkJwt, async (req, res) => {
   const { season } = req.params;
   if (!SEASON_RE.test(season)) {
-    return res.status(400).json({ error: 'season must be a 4-digit year' });
+    return res.status(400).json({ error: "season must be a 4-digit year" });
   }
 
   const userSub = req.auth.payload.sub;
 
   try {
     const result = await pool.query(
-      'SELECT picks FROM nba_playoff_brackets WHERE user_sub = $1 AND season = $2',
+      "SELECT picks FROM nba_playoff_brackets WHERE user_sub = $1 AND season = $2",
       [userSub, Number(season)],
     );
     const picks = result.rows[0]?.picks ?? {};
     res.json({ picks });
   } catch (err) {
-    console.error('[nba-playoffs] GET /picks/:season failed:', err.message);
-    res.status(500).json({ error: 'Failed to fetch picks' });
+    console.error("[nba-playoffs] GET /picks/:season failed:", err.message);
+    res.status(500).json({ error: "Failed to fetch picks" });
   }
 });
 
 // PUT /api/nba/playoffs/picks/:season
 // Upserts the authenticated user's picks for the season.
-router.put('/picks/:season', checkJwt, async (req, res) => {
+router.put("/picks/:season", checkJwt, async (req, res) => {
   const { season } = req.params;
   if (!SEASON_RE.test(season)) {
-    return res.status(400).json({ error: 'season must be a 4-digit year' });
+    return res.status(400).json({ error: "season must be a 4-digit year" });
   }
 
   const { picks } = req.body;
   if (!isPlainObject(picks)) {
-    return res.status(400).json({ error: 'picks must be a plain object' });
+    return res.status(400).json({ error: "picks must be a plain object" });
   }
 
   const userSub = req.auth.payload.sub;
@@ -60,49 +60,70 @@ router.put('/picks/:season', checkJwt, async (req, res) => {
     );
     res.json({ ok: true });
   } catch (err) {
-    console.error('[nba-playoffs] PUT /picks/:season failed:', err.message);
-    res.status(500).json({ error: 'Failed to save picks' });
+    console.error("[nba-playoffs] PUT /picks/:season failed:", err.message);
+    res.status(500).json({ error: "Failed to save picks" });
   }
 });
 
 // GET /api/nba/playoffs/leaderboard/:season
 // Public — scores all user brackets against the official results row.
-router.get('/leaderboard/:season', async (req, res) => {
+router.get("/leaderboard/:season", async (req, res) => {
   const { season } = req.params;
   if (!SEASON_RE.test(season)) {
-    return res.status(400).json({ error: 'season must be a 4-digit year' });
+    return res.status(400).json({ error: "season must be a 4-digit year" });
   }
 
   try {
     const officialResult = await pool.query(
-      'SELECT picks FROM nba_playoff_brackets WHERE user_sub = $1 AND season = $2',
+      "SELECT picks FROM nba_playoff_brackets WHERE user_sub = $1 AND season = $2",
       [OFFICIAL_RESULTS_SUB, Number(season)],
     );
 
     const officialPicks = officialResult.rows[0]?.picks ?? null;
 
-    // No official results yet — return empty leaderboard
-    if (!officialPicks) {
-      return res.json({ entries: [] });
-    }
-
     const userBrackets = await pool.query(
-      'SELECT user_sub, picks FROM nba_playoff_brackets WHERE user_sub != $1 AND season = $2',
+      "SELECT user_sub, picks, updated_at FROM nba_playoff_brackets WHERE user_sub != $1 AND season = $2",
       [OFFICIAL_RESULTS_SUB, Number(season)],
     );
 
     const entries = await Promise.all(
-      userBrackets.rows.map(async ({ user_sub, picks }) => {
+      userBrackets.rows.map(async ({ user_sub, picks, updated_at }) => {
         const profileResult = await pool.query(
-          'SELECT display_name, username FROM user_profiles WHERE user_sub = $1',
+          "SELECT display_name, username FROM user_profiles WHERE user_sub = $1",
           [user_sub],
         );
         const profile = profileResult.rows[0];
-        const displayName = profile?.display_name ?? profile?.username ?? 'Anonymous';
+        const displayName =
+          profile?.display_name ?? profile?.username ?? "Anonymous";
+
+        if (!officialPicks) {
+          return {
+            userSub: user_sub,
+            displayName,
+            score: 0,
+            maxPossible: MAX_POSSIBLE,
+            breakdown: {
+              r1: 0,
+              r2: 0,
+              cf: 0,
+              finals: 0,
+              bonuses: 0,
+              mvp: 0,
+              combinedScoreDiff: null,
+            },
+            updatedAt: updated_at,
+          };
+        }
 
         const { total, breakdown } = scoreBracket(picks, officialPicks);
-
-        return { userSub: user_sub, displayName, score: total, maxPossible: MAX_POSSIBLE, breakdown };
+        return {
+          userSub: user_sub,
+          displayName,
+          score: total,
+          maxPossible: MAX_POSSIBLE,
+          breakdown,
+          updatedAt: updated_at,
+        };
       }),
     );
 
@@ -111,34 +132,39 @@ router.get('/leaderboard/:season', async (req, res) => {
       // Tiebreak: lower combinedScoreDiff wins; null diff goes last
       const aDiff = a.breakdown.combinedScoreDiff ?? Infinity;
       const bDiff = b.breakdown.combinedScoreDiff ?? Infinity;
-      return aDiff - bDiff;
+      if (aDiff !== bDiff) return aDiff - bDiff;
+      // Final tiebreak: earliest submission first
+      return new Date(a.updatedAt) - new Date(b.updatedAt);
     });
 
     const ranked = entries.map((entry, i) => ({ rank: i + 1, ...entry }));
 
     res.json({ entries: ranked });
   } catch (err) {
-    console.error('[nba-playoffs] GET /leaderboard/:season failed:', err.message);
-    res.status(500).json({ error: 'Failed to fetch leaderboard' });
+    console.error(
+      "[nba-playoffs] GET /leaderboard/:season failed:",
+      err.message,
+    );
+    res.status(500).json({ error: "Failed to fetch leaderboard" });
   }
 });
 
 // PUT /api/nba/playoffs/results/:season
 // Admin-only — sets the official results for scoring. Protected by PLAYOFFS_ADMIN_SECRET.
-router.put('/results/:season', async (req, res) => {
+router.put("/results/:season", async (req, res) => {
   const { season } = req.params;
   if (!SEASON_RE.test(season)) {
-    return res.status(400).json({ error: 'season must be a 4-digit year' });
+    return res.status(400).json({ error: "season must be a 4-digit year" });
   }
 
   const secret = process.env.PLAYOFFS_ADMIN_SECRET;
   if (!secret || req.headers.authorization !== `Bearer ${secret}`) {
-    return res.status(401).json({ error: 'Unauthorized' });
+    return res.status(401).json({ error: "Unauthorized" });
   }
 
   const { picks } = req.body;
   if (!isPlainObject(picks)) {
-    return res.status(400).json({ error: 'picks must be a plain object' });
+    return res.status(400).json({ error: "picks must be a plain object" });
   }
 
   try {
@@ -151,8 +177,8 @@ router.put('/results/:season', async (req, res) => {
     );
     res.json({ ok: true });
   } catch (err) {
-    console.error('[nba-playoffs] PUT /results/:season failed:', err.message);
-    res.status(500).json({ error: 'Failed to save results' });
+    console.error("[nba-playoffs] PUT /results/:season failed:", err.message);
+    res.status(500).json({ error: "Failed to save results" });
   }
 });
 

--- a/routes/nba-playoffs.js
+++ b/routes/nba-playoffs.js
@@ -1,0 +1,159 @@
+const express = require('express');
+const { pool } = require('../config/database');
+const { checkJwt } = require('../middleware/auth');
+const { scoreBracket, MAX_POSSIBLE } = require('../utils/playoffScoring');
+
+const router = express.Router();
+
+const OFFICIAL_RESULTS_SUB = 'OFFICIAL_RESULTS';
+const SEASON_RE = /^\d{4}$/;
+
+function isPlainObject(val) {
+  return val !== null && typeof val === 'object' && !Array.isArray(val);
+}
+
+// GET /api/nba/playoffs/picks/:season
+// Returns the authenticated user's picks for the season.
+router.get('/picks/:season', checkJwt, async (req, res) => {
+  const { season } = req.params;
+  if (!SEASON_RE.test(season)) {
+    return res.status(400).json({ error: 'season must be a 4-digit year' });
+  }
+
+  const userSub = req.auth.payload.sub;
+
+  try {
+    const result = await pool.query(
+      'SELECT picks FROM nba_playoff_brackets WHERE user_sub = $1 AND season = $2',
+      [userSub, Number(season)],
+    );
+    const picks = result.rows[0]?.picks ?? {};
+    res.json({ picks });
+  } catch (err) {
+    console.error('[nba-playoffs] GET /picks/:season failed:', err.message);
+    res.status(500).json({ error: 'Failed to fetch picks' });
+  }
+});
+
+// PUT /api/nba/playoffs/picks/:season
+// Upserts the authenticated user's picks for the season.
+router.put('/picks/:season', checkJwt, async (req, res) => {
+  const { season } = req.params;
+  if (!SEASON_RE.test(season)) {
+    return res.status(400).json({ error: 'season must be a 4-digit year' });
+  }
+
+  const { picks } = req.body;
+  if (!isPlainObject(picks)) {
+    return res.status(400).json({ error: 'picks must be a plain object' });
+  }
+
+  const userSub = req.auth.payload.sub;
+
+  try {
+    await pool.query(
+      `INSERT INTO nba_playoff_brackets (id, user_sub, season, picks)
+       VALUES (gen_random_uuid(), $1, $2, $3)
+       ON CONFLICT (user_sub, season)
+       DO UPDATE SET picks = EXCLUDED.picks, updated_at = now()`,
+      [userSub, Number(season), JSON.stringify(picks)],
+    );
+    res.json({ ok: true });
+  } catch (err) {
+    console.error('[nba-playoffs] PUT /picks/:season failed:', err.message);
+    res.status(500).json({ error: 'Failed to save picks' });
+  }
+});
+
+// GET /api/nba/playoffs/leaderboard/:season
+// Public — scores all user brackets against the official results row.
+router.get('/leaderboard/:season', async (req, res) => {
+  const { season } = req.params;
+  if (!SEASON_RE.test(season)) {
+    return res.status(400).json({ error: 'season must be a 4-digit year' });
+  }
+
+  try {
+    const officialResult = await pool.query(
+      'SELECT picks FROM nba_playoff_brackets WHERE user_sub = $1 AND season = $2',
+      [OFFICIAL_RESULTS_SUB, Number(season)],
+    );
+
+    const officialPicks = officialResult.rows[0]?.picks ?? null;
+
+    // No official results yet — return empty leaderboard
+    if (!officialPicks) {
+      return res.json({ entries: [] });
+    }
+
+    const userBrackets = await pool.query(
+      'SELECT user_sub, picks FROM nba_playoff_brackets WHERE user_sub != $1 AND season = $2',
+      [OFFICIAL_RESULTS_SUB, Number(season)],
+    );
+
+    const entries = await Promise.all(
+      userBrackets.rows.map(async ({ user_sub, picks }) => {
+        const profileResult = await pool.query(
+          'SELECT display_name, username FROM user_profiles WHERE user_sub = $1',
+          [user_sub],
+        );
+        const profile = profileResult.rows[0];
+        const displayName = profile?.display_name ?? profile?.username ?? 'Anonymous';
+
+        const { total, breakdown } = scoreBracket(picks, officialPicks);
+
+        return { userSub: user_sub, displayName, score: total, maxPossible: MAX_POSSIBLE, breakdown };
+      }),
+    );
+
+    entries.sort((a, b) => {
+      if (b.score !== a.score) return b.score - a.score;
+      // Tiebreak: lower combinedScoreDiff wins; null diff goes last
+      const aDiff = a.breakdown.combinedScoreDiff ?? Infinity;
+      const bDiff = b.breakdown.combinedScoreDiff ?? Infinity;
+      return aDiff - bDiff;
+    });
+
+    const ranked = entries.map((entry, i) => ({ rank: i + 1, ...entry }));
+
+    res.json({ entries: ranked });
+  } catch (err) {
+    console.error('[nba-playoffs] GET /leaderboard/:season failed:', err.message);
+    res.status(500).json({ error: 'Failed to fetch leaderboard' });
+  }
+});
+
+// PUT /api/nba/playoffs/results/:season
+// Admin-only — sets the official results for scoring. Protected by PLAYOFFS_ADMIN_SECRET.
+router.put('/results/:season', async (req, res) => {
+  const { season } = req.params;
+  if (!SEASON_RE.test(season)) {
+    return res.status(400).json({ error: 'season must be a 4-digit year' });
+  }
+
+  const secret = process.env.PLAYOFFS_ADMIN_SECRET;
+  if (!secret || req.headers.authorization !== `Bearer ${secret}`) {
+    return res.status(401).json({ error: 'Unauthorized' });
+  }
+
+  const { picks } = req.body;
+  if (!isPlainObject(picks)) {
+    return res.status(400).json({ error: 'picks must be a plain object' });
+  }
+
+  try {
+    await pool.query(
+      `INSERT INTO nba_playoff_brackets (id, user_sub, season, picks)
+       VALUES (gen_random_uuid(), $1, $2, $3)
+       ON CONFLICT (user_sub, season)
+       DO UPDATE SET picks = EXCLUDED.picks, updated_at = now()`,
+      [OFFICIAL_RESULTS_SUB, Number(season), JSON.stringify(picks)],
+    );
+    res.json({ ok: true });
+  } catch (err) {
+    console.error('[nba-playoffs] PUT /results/:season failed:', err.message);
+    res.status(500).json({ error: 'Failed to save results' });
+  }
+});
+
+module.exports = router;

--- a/scripts/run-migration.js
+++ b/scripts/run-migration.js
@@ -1,0 +1,28 @@
+require("dotenv").config({ path: ".env.local" });
+const { Pool } = require("pg");
+const fs = require("fs");
+const path = require("path");
+
+const file = process.argv[2];
+if (!file) {
+  console.error("Usage: node scripts/run-migration.js <migration-file>");
+  process.exit(1);
+}
+
+const sql = fs.readFileSync(path.resolve(file), "utf8");
+const pool = new Pool({
+  connectionString: process.env.DATABASE_PUBLIC_URL,
+  ssl: { rejectUnauthorized: false },
+});
+
+pool
+  .query(sql)
+  .then(() => {
+    console.log(`Applied: ${file}`);
+    pool.end();
+  })
+  .catch((err) => {
+    console.error(err.message);
+    pool.end();
+    process.exit(1);
+  });

--- a/server.js
+++ b/server.js
@@ -50,6 +50,9 @@ app.use(
 // Performance middleware
 app.use(compression());
 
+// Request parsing middleware — must come before any route that reads req.body
+app.use(express.json());
+
 // Caching middleware
 const cache = apicache.middleware;
 const oneHourCache = cache("1 hour");
@@ -62,8 +65,6 @@ app.use("/api/nba", oneHourCache);
 app.use("/api/f1", oneHourCache);
 app.use("/api/fantasy", oneHourCache);
 
-// Request parsing middleware
-app.use(express.json());
 app.use(express.static(path.join(__dirname, "public")));
 
 // Logging middleware

--- a/server.js
+++ b/server.js
@@ -10,6 +10,7 @@ const apicache = require("apicache");
 
 // Local imports
 const nbaRoutes = require("./routes/nba");
+const nbaPlayoffsRoutes = require("./routes/nba-playoffs");
 const dbRoutes = require("./routes/db");
 const youtubeRoutes = require("./routes/youtube");
 const f1Routes = require("./routes/f1");
@@ -52,6 +53,9 @@ app.use(compression());
 // Caching middleware
 const cache = apicache.middleware;
 const oneHourCache = cache("1 hour");
+
+// Playoffs picks are user-specific and mutable — must be mounted before the nba cache
+app.use("/api/nba/playoffs", nbaPlayoffsRoutes);
 
 // Apply 1-hour cache to specific API routes
 app.use("/api/nba", oneHourCache);

--- a/utils/playoffScoring.js
+++ b/utils/playoffScoring.js
@@ -1,0 +1,77 @@
+/**
+ * Points awarded for a correct series winner, by round.
+ * Round is derived from the matchup ID string.
+ */
+const ROUND_POINTS = {
+  r1: 1,
+  r2: 2,
+  cf: 4,
+  finals: 8,
+};
+
+const MAX_POSSIBLE = 52;
+
+/**
+ * Derive the round key from a matchup ID.
+ * Patterns: E_R1_M1..4, W_R1_M1..4 → r1
+ *           E_R2_M1/2, W_R2_M1/2   → r2
+ *           E_CF, W_CF              → cf
+ *           NBA_FINALS              → finals
+ *
+ * @param {string} matchupId
+ * @returns {'r1' | 'r2' | 'cf' | 'finals' | null}
+ */
+function getRound(matchupId) {
+  if (matchupId === 'NBA_FINALS') return 'finals';
+  if (matchupId.endsWith('_CF')) return 'cf';
+  if (matchupId.includes('_R2_')) return 'r2';
+  if (matchupId.includes('_R1_')) return 'r1';
+  return null;
+}
+
+/**
+ * Score a user's bracket picks against the official results.
+ *
+ * @param {Record<string, { winner: string; seriesScore: string; mvp?: string; lastGameCombinedScore?: number | null }>} picks
+ * @param {Record<string, { winner: string; seriesScore: string; mvp?: string; lastGameCombinedScore?: number | null }>} official
+ * @returns {{ total: number, breakdown: { r1: number, r2: number, cf: number, finals: number, bonuses: number, mvp: number, combinedScoreDiff: number | null } }}
+ */
+function scoreBracket(picks, official) {
+  const breakdown = { r1: 0, r2: 0, cf: 0, finals: 0, bonuses: 0, mvp: 0, combinedScoreDiff: null };
+
+  for (const matchupId of Object.keys(official)) {
+    const officialPick = official[matchupId];
+    const userPick = picks[matchupId];
+
+    if (!officialPick?.winner || !userPick?.winner) continue;
+
+    const round = getRound(matchupId);
+    if (!round) continue;
+
+    const winnerCorrect = userPick.winner === officialPick.winner;
+
+    if (winnerCorrect) {
+      breakdown[round] += ROUND_POINTS[round];
+    }
+
+    if (officialPick.seriesScore && userPick.seriesScore === officialPick.seriesScore) {
+      breakdown.bonuses += 1;
+    }
+
+    if (round === 'finals') {
+      if (officialPick.mvp && userPick.mvp && userPick.mvp.trim().toLowerCase() === officialPick.mvp.trim().toLowerCase()) {
+        breakdown.mvp += 5;
+      }
+
+      if (officialPick.lastGameCombinedScore != null && userPick.lastGameCombinedScore != null) {
+        breakdown.combinedScoreDiff = Math.abs(userPick.lastGameCombinedScore - officialPick.lastGameCombinedScore);
+      }
+    }
+  }
+
+  const total = breakdown.r1 + breakdown.r2 + breakdown.cf + breakdown.finals + breakdown.bonuses + breakdown.mvp;
+
+  return { total, breakdown };
+}
+
+module.exports = { scoreBracket, getRound, ROUND_POINTS, MAX_POSSIBLE };


### PR DESCRIPTION
# Changelog

## 2026-04-16 - version 1.5.8

- `routes/nba-playoffs.js`: NBA playoff bracket API — `GET /api/nba/playoffs/picks/:season` and `PUT /api/nba/playoffs/picks/:season` for authenticated users to read/save picks; `GET /api/nba/playoffs/leaderboard/:season` (public) scores all brackets against the official results row and returns ranked entries with max-possible score
- `utils/playoffScoring.js`: playoff bracket scoring engine (`scoreBracket`, `MAX_POSSIBLE`)
- `migrations/006_nba_playoffs.sql`: `nba_playoff_brackets` table with `(user_sub, season)` unique constraint; official results stored as a reserved `OFFICIAL_RESULTS` row
- `scripts/run-migration.js`: generic migration runner — `node scripts/run-migration.js <sql-file>`
- `server.js`: moved `express.json()` before route registration (fixes body parsing for all routes); mounted `/api/nba/playoffs` before the NBA 1-hour cache so picks endpoints are never cached
