### PR TITLE
phase 3: cross-cutting middleware and logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 2026-07-17 - version 2.2.0
+
+- `src/middleware/upsertUser.ts`: typed Auth0 user upsert middleware with per-process caching
+- `src/middleware/validate.ts`: generic Zod validation middleware — `validateBody<T>()`, `validateParams<T>()`, `validateQuery<T>()` with typed schemas
+- `src/middleware/rateLimiter.ts`: typed factory functions `createIpLimiter()` and `createUserLimiter()` with pre-configured NBA limiter
+- `src/middleware/cache.ts`: typed response cache middleware with TTL, LRU eviction, prefix invalidation, and X-Cache headers
+- `src/shared/types/express.d.ts`: global Express Request type augmentation for `auth`, `validatedBody`, `validatedQuery`
+
 ## 2026-07-16 - version 2.1.3
 
 - `src/modules/f1/`: TypeScript migration — service wraps Python queue for FastF1 data, 14 route handlers including cache clear

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2026-07-17 - version 2.2.1
+
+- `src/shared/utils/logger.ts`: pino-based structured logger with pretty-print in dev, JSON in production
+- `src/middleware/requestLogger.ts`: pino-http request/response logging with userId and timing
+- Replace all `console.log/error/warn` calls across 17 files with structured pino logging
+
 ## 2026-07-17 - version 2.2.0
 
 - `src/middleware/upsertUser.ts`: typed Auth0 user upsert middleware with per-process caching

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "portfolio_api",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "portfolio_api",
-      "version": "2.1.1",
+      "version": "2.2.0",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.995.0",
         "@aws-sdk/lib-storage": "^3.995.0",
@@ -30,6 +30,8 @@
         "openai": "^4.98.0",
         "p-throttle": "^4.1.1",
         "pg": "^8.14.1",
+        "pino": "^10.3.1",
+        "pino-http": "^11.0.0",
         "sharp": "^0.34.1",
         "uuid": "^9.0.0",
         "xml2js": "^0.6.2",
@@ -43,11 +45,13 @@
         "@types/multer": "^2.2.0",
         "@types/node": "^26.1.1",
         "@types/pg": "^8.20.0",
+        "@types/pino-http": "^5.8.4",
         "@types/uuid": "^10.0.0",
         "@types/xml2js": "^0.4.14",
         "drizzle-kit": "^0.31.10",
         "jest": "^30.2.0",
         "nodemon": "^2.0.22",
+        "pino-pretty": "^13.1.3",
         "ts-node": "^10.9.2",
         "typescript": "^7.0.2"
       },
@@ -3415,6 +3419,12 @@
         "@tybys/wasm-util": "^0.10.0"
       }
     },
+    "node_modules/@pinojs/redact": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@pinojs/redact/-/redact-0.4.0.tgz",
+      "integrity": "sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==",
+      "license": "MIT"
+    },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -4459,6 +4469,60 @@
         "pg-types": "^2.2.0"
       }
     },
+    "node_modules/@types/pino": {
+      "version": "6.3.12",
+      "resolved": "https://registry.npmjs.org/@types/pino/-/pino-6.3.12.tgz",
+      "integrity": "sha512-dsLRTq8/4UtVSpJgl9aeqHvbh6pzdmjYD3C092SYgLD2TyoCqHpTJk6vp8DvCTGGc7iowZ2MoiYiVUUCcu7muw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/pino-pretty": "*",
+        "@types/pino-std-serializers": "*",
+        "sonic-boom": "^2.1.0"
+      }
+    },
+    "node_modules/@types/pino-http": {
+      "version": "5.8.4",
+      "resolved": "https://registry.npmjs.org/@types/pino-http/-/pino-http-5.8.4.tgz",
+      "integrity": "sha512-UTYBQ2acmJ2eK0w58vVtgZ9RAicFFndfrnWC1w5cBTf8zwn/HEy8O+H7psc03UZgTzHmlcuX8VkPRnRDEj+FUQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/pino": "6.3"
+      }
+    },
+    "node_modules/@types/pino-pretty": {
+      "version": "4.7.5",
+      "resolved": "https://registry.npmjs.org/@types/pino-pretty/-/pino-pretty-4.7.5.tgz",
+      "integrity": "sha512-rfHe6VIknk14DymxGqc9maGsRe8/HQSvM2u46EAz2XrS92qsAJnW16dpdFejBuZKD8cRJX6Aw6uVZqIQctMpAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/pino": "6.3"
+      }
+    },
+    "node_modules/@types/pino-std-serializers": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@types/pino-std-serializers/-/pino-std-serializers-2.4.1.tgz",
+      "integrity": "sha512-17XcksO47M24IVTVKPeAByWUd3Oez7EbIjXpSbzMPhXVzgjGtrOa49gKBwxH9hb8dKv58OelsWQ+A1G1l9S3wQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/pino/node_modules/sonic-boom": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-2.8.0.tgz",
+      "integrity": "sha512-kuonw1YOYYNOve5iHdSahXPOK49GqwA+LZhI6Wz/l0rP57iKyXXIHaRagOBHAPmGwJC6od2Z9zgvZ5loSgMlVg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "atomic-sleep": "^1.0.0"
+      }
+    },
     "node_modules/@types/qs": {
       "version": "6.15.1",
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.15.1.tgz",
@@ -5358,6 +5422,15 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
       "license": "MIT"
     },
+    "node_modules/atomic-sleep": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
+      "integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/babel-jest": {
       "version": "30.2.0",
       "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-30.2.0.tgz",
@@ -6170,6 +6243,16 @@
         "node": ">= 8"
       }
     },
+    "node_modules/dateformat": {
+      "version": "4.6.3",
+      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-4.6.3.tgz",
+      "integrity": "sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -6481,6 +6564,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
       }
     },
     "node_modules/env-paths": {
@@ -6826,10 +6919,24 @@
       ],
       "license": "MIT"
     },
+    "node_modules/fast-copy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/fast-copy/-/fast-copy-4.0.4.tgz",
+      "integrity": "sha512-eVAiWVNPSEGIzDl5yPuLrx8fNMogScXvD9xp1Kzd41FjRIz2I3sSIcxsFeM5EzFfHAfobdvs8ZySffUopljvIA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-safe-stringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
       "dev": true,
       "license": "MIT"
     },
@@ -7085,7 +7192,6 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
@@ -7306,6 +7412,13 @@
       "engines": {
         "node": ">=16.0.0"
       }
+    },
+    "node_modules/help-me": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/help-me/-/help-me-5.0.0.tgz",
+      "integrity": "sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/html-escaper": {
       "version": "2.0.2",
@@ -8386,6 +8499,16 @@
         "url": "https://github.com/sponsors/panva"
       }
     },
