### PR TITLE
phase 4: performance and reliability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2026-07-17 - version 2.3.1
+
+- `src/shared/utils/cache.ts`: tag-based invalidation, updated TTL tiers (SHORT/MEDIUM/LONG/DAY), LRU cleanup on eviction
+- `src/middleware/cache.ts`: typed cache options with `varyByUser`, ETag support with 304 responses, `Cache-Control` headers, tag-based response cache invalidation
+
 ## 2026-07-17 - version 2.3.0
 
 - `src/config/database.ts`: explicit pool settings (max 20, idle/connection timeouts), pool event logging, slow query warnings (>100ms)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2026-07-17 - version 2.3.2
+
+- `src/shared/utils/shutdown.ts`: graceful shutdown with SIGTERM/SIGINT handling, 30s drain timeout, pg and Knex pool cleanup
+- `src/modules/health/routes.ts`: readiness probe (`GET /ready`) returns 503 once shutdown begins
+
 ## 2026-07-17 - version 2.3.1
 
 - `src/shared/utils/cache.ts`: tag-based invalidation, updated TTL tiers (SHORT/MEDIUM/LONG/DAY), LRU cleanup on eviction

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 2026-07-17 - version 2.3.0
+
+- `src/config/database.ts`: explicit pool settings (max 20, idle/connection timeouts), pool event logging, slow query warnings (>100ms)
+- `src/config/drizzle/index.ts`: centralized Drizzle instance shared by posts, profiles, and follows repositories
+- `src/modules/calendar/repository.ts`: Knex pool configuration (min 2, max 10) with exported instance for shutdown
+- `src/modules/health/routes.ts`: health check endpoint returning status, uptime, DB connectivity, and version
+
 ## 2026-07-17 - version 2.2.1
 
 - `src/shared/utils/logger.ts`: pino-based structured logger with pretty-print in dev, JSON in production

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portfolio_api",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "description": "Portfolio API with Node.js and Python",
   "main": "server.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portfolio_api",