+    "node_modules/joycon": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/joycon/-/joycon-3.1.1.tgz",
+      "integrity": "sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -9088,6 +9211,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/on-exit-leak-free": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz",
+      "integrity": "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/on-finished": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
@@ -9475,6 +9607,93 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/pino": {
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-10.3.1.tgz",
+      "integrity": "sha512-r34yH/GlQpKZbU1BvFFqOjhISRo1MNx1tWYsYvmj6KIRHSPMT2+yHOEb1SG6NMvRoHRF0a07kCOox/9yakl1vg==",
+      "license": "MIT",
+      "dependencies": {
+        "@pinojs/redact": "^0.4.0",
+        "atomic-sleep": "^1.0.0",
+        "on-exit-leak-free": "^2.1.0",
+        "pino-abstract-transport": "^3.0.0",
+        "pino-std-serializers": "^7.0.0",
+        "process-warning": "^5.0.0",
+        "quick-format-unescaped": "^4.0.3",
+        "real-require": "^0.2.0",
+        "safe-stable-stringify": "^2.3.1",
+        "sonic-boom": "^4.0.1",
+        "thread-stream": "^4.0.0"
+      },
+      "bin": {
+        "pino": "bin.js"
+      }
+    },
+    "node_modules/pino-abstract-transport": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-3.0.0.tgz",
+      "integrity": "sha512-wlfUczU+n7Hy/Ha5j9a/gZNy7We5+cXp8YL+X+PG8S0KXxw7n/JXA3c46Y0zQznIJ83URJiwy7Lh56WLokNuxg==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.0.0"
+      }
+    },
+    "node_modules/pino-http": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/pino-http/-/pino-http-11.0.0.tgz",
+      "integrity": "sha512-wqg5XIAGRRIWtTk8qPGxkbrfiwEWz1lgedVLvhLALudKXvg1/L2lTFgTGPJ4Z2e3qcRmxoFxDuSdMdMGNM6I1g==",
+      "license": "MIT",
+      "dependencies": {
+        "get-caller-file": "^2.0.5",
+        "pino": "^10.0.0",
+        "pino-std-serializers": "^7.0.0",
+        "process-warning": "^5.0.0"
+      }
+    },
+    "node_modules/pino-pretty": {
+      "version": "13.1.3",
+      "resolved": "https://registry.npmjs.org/pino-pretty/-/pino-pretty-13.1.3.tgz",
+      "integrity": "sha512-ttXRkkOz6WWC95KeY9+xxWL6AtImwbyMHrL1mSwqwW9u+vLp/WIElvHvCSDg0xO/Dzrggz1zv3rN5ovTRVowKg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "colorette": "^2.0.7",
+        "dateformat": "^4.6.3",
+        "fast-copy": "^4.0.0",
+        "fast-safe-stringify": "^2.1.1",
+        "help-me": "^5.0.0",
+        "joycon": "^3.1.1",
+        "minimist": "^1.2.6",
+        "on-exit-leak-free": "^2.1.0",
+        "pino-abstract-transport": "^3.0.0",
+        "pump": "^3.0.0",
+        "secure-json-parse": "^4.0.0",
+        "sonic-boom": "^4.0.1",
+        "strip-json-comments": "^5.0.2"
+      },
+      "bin": {
+        "pino-pretty": "bin.js"
+      }
+    },
+    "node_modules/pino-pretty/node_modules/strip-json-comments": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-5.0.3.tgz",
+      "integrity": "sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/pino-std-serializers": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-7.1.0.tgz",
+      "integrity": "sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==",
+      "license": "MIT"
+    },
     "node_modules/pirates": {
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
@@ -9580,6 +9799,22 @@
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
       "license": "MIT"
     },
+    "node_modules/process-warning": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-5.0.0.tgz",
+      "integrity": "sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/progress": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
@@ -9608,6 +9843,17 @@
       "integrity": "sha512-77DZwxQmxKnu3aR542U+X8FypNzbfJ+C5XQDk3uWjWxn6151aIMGthWYRXTqT1E5oJvg+ljaa2OJi+VfvCOQ8w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
     },
     "node_modules/pure-rand": {
       "version": "7.0.1",
@@ -9640,6 +9886,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/quick-format-unescaped": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
+      "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==",
+      "license": "MIT"
     },
     "node_modules/range-parser": {
       "version": "1.2.1",
@@ -9785,6 +10037,15 @@
         "node": ">=8.10.0"
       }
     },
+    "node_modules/real-require": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.2.0.tgz",
+      "integrity": "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12.13.0"
+      }
+    },
     "node_modules/rechoir": {
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.8.0.tgz",
@@ -9866,11 +10127,37 @@
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "license": "MIT"
     },
+    "node_modules/safe-stable-stringify": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
+      "integrity": "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
+    },
+    "node_modules/secure-json-parse": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-4.1.0.tgz",
+      "integrity": "sha512-l4KnYfEyqYJxDwlNVyRfO2E4NTHfMKAWdUuA8J0yve2Dz/E/PdBepY03RvyJpssIpRFwJoCD55wA+mEDs6ByWA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/semver": {
       "version": "5.7.2",
@@ -10136,6 +10423,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/sonic-boom": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-4.2.1.tgz",
+      "integrity": "sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==",
+      "license": "MIT",
+      "dependencies": {
+        "atomic-sleep": "^1.0.0"
       }
     },
     "node_modules/source-map": {
@@ -10527,6 +10823,24 @@
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
+    },
+    "node_modules/thread-stream": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-4.2.0.tgz",
+      "integrity": "sha512-e2zZ96wSChazBsbENf/Pcm/4swHt2cEKQ92rhUjkL9GCKiTDJIaTBenjE/m9DXi0QBmTMDkFDdOomUy20A1tDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "real-require": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/thread-stream/node_modules/real-require": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/real-require/-/real-require-1.0.0.tgz",
+      "integrity": "sha512-P4nbQYQfePJxRSmY+v/KINxVucm4NF3p3s7pJveMTtom52FR4YGltUQLB8idDXwDDWW+eYrWDFbuzUnjoWHF7g==",
+      "license": "MIT"
     },
     "node_modules/tildify": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portfolio_api",
-  "version": "2.1.3",
+  "version": "2.2.0",
   "description": "Portfolio API with Node.js and Python",
   "main": "server.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portfolio_api",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "Portfolio API with Node.js and Python",
   "main": "server.js",
   "scripts": {
@@ -33,6 +33,8 @@
     "openai": "^4.98.0",
     "p-throttle": "^4.1.1",
     "pg": "^8.14.1",
+    "pino": "^10.3.1",
+    "pino-http": "^11.0.0",
     "sharp": "^0.34.1",
     "uuid": "^9.0.0",
     "xml2js": "^0.6.2",
@@ -46,11 +48,13 @@
     "@types/multer": "^2.2.0",
     "@types/node": "^26.1.1",
     "@types/pg": "^8.20.0",
+    "@types/pino-http": "^5.8.4",
     "@types/uuid": "^10.0.0",
     "@types/xml2js": "^0.4.14",
     "drizzle-kit": "^0.31.10",
     "jest": "^30.2.0",
     "nodemon": "^2.0.22",
+    "pino-pretty": "^13.1.3",
     "ts-node": "^10.9.2",
     "typescript": "^7.0.2"
   },

--- a/src/middleware/cache.ts
+++ b/src/middleware/cache.ts
@@ -1,0 +1,77 @@
+import type { Request, Response, NextFunction } from 'express';
+
+interface CacheEntry {
+  body: unknown;
+  statusCode: number;
+  headers: Record<string, string>;
+  timestamp: number;
+}
+
+const responseCache = new Map<string, CacheEntry>();
+
+/**
+ * Returns Express middleware that caches JSON responses for the given duration.
+ * Cache key is derived from method + path + query string.
+ *
+ * @param duration - cache TTL in seconds
+ */
+export function cacheMiddleware(duration: number) {
+  return (req: Request, res: Response, next: NextFunction): void => {
+    if (req.method !== 'GET') {
+      next();
+      return;
+    }
+
+    const key = `${req.method}:${req.originalUrl}`;
+    const cached = responseCache.get(key);
+    const now = Date.now();
+
+    if (cached && now - cached.timestamp < duration * 1000) {
+      res.set('X-Cache', 'HIT');
+      for (const [h, v] of Object.entries(cached.headers)) {
+        res.set(h, v);
+      }
+      res.status(cached.statusCode).json(cached.body);
+      return;
+    }
+
+    // Intercept res.json to capture the response for caching
+    const originalJson = res.json.bind(res);
+    res.json = (body: unknown) => {
+      if (res.statusCode >= 200 && res.statusCode < 300) {
+        // Evict oldest if cache gets too large
+        if (responseCache.size >= 500) {
+          const oldestKey = [...responseCache.entries()].sort(
+            ([, a], [, b]) => a.timestamp - b.timestamp,
+          )[0][0];
+          responseCache.delete(oldestKey);
+        }
+
+        responseCache.set(key, {
+          body,
+          statusCode: res.statusCode,
+          headers: { 'Content-Type': 'application/json' },
+          timestamp: now,
+        });
+      }
+      res.set('X-Cache', 'MISS');
+      return originalJson(body);
+    };
+
+    next();
+  };
+}
+
+/** Invalidate all cache entries matching a prefix (e.g. 'GET:/api/nba'). */
+export function invalidateCacheByPrefix(prefix: string): void {
+  for (const key of responseCache.keys()) {
+    if (key.startsWith(prefix)) {
+      responseCache.delete(key);
+    }
+  }
+}
+
+/** Clear the entire response cache. */
+export function clearResponseCache(): void {
+  responseCache.clear();
+}

--- a/src/middleware/errorHandler.ts
+++ b/src/middleware/errorHandler.ts
@@ -1,6 +1,9 @@
 import type { Request, Response, NextFunction } from 'express';
 import { ZodError } from 'zod';
 import { AppError } from '../shared/errors/index.js';
+import { createModuleLogger } from '../shared/utils/logger.js';
+
+const log = createModuleLogger('errorHandler');
 
 interface ErrorResponse {
   error: string;
@@ -57,7 +60,7 @@ export function errorHandler(
 
   // Unknown errors
   const isProduction = process.env.NODE_ENV === 'production';
-  console.error('Unhandled error:', err);
+  log.error({ err }, 'unhandled error');
 
   res.status(500).json({
     error: 'InternalServerError',

--- a/src/middleware/index.ts
+++ b/src/middleware/index.ts
@@ -1,1 +1,13 @@
 export { errorHandler } from './errorHandler.js';
+export { upsertUser } from './upsertUser.js';
+export { validateBody, validateParams, validateQuery } from './validate.js';
+export {
+  createIpLimiter,
+  createUserLimiter,
+  nbaIpLimiter,
+} from './rateLimiter.js';
+export {
+  cacheMiddleware,
+  invalidateCacheByPrefix,
+  clearResponseCache,
+} from './cache.js';

--- a/src/middleware/index.ts
+++ b/src/middleware/index.ts
@@ -11,3 +11,4 @@ export {
   invalidateCacheByPrefix,
   clearResponseCache,
 } from './cache.js';
+export { requestLogger } from './requestLogger.js';

--- a/src/middleware/rateLimiter.ts
+++ b/src/middleware/rateLimiter.ts
@@ -1,0 +1,49 @@
+import rateLimit, { type Options } from 'express-rate-limit';
+import type { Request } from 'express';
+
+/**
+ * Creates an IP-based rate limiter.
+ */
+export function createIpLimiter(opts: {
+  windowMs: number;
+  max: number;
+  message?: string;
+}) {
+  return rateLimit({
+    windowMs: opts.windowMs,
+    max: opts.max,
+    standardHeaders: true,
+    legacyHeaders: false,
+    message: {
+      error: opts.message ?? 'Too many requests, please try again later.',
+    },
+  });
+}
+
+/**
+ * Creates a rate limiter keyed by the authenticated user's sub claim,
+ * falling back to the request IP when no auth is present.
+ */
+export function createUserLimiter(opts: {
+  windowMs: number;
+  max: number;
+  message?: string;
+}) {
+  return rateLimit({
+    windowMs: opts.windowMs,
+    max: opts.max,
+    standardHeaders: true,
+    legacyHeaders: false,
+    keyGenerator: (req: Request) =>
+      (req as any).auth?.payload?.sub ?? req.ip ?? 'unknown',
+    message: {
+      error: opts.message ?? 'Too many requests, please try again later.',
+    },
+  });
+}
+
+/** Pre-configured IP limiter for NBA proxy routes: 60 req / 5 min. */
+export const nbaIpLimiter = createIpLimiter({
+  windowMs: 5 * 60 * 1000,
+  max: 60,
+});

--- a/src/middleware/requestLogger.ts
+++ b/src/middleware/requestLogger.ts
@@ -1,0 +1,18 @@
+import pinoHttp from 'pino-http';
+import { logger } from '../shared/utils/logger.js';
+
+/**
+ * Pino-http middleware that auto-logs request/response with timing.
+ * Includes userId when the request is authenticated.
+ */
+export const requestLogger = pinoHttp({
+  logger,
+  autoLogging: true,
+  customProps: (req) => ({
+    userId: (req as any).auth?.payload?.sub ?? undefined,
+  }),
+  customSuccessMessage: (req, res) =>
+    `${req.method} ${req.url} ${res.statusCode}`,
+  customErrorMessage: (req, _res, err) =>
+    `${req.method} ${req.url} failed: ${err.message}`,
+});

--- a/src/middleware/upsertUser.ts
+++ b/src/middleware/upsertUser.ts
@@ -1,5 +1,8 @@
 import type { Request, Response, NextFunction } from 'express';
 import { query } from '../config/database.js';
+import { createModuleLogger } from '../shared/utils/logger.js';
+
+const log = createModuleLogger('upsertUser');
 
 /**
  * Module-level cache: sub → email for subs seen this process lifetime.
@@ -23,9 +26,7 @@ export async function upsertUser(
     null;
 
   if (!sub || !email) {
-    console.warn(
-      '[upsertUser] email not available from JWT or BFF header — sharing will not work for this user',
-    );
+    log.warn('email not available from JWT or BFF header — sharing will not work for this user');
     return next();
   }
 
@@ -42,10 +43,7 @@ export async function upsertUser(
     );
     _seenUsers.set(sub, email);
   } catch (err) {
-    console.error(
-      '[upsertUser] DB upsert failed (non-fatal):',
-      (err as Error).message,
-    );
+    log.error({ err }, 'DB upsert failed (non-fatal)');
   }
 
   next();

--- a/src/middleware/upsertUser.ts
+++ b/src/middleware/upsertUser.ts
@@ -1,0 +1,52 @@
+import type { Request, Response, NextFunction } from 'express';
+import { query } from '../config/database.js';
+
+/**
+ * Module-level cache: sub → email for subs seen this process lifetime.
+ * Skips the DB upsert when the sub+email pair hasn't changed.
+ */
+const _seenUsers = new Map<string, string>();
+
+/**
+ * Express middleware that upserts a `users` row from the Auth0 JWT payload.
+ * Must be placed after checkJwt so req.auth is populated.
+ */
+export async function upsertUser(
+  req: Request,
+  _res: Response,
+  next: NextFunction,
+): Promise<void> {
+  const sub = req.auth?.payload?.sub;
+  const email =
+    (req.auth?.payload?.email as string | undefined) ??
+    (req.headers['x-user-email'] as string | undefined) ??
+    null;
+
+  if (!sub || !email) {
+    console.warn(
+      '[upsertUser] email not available from JWT or BFF header — sharing will not work for this user',
+    );
+    return next();
+  }
+
+  if (_seenUsers.get(sub) === email) {
+    return next();
+  }
+
+  try {
+    await query(
+      `INSERT INTO users (sub, email, updated_at)
+       VALUES ($1, $2, NOW())
+       ON CONFLICT (sub) DO UPDATE SET email = EXCLUDED.email, updated_at = NOW()`,
+      [sub, email],
+    );
+    _seenUsers.set(sub, email);
+  } catch (err) {
+    console.error(
+      '[upsertUser] DB upsert failed (non-fatal):',
+      (err as Error).message,
+    );
+  }
+
+  next();
+}

--- a/src/middleware/validate.ts
+++ b/src/middleware/validate.ts
@@ -1,0 +1,62 @@
+import type { Request, Response, NextFunction } from 'express';
+import type { ZodSchema } from 'zod';
+
+/**
+ * Returns Express middleware that validates req.body against a Zod schema.
+ * On success, replaces req.body with the parsed (and potentially transformed) data.
+ */
+export function validateBody<T>(schema: ZodSchema<T>) {
+  return (req: Request, res: Response, next: NextFunction): void => {
+    const result = schema.safeParse(req.body);
+    if (!result.success) {
+      const details = result.error.errors.map((e) => ({
+        field: e.path.join('.'),
+        message: e.message,
+      }));
+      res.status(400).json({ error: 'Validation failed', details });
+      return;
+    }
+    req.body = result.data;
+    next();
+  };
+}
+
+/**
+ * Returns Express middleware that validates req.params against a Zod schema.
+ * On success, replaces req.params with the parsed data.
+ */
+export function validateParams<T>(schema: ZodSchema<T>) {
+  return (req: Request, res: Response, next: NextFunction): void => {
+    const result = schema.safeParse(req.params);
+    if (!result.success) {
+      const details = result.error.errors.map((e) => ({
+        field: e.path.join('.'),
+        message: e.message,
+      }));
+      res.status(400).json({ error: 'Validation failed', details });
+      return;
+    }
+    req.params = result.data as any;
+    next();
+  };
+}
+
+/**
+ * Returns Express middleware that validates req.query against a Zod schema.
+ * On success, sets req.validatedQuery with the parsed data.
+ */
+export function validateQuery<T>(schema: ZodSchema<T>) {
+  return (req: Request, res: Response, next: NextFunction): void => {
+    const result = schema.safeParse(req.query);
+    if (!result.success) {
+      const details = result.error.errors.map((e) => ({
+        field: e.path.join('.'),
+        message: e.message,
+      }));
+      res.status(400).json({ error: 'Validation failed', details });
+      return;
+    }
+    req.validatedQuery = result.data;
+    next();
+  };
+}

--- a/src/modules/calendar/service.ts
+++ b/src/modules/calendar/service.ts
@@ -3,6 +3,9 @@
 // ---------------------------------------------------------------------------
 
 import { CalendarRepository } from './repository.js';
+import { createModuleLogger } from '../../shared/utils/logger.js';
+
+const log = createModuleLogger('calendar');
 import {
   NotFoundError,
   ValidationError,
@@ -125,10 +128,7 @@ export class CalendarService {
           await repo.setEventGoogleId(event.id, googleEventId, userSub);
         }
       } catch (syncErr) {
-        console.error(
-          'CalendarService.createEvent Google sync failed:',
-          (syncErr as Error).message,
-        );
+        log.error({ err: syncErr }, 'createEvent Google sync failed');
       }
     }
 
@@ -174,10 +174,7 @@ export class CalendarService {
           );
         }
       } catch (syncErr) {
-        console.error(
-          'CalendarService.updateEvent Google sync failed:',
-          (syncErr as Error).message,
-        );
+        log.error({ err: syncErr }, 'updateEvent Google sync failed');
       }
     }
 