-  "version": "2.2.1",
+  "version": "2.3.0",
   "description": "Portfolio API with Node.js and Python",
   "main": "server.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portfolio_api",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "Portfolio API with Node.js and Python",
   "main": "server.js",
   "scripts": {

--- a/src/config/database.ts
+++ b/src/config/database.ts
@@ -1,5 +1,8 @@
 import { Pool, type QueryResult, type QueryResultRow } from 'pg';
 import { env } from './env.js';
+import { createModuleLogger } from '../shared/utils/logger.js';
+
+const log = createModuleLogger('database');
 
 const connectionString =
   env.DATABASE_URL ||
@@ -8,13 +11,34 @@ const connectionString =
 export const pool = new Pool({
   connectionString,
   ssl: env.NODE_ENV === 'production' ? { rejectUnauthorized: false } : false,
+  max: 20,
+  idleTimeoutMillis: 30000,
+  connectionTimeoutMillis: 5000,
+});
+
+pool.on('error', (err) => {
+  log.error({ err }, 'unexpected idle client error');
+});
+
+pool.on('connect', () => {
+  log.debug('new client connected');
+});
+
+pool.on('remove', () => {
+  log.debug('client removed from pool');
 });
 
 export async function query<T extends QueryResultRow = QueryResultRow>(
   text: string,
   params?: unknown[],
 ): Promise<QueryResult<T>> {
-  return pool.query<T>(text, params);
+  const start = Date.now();
+  const result = await pool.query<T>(text, params);
+  const duration = Date.now() - start;
+  if (duration > 100) {
+    log.warn({ duration, text }, 'slow query detected');
+  }
+  return result;
 }
 
 export async function checkDatabaseHealth(): Promise<boolean> {

--- a/src/config/drizzle/index.ts
+++ b/src/config/drizzle/index.ts
@@ -1,0 +1,4 @@
+import { drizzle } from 'drizzle-orm/node-postgres';
+import { pool } from '../database.js';
+
+export const db = drizzle(pool);

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -3,3 +3,4 @@ export type { Env } from './env.js';
 export { pool, query, checkDatabaseHealth } from './database.js';
 export { checkJwt, checkPermissions, optionalCheckJwt } from './auth.js';
 export { s3, S3_BUCKET, CDN_BASE } from './s3.js';
+export { db as drizzleDb } from './drizzle/index.js';

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,11 @@
  * - Controllers:   orchestrate service calls, handle HTTP concerns (status codes, headers)
  * - Services:      pure business logic, no HTTP or DB awareness
  * - Repositories:  data access, one per persistence boundary
+ *
+ * Lifecycle:
+ * - Startup:       validate env → connect pools → bind HTTP
+ * - Shutdown:      SIGTERM/SIGINT → stop accepting → drain in-flight → close pools → exit
+ *   See src/shared/utils/shutdown.ts for setupGracefulShutdown()
  */
 
 export {};

--- a/src/middleware/cache.ts
+++ b/src/middleware/cache.ts
@@ -5,29 +5,92 @@ interface CacheEntry {
   statusCode: number;
   headers: Record<string, string>;
   timestamp: number;
+  etag: string;
+  tags: string[];
+}
+
+interface CacheOptions {
+  ttl: number;
+  tags?: string[];
+  varyByUser?: boolean;
 }
 
 const responseCache = new Map<string, CacheEntry>();
+const tagIndex = new Map<string, Set<string>>();
+
+/** Simple non-crypto string hash (djb2). */
+function hashString(str: string): string {
+  let hash = 5381;
+  for (let i = 0; i < str.length; i++) {
+    hash = ((hash << 5) + hash + str.charCodeAt(i)) | 0;
+  }
+  return (hash >>> 0).toString(36);
+}
+
+function evictEntry(key: string): void {
+  const entry = responseCache.get(key);
+  if (entry) {
+    for (const tag of entry.tags) {
+      const keys = tagIndex.get(tag);
+      if (keys) {
+        keys.delete(key);
+        if (keys.size === 0) tagIndex.delete(tag);
+      }
+    }
+    responseCache.delete(key);
+  }
+}
+
+function evictOldest(): void {
+  const oldestKey = [...responseCache.entries()].sort(
+    ([, a], [, b]) => a.timestamp - b.timestamp,
+  )[0][0];
+  evictEntry(oldestKey);
+}
 
 /**
- * Returns Express middleware that caches JSON responses for the given duration.
- * Cache key is derived from method + path + query string.
+ * Returns Express middleware that caches JSON responses.
  *
- * @param duration - cache TTL in seconds
+ * Accepts either a plain number (TTL in seconds, backwards-compatible) or
+ * a CacheOptions object with ttl, optional tags, and varyByUser flag.
  */
-export function cacheMiddleware(duration: number) {
+export function cacheMiddleware(options: number | CacheOptions) {
+  const opts: CacheOptions =
+    typeof options === 'number' ? { ttl: options } : options;
+
   return (req: Request, res: Response, next: NextFunction): void => {
     if (req.method !== 'GET') {
       next();
       return;
     }
 
-    const key = `${req.method}:${req.originalUrl}`;
+    const authReq = req as Request & {
+      auth?: { payload?: { sub?: string } };
+    };
+    const userSuffix =
+      opts.varyByUser && authReq.auth
+        ? `:${authReq.auth.payload?.sub ?? 'anon'}`
+        : '';
+    const key = `${req.method}:${req.originalUrl}${userSuffix}`;
     const cached = responseCache.get(key);
     const now = Date.now();
 
-    if (cached && now - cached.timestamp < duration * 1000) {
+    // Cache-Control header
+    const visibility = opts.varyByUser ? 'private' : 'public';
+    res.set('Cache-Control', `${visibility}, max-age=${opts.ttl}`);
+
+    if (cached && now - cached.timestamp < opts.ttl * 1000) {
+      // ETag: check If-None-Match
+      const ifNoneMatch = req.get('If-None-Match');
+      if (ifNoneMatch && ifNoneMatch === cached.etag) {
+        res.set('X-Cache', 'HIT');
+        res.set('ETag', cached.etag);
+        res.status(304).end();
+        return;
+      }
+
       res.set('X-Cache', 'HIT');
+      res.set('ETag', cached.etag);
       for (const [h, v] of Object.entries(cached.headers)) {
         res.set(h, v);
       }
@@ -41,18 +104,31 @@ export function cacheMiddleware(duration: number) {
       if (res.statusCode >= 200 && res.statusCode < 300) {
         // Evict oldest if cache gets too large
         if (responseCache.size >= 500) {
-          const oldestKey = [...responseCache.entries()].sort(
-            ([, a], [, b]) => a.timestamp - b.timestamp,
-          )[0][0];
-          responseCache.delete(oldestKey);
+          evictOldest();
         }
+
+        const etag = `"${hashString(JSON.stringify(body))}"`;
+        const tags = opts.tags ?? [];
 
         responseCache.set(key, {
           body,
           statusCode: res.statusCode,
           headers: { 'Content-Type': 'application/json' },
           timestamp: now,
+          etag,
+          tags,
         });
+
+        for (const tag of tags) {
+          let keys = tagIndex.get(tag);
+          if (!keys) {
+            keys = new Set();
+            tagIndex.set(tag, keys);
+          }
+          keys.add(key);
+        }
+
+        res.set('ETag', etag);
       }
       res.set('X-Cache', 'MISS');
       return originalJson(body);
@@ -66,12 +142,23 @@ export function cacheMiddleware(duration: number) {
 export function invalidateCacheByPrefix(prefix: string): void {
   for (const key of responseCache.keys()) {
     if (key.startsWith(prefix)) {
-      responseCache.delete(key);
+      evictEntry(key);
     }
   }
+}
+
+/** Invalidate all response cache entries matching a tag. */
+export function invalidateResponseCacheByTag(tag: string): void {
+  const keys = tagIndex.get(tag);
+  if (!keys) return;
+  for (const key of keys) {
+    responseCache.delete(key);
+  }
+  tagIndex.delete(tag);
 }
 
 /** Clear the entire response cache. */
 export function clearResponseCache(): void {
   responseCache.clear();
+  tagIndex.clear();
 }

--- a/src/middleware/index.ts
+++ b/src/middleware/index.ts
@@ -9,6 +9,7 @@ export {
 export {
   cacheMiddleware,
   invalidateCacheByPrefix,
+  invalidateResponseCacheByTag,
   clearResponseCache,
 } from './cache.js';
 export { requestLogger } from './requestLogger.js';

--- a/src/modules/calendar/repository.ts
+++ b/src/modules/calendar/repository.ts
@@ -39,12 +39,13 @@ const connectionString =
   env.DATABASE_URL ||
   `postgresql://${env.DB_USER}:${env.DB_PASSWORD}@${env.DB_HOST}:${env.DB_PORT}/${env.DB_NAME}`;
 
-const db: Knex = knex({
+export const db: Knex = knex({
   client: 'pg',
   connection: {
     connectionString,
     ssl: env.NODE_ENV === 'production' ? { rejectUnauthorized: false } : false,
   },
+  pool: { min: 2, max: 10 },
 });
 
 // ---------------------------------------------------------------------------

--- a/src/modules/follows/repository.ts
+++ b/src/modules/follows/repository.ts
@@ -3,15 +3,13 @@
 // ---------------------------------------------------------------------------
 
 import { eq, and, desc } from 'drizzle-orm';
-import { drizzle } from 'drizzle-orm/node-postgres';
+import { db } from '../../config/drizzle/index.js';
 import { pool } from '../../config/database.js';
 import {
   follows,
   userProfiles,
 } from '../../config/drizzle/schema.js';
 import type { FollowRow, FollowRequestItem, FollowListItem } from './types.js';
-
-export const db = drizzle(pool);
 
 // ── Lookup target by username ──────────────────────────────────────────────
 

--- a/src/modules/health/routes.ts
+++ b/src/modules/health/routes.ts
@@ -1,0 +1,16 @@
+import { Router } from 'express';
+import { checkDatabaseHealth } from '../../config/database.js';
+
+const router = Router();
+
+router.get('/health', async (_req, res) => {
+  const dbConnected = await checkDatabaseHealth();
+  res.json({
+    status: dbConnected ? 'ok' : 'degraded',
+    uptime: process.uptime(),
+    dbConnected,
+    version: '2.3.0',
+  });
+});
+
+export default router;

--- a/src/modules/health/routes.ts
+++ b/src/modules/health/routes.ts
@@ -1,5 +1,6 @@
 import { Router } from 'express';
 import { checkDatabaseHealth } from '../../config/database.js';
+import { isShutdown } from '../../shared/utils/shutdown.js';
 
 const router = Router();
 
@@ -9,8 +10,16 @@ router.get('/health', async (_req, res) => {
     status: dbConnected ? 'ok' : 'degraded',
     uptime: process.uptime(),
     dbConnected,
-    version: '2.3.0',
+    version: '2.3.2',
   });
+});
+
+router.get('/ready', (_req, res) => {
+  if (isShutdown()) {
+    res.status(503).json({ status: 'shutting_down' });
+    return;
+  }
+  res.json({ status: 'ready' });
 });
 
 export default router;

--- a/src/modules/posts/repository.ts
+++ b/src/modules/posts/repository.ts
@@ -3,7 +3,7 @@
 // ---------------------------------------------------------------------------
 
 import { eq, and, lt, sql, desc } from 'drizzle-orm';
-import { drizzle } from 'drizzle-orm/node-postgres';
+import { db } from '../../config/drizzle/index.js';
 import { pool } from '../../config/database.js';
 import {
   posts,
@@ -12,8 +12,6 @@ import {
   follows,
 } from '../../config/drizzle/schema.js';
 import type { PostRow, MediaRow } from './types.js';
-
-export const db = drizzle(pool);
 
 // ── Post CRUD ──────────────────────────────────────────────────────────────
 

--- a/src/modules/profiles/repository.ts
+++ b/src/modules/profiles/repository.ts
@@ -3,14 +3,12 @@
 // ---------------------------------------------------------------------------
 
 import { eq, and, sql } from 'drizzle-orm';
-import { drizzle } from 'drizzle-orm/node-postgres';
+import { db } from '../../config/drizzle/index.js';
 import { pool } from '../../config/database.js';
 import {
   userProfiles,
   follows,
 } from '../../config/drizzle/schema.js';
-
-export const db = drizzle(pool);
 
 // ── Own profile ────────────────────────────────────────────────────────────
 

--- a/src/shared/utils/cache.ts
+++ b/src/shared/utils/cache.ts
@@ -1,14 +1,17 @@
 interface CacheEntry<T> {
   data: T;
   timestamp: number;
+  tags: string[];
 }
 
 const cache = new Map<string, CacheEntry<unknown>>();
+const tagIndex = new Map<string, Set<string>>();
 
 export const CACHE_TTL = {
-  SHORT: 300, // 5 minutes
-  MEDIUM: 3600, // 1 hour
-  LONG: 86400, // 1 day
+  SHORT: 300, // 5 minutes — vitals, geo
+  MEDIUM: 900, // 15 minutes — youtube RSS
+  LONG: 3600, // 1 hour — nba, f1, fantasy
+  DAY: 86400, // 1 day
 } as const;
 
 const MAX_CACHE_SIZE = 1000;
@@ -17,6 +20,7 @@ export async function getCachedData<T>(
   key: string,
   fetchFn: () => Promise<T>,
   ttl: number = CACHE_TTL.MEDIUM,
+  tags: string[] = [],
 ): Promise<T> {
   const cached = cache.get(key);
   const now = Date.now();
@@ -31,17 +35,51 @@ export async function getCachedData<T>(
     const oldestKey = [...cache.entries()].sort(
       ([, a], [, b]) => a.timestamp - b.timestamp,
     )[0][0];
-    cache.delete(oldestKey);
+    evictEntry(oldestKey);
   }
 
-  cache.set(key, { data, timestamp: now });
+  cache.set(key, { data, timestamp: now, tags });
+
+  for (const tag of tags) {
+    let keys = tagIndex.get(tag);
+    if (!keys) {
+      keys = new Set();
+      tagIndex.set(tag, keys);
+    }
+    keys.add(key);
+  }
+
   return data;
 }
 
+function evictEntry(key: string): void {
+  const entry = cache.get(key);
+  if (entry) {
+    for (const tag of entry.tags) {
+      const keys = tagIndex.get(tag);
+      if (keys) {
+        keys.delete(key);
+        if (keys.size === 0) tagIndex.delete(tag);
+      }
+    }
+    cache.delete(key);
+  }
+}
+
 export function invalidateCache(key: string): void {
-  cache.delete(key);
+  evictEntry(key);
+}
+
+export function invalidateCacheByTag(tag: string): void {
+  const keys = tagIndex.get(tag);
+  if (!keys) return;
+  for (const key of keys) {
+    cache.delete(key);
+  }
+  tagIndex.delete(tag);
 }
 
 export function clearCache(): void {
   cache.clear();
+  tagIndex.clear();
 }

--- a/src/shared/utils/index.ts
+++ b/src/shared/utils/index.ts
@@ -13,3 +13,4 @@ export {
 } from './mediaProcessor.js';
 export type { ProcessedImage, ProcessedVideo } from './mediaProcessor.js';
 export { logger, createModuleLogger } from './logger.js';
+export { setupGracefulShutdown, isShutdown } from './shutdown.js';

--- a/src/shared/utils/index.ts
+++ b/src/shared/utils/index.ts
@@ -1,4 +1,10 @@
-export { getCachedData, invalidateCache, clearCache, CACHE_TTL } from './cache.js';
+export {
+  getCachedData,
+  invalidateCache,
+  invalidateCacheByTag,
+  clearCache,
+  CACHE_TTL,
+} from './cache.js';
 export {
   processImage,
   processVideo,

--- a/src/shared/utils/shutdown.ts
+++ b/src/shared/utils/shutdown.ts
@@ -1,0 +1,63 @@
+import type { Server } from 'http';
+import { pool } from '../../config/database.js';
+import { db as knexDb } from '../../modules/calendar/repository.js';
+import { logger } from './logger.js';
+
+const log = logger.child({ module: 'shutdown' });
+
+let isShuttingDown = false;
+
+/** Returns true once a shutdown signal has been received. */
+export function isShutdown(): boolean {
+  return isShuttingDown;
+}
+
+/**
+ * Gracefully shut down the process.
+ *
+ * 1. Stop accepting new connections
+ * 2. Wait for in-flight requests (30 s timeout)
+ * 3. Close database pools (pg, Knex)
+ * 4. Flush the logger
+ * 5. Exit
+ */
+export function setupGracefulShutdown(server: Server): void {
+  const shutdown = async (signal: string) => {
+    if (isShuttingDown) return;
+    isShuttingDown = true;
+
+    log.info({ signal }, 'shutdown signal received — draining connections');
+
+    // 1. Stop accepting new connections
+    server.close(() => {
+      log.info('HTTP server closed');
+    });
+
+    // 2. Force-close after 30 s
+    const forceTimer = setTimeout(() => {
+      log.error('graceful shutdown timed out — forcing exit');
+      process.exit(1);
+    }, 30_000);
+    forceTimer.unref();
+
+    try {
+      // 3. Close database pools
+      await Promise.allSettled([
+        pool.end().then(() => log.info('pg pool closed')),
+        knexDb.destroy().then(() => log.info('knex pool closed')),
+      ]);
+    } catch (err) {
+      log.error({ err }, 'error closing database pools');
+    }
+
+    // 4. Flush logger
+    logger.flush();
+
+    log.info('shutdown complete');
+    clearTimeout(forceTimer);
+    process.exit(0);
+  };
+
+  process.on('SIGTERM', () => shutdown('SIGTERM'));
+  process.on('SIGINT', () => shutdown('SIGINT'));
+}


### PR DESCRIPTION
## Summary
- Optimize pg pool with explicit settings, add pool event logging and slow query warnings (>100ms)
- Centralize Drizzle instance, configure Knex pool separately, add health check endpoint
- Redesign caching with typed options, ETag/304 support, Cache-Control headers, and tag-based invalidation
- Add graceful shutdown handling (SIGTERM/SIGINT) with 30s drain timeout and readiness probe

## Test plan
- [x] Verify `tsc --noEmit` passes
- [x] Confirm existing JS routes still work via server.js
- [x] Check health endpoint returns DB connectivity status
- [x] Validate cache ETag returns 304 on matching If-None-Match
- [x] Test readiness probe returns 503 during shutdown