@@ -215,10 +212,7 @@ export class CalendarService {
           );
         }
       } catch (syncErr) {
-        console.error(
-          'CalendarService.deleteEvent Google sync failed:',
-          (syncErr as Error).message,
-        );
+        log.error({ err: syncErr }, 'deleteEvent Google sync failed');
       }
     }
   }
@@ -291,10 +285,7 @@ export class CalendarService {
       try {
         await this.google.stopWatchByCalId(userSub, calendar.googleCalId);
       } catch (watchErr) {
-        console.error(
-          'CalendarService.deleteCalendar stopWatchByCalId failed:',
-          (watchErr as Error).message,
-        );
+        log.error({ err: watchErr }, 'deleteCalendar stopWatchByCalId failed');
       }
     }
 
@@ -331,10 +322,7 @@ export class CalendarService {
     try {
       await this.google.registerWatch(userSub, calId);
     } catch (watchErr) {
-      console.error(
-        'CalendarService.connectGoogle registerWatch failed:',
-        (watchErr as Error).message,
-      );
+      log.error({ err: watchErr }, 'connectGoogle registerWatch failed');
     }
 
     return updated!;
@@ -351,10 +339,7 @@ export class CalendarService {
       try {
         await this.google.stopWatchByCalId(userSub, calendar.googleCalId);
       } catch (watchErr) {
-        console.error(
-          'CalendarService.disconnectGoogle stopWatchByCalId failed:',
-          (watchErr as Error).message,
-        );
+        log.error({ err: watchErr }, 'disconnectGoogle stopWatchByCalId failed');
       }
     }
 
@@ -439,10 +424,7 @@ export class CalendarService {
       this.google
         .addCalendarAclEntry(ownerSub, cal.googleCalId, email, member.role)
         .catch((err: Error) =>
-          console.warn(
-            '[calendar] addCalendarAclEntry failed (non-fatal):',
-            err.message,
-          ),
+          log.warn({ err }, 'addCalendarAclEntry failed (non-fatal)'),
         );
     }
 

--- a/src/modules/chat/controller.ts
+++ b/src/modules/chat/controller.ts
@@ -1,5 +1,8 @@
 import type { Request, Response, NextFunction } from 'express';
 import { ChatService } from './service.js';
+import { createModuleLogger } from '../../shared/utils/logger.js';
+
+const log = createModuleLogger('chat');
 
 const service = new ChatService();
 
@@ -21,7 +24,7 @@ export class ChatController {
       const reply = await service.chat(prompt);
       res.json({ reply });
     } catch (error) {
-      console.error('ChatGPT error:', error);
+      log.error({ err: error }, 'ChatGPT request failed');
       res.status(500).json({ error: 'ChatGPT request failed' });
     }
   }
@@ -43,7 +46,7 @@ export class ChatController {
       const reply = await service.summarize(text);
       res.json({ reply });
     } catch (error) {
-      console.error('ChatGPT error:', error);
+      log.error({ err: error }, 'ChatGPT request failed');
       res.status(500).json({ error: 'ChatGPT request failed' });
     }
   }

--- a/src/modules/f1/service.ts
+++ b/src/modules/f1/service.ts
@@ -1,6 +1,9 @@
 import path from 'path';
 import fs from 'fs';
 import { env } from '../../config/env.js';
+import { createModuleLogger } from '../../shared/utils/logger.js';
+
+const log = createModuleLogger('f1');
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires -- JS util, not yet migrated
 const requestQueue = require('../../../utils/queue') as {
@@ -31,13 +34,13 @@ export class F1Service {
       try {
         fs.mkdirSync(this.cacheDir, { recursive: true });
       } catch (err) {
-        console.error('Failed to create FastF1 cache directory:', err);
+        log.error({ err }, 'failed to create FastF1 cache directory');
       }
     }
     try {
       fs.chmodSync(this.cacheDir, '777');
     } catch (err) {
-      console.error('Failed to update cache directory permissions:', err);
+      log.error({ err }, 'failed to update cache directory permissions');
     }
   }
 

--- a/src/modules/feedback/controller.ts
+++ b/src/modules/feedback/controller.ts
@@ -1,5 +1,8 @@
 import type { Request, Response, NextFunction } from 'express';
 import { FeedbackRepository } from './repository.js';
+import { createModuleLogger } from '../../shared/utils/logger.js';
+
+const log = createModuleLogger('feedback');
 
 /** Extract a single string param (Express 5 params can be string | string[]). */
 function param(val: string | string[]): string {
@@ -26,7 +29,7 @@ export class FeedbackController {
       );
       res.status(200).json({ success: true, feedback, totalCount });
     } catch (error) {
-      console.error('Error fetching feedback:', error);
+      log.error({ err: error }, 'failed to fetch feedback');
       res.status(500).json({ error: 'Failed to fetch feedback' });
     }
   }
@@ -42,7 +45,7 @@ export class FeedbackController {
       const feedback = await repo.add({ text, rotation, journal_entry_id, user_sub: userSub });
       res.status(201).json({ success: true, feedback });
     } catch (error) {
-      console.error('Error adding feedback:', error);
+      log.error({ err: error }, 'failed to add feedback');
       res.status(500).json({ error: 'Failed to add feedback' });
     }
   }
@@ -59,7 +62,7 @@ export class FeedbackController {
       const feedback = await repo.update(id, { text, rotation, journal_entry_id, user_sub: userSub });
       res.status(200).json({ success: true, feedback });
     } catch (error: any) {
-      console.error('Error updating feedback:', error);
+      log.error({ err: error }, 'failed to update feedback');
       if (error.message === 'Feedback not found or unauthorized') {
         res.status(404).json({ error: 'Feedback not found or unauthorized' });
       } else {
@@ -74,7 +77,7 @@ export class FeedbackController {
       await repo.delete(id);
       res.status(200).json({ success: true });
     } catch (error) {
-      console.error('Error deleting feedback:', error);
+      log.error({ err: error }, 'failed to delete feedback');
       res.status(500).json({ error: 'Failed to delete feedback' });
     }
   }

--- a/src/modules/follows/controller.ts
+++ b/src/modules/follows/controller.ts
@@ -5,6 +5,9 @@
 import type { Request, Response, NextFunction } from 'express';
 import { z } from 'zod';
 import * as repo from './repository.js';
+import { createModuleLogger } from '../../shared/utils/logger.js';
+
+const log = createModuleLogger('follows');
 
 // ── Helpers ────────────────────────────────────────────────────────────────
 
@@ -60,7 +63,7 @@ export class FollowsController {
           .status(409)
           .json({ error: 'Follow request already exists' });
       }
-      console.error('[follows] POST /:username error:', err.message);
+      log.error({ err }, 'POST /:username failed');
       return res
         .status(500)
         .json({ error: 'Failed to send follow request' });
@@ -81,7 +84,7 @@ export class FollowsController {
       }
       return res.json(row);
     } catch (err: any) {
-      console.error('[follows] PUT /:id/accept error:', err.message);
+      log.error({ err }, 'PUT /:id/accept failed');
       return res
         .status(500)
         .json({ error: 'Failed to accept follow request' });
@@ -102,7 +105,7 @@ export class FollowsController {
       }
       return res.json(row);
     } catch (err: any) {
-      console.error('[follows] PUT /:id/reject error:', err.message);
+      log.error({ err }, 'PUT /:id/reject failed');
       return res
         .status(500)
         .json({ error: 'Failed to reject follow request' });
@@ -139,7 +142,7 @@ export class FollowsController {
       }
       return res.status(204).end();
     } catch (err: any) {
-      console.error('[follows] DELETE /:username error:', err.message);
+      log.error({ err }, 'DELETE /:username failed');
       return res.status(500).json({ error: 'Failed to unfollow user' });
     }
   }
@@ -152,7 +155,7 @@ export class FollowsController {
       const rows = await repo.getPendingRequests(followingSub);
       return res.json({ requests: rows });
     } catch (err: any) {
-      console.error('[follows] GET /requests error:', err.message);
+      log.error({ err }, 'GET /requests failed');
       return res
         .status(500)
         .json({ error: 'Failed to fetch follow requests' });
@@ -167,7 +170,7 @@ export class FollowsController {
       const rows = await repo.getFollowing(followerSub);
       return res.json({ following: rows });
     } catch (err: any) {
-      console.error('[follows] GET /following error:', err.message);
+      log.error({ err }, 'GET /following failed');
       return res
         .status(500)
         .json({ error: 'Failed to fetch following list' });
@@ -182,7 +185,7 @@ export class FollowsController {
       const rows = await repo.getFollowers(followingSub);
       return res.json({ followers: rows });
     } catch (err: any) {
-      console.error('[follows] GET /followers error:', err.message);
+      log.error({ err }, 'GET /followers failed');
       return res
         .status(500)
         .json({ error: 'Failed to fetch followers list' });

--- a/src/modules/forum/controller.ts
+++ b/src/modules/forum/controller.ts
@@ -1,5 +1,8 @@
 import type { Request, Response, NextFunction } from 'express';
 import { ForumRepository } from './repository.js';
+import { createModuleLogger } from '../../shared/utils/logger.js';
+
+const log = createModuleLogger('forum');
 
 /** Extract a single string param (Express 5 params can be string | string[]). */
 function param(val: string | string[]): string {
@@ -87,7 +90,7 @@ export class ForumController {
       const marker = await repo.createMarker(latitude, longitude, text);
       res.status(201).json(marker);
     } catch (error) {
-      console.error('Error saving marker:', (error as Error).message);
+      log.error({ err: error }, 'failed to save marker');
       next(error);
     }
   }
@@ -97,7 +100,7 @@ export class ForumController {
       const markers = await repo.getMarkers();
       res.status(200).json(markers);
     } catch (error) {
-      console.error('Error fetching markers:', (error as Error).message);
+      log.error({ err: error }, 'failed to fetch markers');
       next(error);
     }
   }

--- a/src/modules/gallery/controller.ts
+++ b/src/modules/gallery/controller.ts
@@ -1,5 +1,8 @@
 import type { Request, Response, NextFunction } from 'express';
 import sharp from 'sharp';
+import { createModuleLogger } from '../../shared/utils/logger.js';
+
+const log = createModuleLogger('gallery');
 import { Upload } from '@aws-sdk/lib-storage';
 import { DeleteObjectCommand } from '@aws-sdk/client-s3';
 import { s3, S3_BUCKET, CDN_BASE } from '../../config/s3.js';
@@ -87,7 +90,7 @@ export class GalleryController {
 
       res.status(201).json(savedData);
     } catch (error) {
-      console.error('Error uploading image or saving data:', error);
+      log.error({ err: error }, 'failed to upload image or save data');
       res.status(500).json({ error: 'Failed to upload image or save data.' });
     }
   }
@@ -117,7 +120,7 @@ export class GalleryController {
 
       res.status(200).json(images);
     } catch (error) {
-      console.error('Error fetching gallery items from database:', error);
+      log.error({ err: error }, 'failed to fetch gallery items');
       res.status(500).json({ error: 'Failed to fetch gallery items from database.' });
     }
   }
@@ -146,7 +149,7 @@ export class GalleryController {
 
       res.status(200).json({ message: 'Record and image deleted successfully.' });
     } catch (error) {
-      console.error('Error deleting gallery item:', error);
+      log.error({ err: error }, 'failed to delete gallery item');
       res.status(500).json({ error: 'Failed to delete record.' });
     }
   }

--- a/src/modules/google-auth/controller.ts
+++ b/src/modules/google-auth/controller.ts
@@ -1,5 +1,8 @@
 import type { Request, Response, NextFunction } from 'express';
 import { env } from '../../config/env.js';
+import { createModuleLogger } from '../../shared/utils/logger.js';
+
+const log = createModuleLogger('google-auth');
 import {
   db,
   registerWatch,
@@ -20,7 +23,7 @@ function enqueueForUser(userId: string, fn: () => Promise<void>): Promise<void> 
   const curr = prev
     .then(() => fn())
     .catch((err: Error) => {
-      console.error(`[googleWebhook] handler error for ${userId}:`, err.message);
+      log.error({ err, userId }, 'webhook handler error');
     });
   userQueues.set(userId, curr);
   curr.finally(() => {
@@ -40,7 +43,7 @@ export class GoogleAuthController {
         res.json({ connected: false });
       }
     } catch (err: any) {
-      console.error('[google] GET /auth/status failed:', err.message);
+      log.error({ err }, 'GET /auth/status failed');
       res.status(500).json({ error: 'Failed to check connection status' });
     }
   }
@@ -67,7 +70,7 @@ export class GoogleAuthController {
       });
       res.json({ url: `https://accounts.google.com/o/oauth2/v2/auth?${params}` });
     } catch (err: any) {
-      console.error('[google] GET /auth/url failed:', err.message);
+      log.error({ err }, 'GET /auth/url failed');
       res.status(500).json({ error: 'Failed to generate authorization URL' });
     }
   }
@@ -79,13 +82,13 @@ export class GoogleAuthController {
     const origin = parsed?.origin ?? env.FRONTEND_URL;
 
     if (error) {
-      console.warn('[google] OAuth denied by user:', error);
+      log.warn({ error }, 'OAuth denied by user');
       res.redirect(`${origin}/settings?gcal=denied`);
       return;
     }
 
     if (!parsed) {
-      console.warn('[google] Invalid state param in callback');
+      log.warn('invalid state param in callback');
       res.status(400).json({ error: 'Invalid state parameter' });
       return;
     }
@@ -107,7 +110,7 @@ export class GoogleAuthController {
 
       if (!tokenRes.ok) {
         const body = await tokenRes.text();
-        console.error('[google] Token exchange failed:', body);
+        log.error({ body }, 'token exchange failed');
         res.redirect(`${origin}/settings?gcal=error`);
         return;
       }
@@ -124,12 +127,12 @@ export class GoogleAuthController {
       try {
         await registerWatch(userId);
       } catch (watchErr: any) {
-        console.error('[google] registerWatch failed after connect:', watchErr.message);
+        log.error({ err: watchErr }, 'registerWatch failed after connect');
       }
 
       res.redirect(`${origin}/settings?gcal=connected`);
     } catch (err: any) {
-      console.error('[google] Callback error:', err.message);
+      log.error({ err }, 'callback error');
       res.redirect(`${origin}/settings?gcal=error`);
     }
   }
@@ -140,12 +143,12 @@ export class GoogleAuthController {
       try {
         await stopWatch(userId);
       } catch (watchErr: any) {
-        console.warn('[google] stopWatch failed on disconnect:', watchErr.message);
+        log.warn({ err: watchErr }, 'stopWatch failed on disconnect');
       }
       await db.deleteGoogleAuth(userId);
       res.sendStatus(204);
     } catch (err: any) {
-      console.error('[google] DELETE /auth/disconnect failed:', err.message);
+      log.error({ err }, 'DELETE /auth/disconnect failed');
       res.status(500).json({ error: 'Failed to disconnect Google Calendar' });
     }
   }
@@ -168,7 +171,7 @@ export class GoogleAuthController {
       if (googleCalId) {
         const calendar = await db.getCalendarByGoogleCalId(googleCalId, userId);
         if (!calendar) {
-          console.log(`[googleWebhook] orphaned channel for googleCalId=${googleCalId} userId=${userId}`);
+          log.info({ googleCalId, userId }, 'orphaned channel');
           return;
         }
 
@@ -177,7 +180,7 @@ export class GoogleAuthController {
           calendar.syncToken,
           googleCalId,
         );
-        console.log(`[googleWebhook] ${items.length} item(s) for ${userId} calId=${googleCalId}`);
+        log.info({ count: items.length, userId, googleCalId }, 'webhook items received');
 
         await db.updateCalendar(calendar.id, { syncToken: nextSyncToken }, userId);
 
@@ -186,12 +189,12 @@ export class GoogleAuthController {
 
           if (!existing) {
             if (calendar.syncMode !== 'two_way') {
-              console.log(`[googleWebhook] skipping ${item.id}: calendar is not two_way`);
+              log.info({ itemId: item.id }, 'skipping item: calendar is not two_way');
               continue;
             }
             if (item.status === 'cancelled') continue;
             const fields = fromGoogleEvent(item);
-            console.log(`[googleWebhook] importing new event ${item.id} into calendar ${calendar.id}`);
+            log.info({ itemId: item.id, calendarId: calendar.id }, 'importing new event');
             await db.createCalendarEventFromWebhook(fields, item.id, calendar.id, userId);
             continue;
           }
@@ -203,14 +206,14 @@ export class GoogleAuthController {
         if (!auth) return;
 
         const { items, nextSyncToken } = await fetchIncrementalEvents(userId, auth.sync_token);
-        console.log(`[googleWebhook] ${items.length} item(s) from incremental fetch for ${userId}`);
+        log.info({ count: items.length, userId }, 'incremental fetch items received');
 
         await db.updateSyncToken(userId, nextSyncToken);
 
         for (const item of items) {
           const existing = await db.getEventByGoogleId(item.id, userId);
           if (!existing) {
-            console.log(`[googleWebhook] skipping item ${item.id} (status=${item.status}): not in our DB`);
+            log.info({ itemId: item.id, status: item.status }, 'skipping item: not in our DB');
             continue;
           }
           await processExistingItem(item, userId, existing);

--- a/src/modules/google-auth/service.ts
+++ b/src/modules/google-auth/service.ts
@@ -1,6 +1,9 @@
 import crypto from 'crypto';
 import { env } from '../../config/env.js';
+import { createModuleLogger } from '../../shared/utils/logger.js';
 import type { OAuthState, GoogleCalendarItem, WebhookEventFields } from './types.js';
+
+const log = createModuleLogger('google-auth');
 
 // JS utils not yet migrated — typed loosely
 // eslint-disable-next-line @typescript-eslint/no-var-requires
@@ -105,7 +108,7 @@ export async function processExistingItem(
   existing: any,
 ): Promise<void> {
   if (item.status === 'cancelled') {
-    console.log(`[googleWebhook] deleting event ${existing.id} (google_event_id=${item.id})`);
+    log.info({ eventId: existing.id, googleEventId: item.id }, 'deleting event');
     await db.deleteCalendarEvent(existing.id, userId);
     return;
   }
@@ -114,15 +117,16 @@ export async function processExistingItem(
   const ourUpdated = new Date(existing.updated_at);
 
   if (googleUpdated <= new Date(ourUpdated.getTime() + SYNC_BUFFER_MS)) {
-    console.log(
-      `[googleWebhook] skipping update for ${existing.id}: googleUpdated=${googleUpdated.toISOString()} ourUpdated=${ourUpdated.toISOString()} (within buffer)`,
+    log.info(
+      { eventId: existing.id, googleUpdated: googleUpdated.toISOString(), ourUpdated: ourUpdated.toISOString() },
+      'skipping update (within buffer)',
     );
     return;
   }
 
   const fields = fromGoogleEvent(item);
   if (Object.keys(fields).length > 0) {
-    console.log(`[googleWebhook] updating event ${existing.id} from Google`);
+    log.info({ eventId: existing.id }, 'updating event from Google');
     await db.updateCalendarEventFromWebhook(existing.id, fields, userId);
   }
 }

--- a/src/modules/medical-journal/controller.ts
+++ b/src/modules/medical-journal/controller.ts
@@ -1,5 +1,8 @@
 import type { Request, Response, NextFunction } from 'express';
 import { MedJournalRepository } from './repository.js';
+import { createModuleLogger } from '../../shared/utils/logger.js';
+
+const log = createModuleLogger('medical-journal');
 
 /** Extract a single string param (Express 5 params can be string | string[]). */
 function param(val: string | string[]): string {
@@ -20,7 +23,7 @@ export class MedJournalController {
       const savedEntry = await repo.saveOrUpdate(entry, userSub);
       res.status(200).json({ success: true, entry: savedEntry });
     } catch (error) {
-      console.error(error);
+      log.error({ err: error }, 'failed to save entry');
       res.status(500).json({ error: 'Failed to save entry' });
     }
   }
@@ -33,7 +36,7 @@ export class MedJournalController {
       await repo.delete(id, userSub);
       res.status(200).json({ success: true });
     } catch (error) {
-      console.error(error);
+      log.error({ err: error }, 'failed to delete entry');
       res.status(500).json({ error: 'Failed to delete entry' });
     }
   }
@@ -50,7 +53,7 @@ export class MedJournalController {
       }
       res.status(200).json({ success: true, entry });
     } catch (error) {
-      console.error(error);
+      log.error({ err: error }, 'failed to fetch entry');
       res.status(500).json({ error: 'Failed to fetch entry' });
     }
   }
@@ -69,7 +72,7 @@ export class MedJournalController {
       );
       res.status(200).json({ success: true, entries });
     } catch (error) {
-      console.error(error);
+      log.error({ err: error }, 'failed to fetch entries');
       res.status(500).json({ error: 'Failed to fetch entries' });
     }
   }

--- a/src/modules/posts/controller.ts
+++ b/src/modules/posts/controller.ts
@@ -4,6 +4,9 @@
 
 import type { Request, Response, NextFunction } from 'express';
 import multer from 'multer';
+import { createModuleLogger } from '../../shared/utils/logger.js';
+
+const log = createModuleLogger('posts');
 import path from 'path';
 import { fromBuffer as fileTypeFromBuffer } from 'file-type';
 import { Upload } from '@aws-sdk/lib-storage';
@@ -130,7 +133,7 @@ export class PostsController {
         const row = await repo.insertTextPost(sub, content);
         return res.status(201).json({ ...row, media: [] });
       } catch (err: any) {
-        console.error('[posts] POST / text error:', err.message);
+        log.error({ err }, 'POST / text failed');
         return res.status(500).json({ error: 'Failed to create post' });
       }
     }
@@ -169,10 +172,7 @@ export class PostsController {
               vidProcessed = await processVideo(fileBuffer);
             } catch (vidErr: any) {
               await client.query('ROLLBACK');
-              console.error(
-                '[posts] video processing error:',
-                vidErr.message,
-              );
+              log.error({ err: vidErr }, 'video processing failed');
               return res
                 .status(400)
                 .json({ error: 'Failed to process video' });
@@ -239,7 +239,7 @@ export class PostsController {
         return res.status(201).json({ ...post, media: mediaRows });
       } catch (err: any) {
         await client.query('ROLLBACK');
-        console.error('[posts] POST / photo error:', err.message);
+        log.error({ err }, 'POST / photo failed');
         return res.status(500).json({ error: 'Failed to create post' });
       } finally {
         client.release();
@@ -309,7 +309,7 @@ export class PostsController {
 
       res.json({ posts: formattedPosts, nextCursor });
     } catch (err: any) {
-      console.error('[posts] GET /user/:username error:', err.message);
+      log.error({ err }, 'GET /user/:username failed');
       res.status(500).json({ error: 'Failed to fetch posts' });
     }
   }
@@ -327,7 +327,7 @@ export class PostsController {
       );
       res.json({ posts: formattedPosts });
     } catch (err: any) {
-      console.error('[posts] GET /discover error:', err.message);
+      log.error({ err }, 'GET /discover failed');
       res.status(500).json({ error: 'Failed to fetch discover posts' });
     }
   }
@@ -350,7 +350,7 @@ export class PostsController {
         media: mediaRows,
       });
     } catch (err: any) {
-      console.error('[posts] GET /:id error:', err.message);
+      log.error({ err }, 'GET /:id failed');
       res.status(500).json({ error: 'Failed to fetch post' });
     }
   }
@@ -388,7 +388,7 @@ export class PostsController {
 
       res.status(204).end();
     } catch (err: any) {
-      console.error('[posts] DELETE /:id error:', err.message);
+      log.error({ err }, 'DELETE /:id failed');
       res.status(500).json({ error: 'Failed to delete post' });
     }
   }

--- a/src/modules/profiles/controller.ts
+++ b/src/modules/profiles/controller.ts
@@ -5,6 +5,9 @@
 import type { Request, Response, NextFunction } from 'express';
 import multer from 'multer';
 import sharp from 'sharp';
+import { createModuleLogger } from '../../shared/utils/logger.js';
+
+const log = createModuleLogger('profiles');
 import { fromBuffer as fileTypeFromBuffer } from 'file-type';
 import { Upload } from '@aws-sdk/lib-storage';
 import { s3, S3_BUCKET, CDN_BASE } from '../../config/s3.js';
@@ -135,7 +138,7 @@ export class ProfilesController {
         .webp({ quality: 85 })
         .toBuffer();
     } catch (err: any) {
-      console.error('[profiles] avatar sharp error:', err.message);
+      log.error({ err }, 'avatar sharp error');
       return res.status(400).json({ error: 'Failed to process image' });
     }
 
@@ -146,7 +149,7 @@ export class ProfilesController {
     try {
       avatarUrl = await s3Upload(avatarBuffer, key, 'image/webp');
     } catch (err: any) {
-      console.error('[profiles] avatar S3 upload error:', err.message);
+      log.error({ err }, 'avatar S3 upload failed');
       return res.status(500).json({ error: 'Failed to upload avatar' });
     }
 
@@ -155,7 +158,7 @@ export class ProfilesController {
       if (!row) return res.status(404).json({ error: 'Profile not set up yet' });
       res.json(row);
     } catch (err: any) {
-      console.error('[profiles] avatar DB update error:', err.message);
+      log.error({ err }, 'avatar DB update failed');
       res.status(500).json({ error: 'Failed to save avatar URL' });
     }
   }
@@ -169,7 +172,7 @@ export class ProfilesController {
         return res.status(404).json({ error: 'Profile not set up yet' });
       res.json(profile);
     } catch (err: any) {
-      console.error('[profiles] GET /me error:', err.message);
+      log.error({ err }, 'GET /me failed');
       res.status(500).json({ error: 'Failed to fetch profile' });
     }
   }
@@ -209,7 +212,7 @@ export class ProfilesController {
 
       res.json(row);
     } catch (err: any) {
-      console.error('[profiles] PUT /me error:', err.message);
+      log.error({ err }, 'PUT /me failed');
       res.status(500).json({ error: 'Failed to update profile' });
     }
   }
@@ -244,7 +247,7 @@ export class ProfilesController {
         }
         return res.status(409).json({ error: 'Username already taken' });
       }
-      console.error('[profiles] POST /setup error:', err.message);
+      log.error({ err }, 'POST /setup failed');
       res.status(500).json({ error: 'Failed to create profile' });
     }
   }
@@ -262,7 +265,7 @@ export class ProfilesController {
         hasMore: rows.length === limit,
       });
     } catch (err: any) {
-      console.error('[profiles] GET /discover error:', err.message);
+      log.error({ err }, 'GET /discover failed');
       res.status(500).json({ error: 'Failed to fetch discover list' });
     }
   }
@@ -290,7 +293,7 @@ export class ProfilesController {
           isOwn || !viewerSub ? null : (profile.follow_status ?? 'none'),
       });
     } catch (err: any) {
-      console.error('[profiles] GET /:username error:', err.message);
+      log.error({ err }, 'GET /:username failed');
       res.status(500).json({ error: 'Failed to fetch profile' });
     }
   }

--- a/src/modules/timeline/controller.ts
+++ b/src/modules/timeline/controller.ts
@@ -4,6 +4,9 @@
 
 import type { Request, Response, NextFunction } from 'express';
 import * as repo from './repository.js';
+import { createModuleLogger } from '../../shared/utils/logger.js';
+
+const log = createModuleLogger('timeline');
 
 const LIMIT = 20;
 
@@ -47,7 +50,7 @@ export class TimelineController {
 
       return res.json({ posts, nextCursor });
     } catch (err: any) {
-      console.error('[timeline] GET / error:', err.message);
+      log.error({ err }, 'GET / failed');
       return res.status(500).json({ error: 'Failed to fetch timeline' });
     }
   }

--- a/src/modules/vitals/controller.ts
+++ b/src/modules/vitals/controller.ts
@@ -1,5 +1,8 @@
 import type { Request, Response, NextFunction } from 'express';
 import { VitalsRepository, VALID_METRICS, VALID_RATINGS } from './repository.js';
+import { createModuleLogger } from '../../shared/utils/logger.js';
+
+const log = createModuleLogger('vitals');
 
 const repo = new VitalsRepository();
 
@@ -49,7 +52,7 @@ export class VitalsController {
       });
       res.status(201).json(row);
     } catch (err: any) {
-      console.error('POST /vitals failed:', err.message);
+      log.error({ err }, 'POST /vitals failed');
       res.status(500).json({ error: 'Failed to store vital' });
     }
   }
@@ -60,7 +63,7 @@ export class VitalsController {
       const summary = await repo.getSummary(v, mode);
       res.json({ summary });
     } catch (err: any) {
-      console.error('GET /vitals/summary failed:', err.message);
+      log.error({ err }, 'GET /vitals/summary failed');
       res.status(500).json({ error: 'Failed to fetch vitals summary' });
     }
   }
@@ -71,7 +74,7 @@ export class VitalsController {
       const byPage = await repo.getByPage(v, mode);
       res.json({ byPage });
     } catch (err: any) {
-      console.error('GET /vitals/by-page failed:', err.message);
+      log.error({ err }, 'GET /vitals/by-page failed');
       res.status(500).json({ error: 'Failed to fetch vitals by page' });
     }
   }
@@ -82,7 +85,7 @@ export class VitalsController {
       const byVersion = await repo.getByVersion(v, mode);
       res.json({ byVersion });
     } catch (err: any) {
-      console.error('GET /vitals/by-version failed:', err.message);
+      log.error({ err }, 'GET /vitals/by-version failed');
       res.status(500).json({ error: 'Failed to fetch vitals by version' });
     }
   }
@@ -92,7 +95,7 @@ export class VitalsController {
       const versions = await repo.getVersions();
       res.json({ versions });
     } catch (err: any) {
-      console.error('GET /vitals/versions failed:', err.message);
+      log.error({ err }, 'GET /vitals/versions failed');
       res.status(500).json({ error: 'Failed to fetch versions' });
     }
   }

--- a/src/modules/youtube/controller.ts
+++ b/src/modules/youtube/controller.ts
@@ -1,5 +1,8 @@
 import type { Request, Response, NextFunction } from 'express';
 import { YouTubeService } from './service.js';
+import { createModuleLogger } from '../../shared/utils/logger.js';
+
+const log = createModuleLogger('youtube');
 
 const service = new YouTubeService();
 
@@ -15,7 +18,7 @@ export class YouTubeController {
       const videos = await service.getRecentVideos(channelId);
       res.status(200).send(videos);
     } catch (error) {
-      console.error('YouTube API Error:', error);
+      log.error({ err: error }, 'YouTube API error');
       next(error);
     }
   }

--- a/src/shared/types/express.d.ts
+++ b/src/shared/types/express.d.ts
@@ -1,0 +1,25 @@
+import type { ZodType } from 'zod';
+
+declare global {
+  namespace Express {
+    interface Request {
+      /** Populated by express-oauth2-jwt-bearer's auth() middleware. */
+      auth?: {
+        payload: {
+          sub: string;
+          email?: string;
+          permissions?: string[];
+          [key: string]: unknown;
+        };
+        header: Record<string, unknown>;
+        token: string;
+      };
+      /** Set by validateBody middleware — the Zod-parsed body. */
+      validatedBody?: unknown;
+      /** Set by validateQuery middleware — the Zod-parsed query. */
+      validatedQuery?: unknown;
+    }
+  }
+}
+
+export {};

--- a/src/shared/utils/index.ts
+++ b/src/shared/utils/index.ts
@@ -6,3 +6,4 @@ export {
   ALLOWED_VIDEO_MIME,
 } from './mediaProcessor.js';
 export type { ProcessedImage, ProcessedVideo } from './mediaProcessor.js';
+export { logger, createModuleLogger } from './logger.js';

--- a/src/shared/utils/logger.ts
+++ b/src/shared/utils/logger.ts
@@ -1,0 +1,20 @@
+import pino from 'pino';
+import { env } from '../../config/env.js';
+
+const isProduction = env.NODE_ENV === 'production';
+
+export const logger = pino({
+  level: isProduction ? 'info' : 'debug',
+  ...(isProduction
+    ? {}
+    : { transport: { target: 'pino-pretty', options: { colorize: true } } }),
+  base: {
+    service: 'portfolio-api',
+    env: env.NODE_ENV,
+  },
+});
+
+/** Create a child logger scoped to a module. */
+export function createModuleLogger(module: string) {
+  return logger.child({ module });
+}


### PR DESCRIPTION
## Summary
- Migrate all middleware to typed TypeScript — upsert user, validation, rate limiting, response caching
- Add pino structured logging with request/response middleware, replace all console calls across 17 files

## Test plan
- [x] Verify `tsc --noEmit` passes
- [x] Confirm existing JS routes still work via server.js
- [x] Check pino pretty-prints in dev, JSON in production
- [x] Validate rate limiter and cache middleware behavior unchanged