### PR TITLE
phase 5: API design and contracts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2026-07-17 - version 2.4.1
+
+- Per-module Zod schemas for all POST/PUT endpoints across 11 modules (calendar, posts, profiles, follows, feedback, chat, vitals, medical-journal, forum, nba, gallery)
+- Wire `validateBody`/`validateParams` middleware into all route files
+
 ## 2026-07-17 - version 2.4.0
 
 - `src/shared/utils/response.ts`: typed response helpers — `success()`, `paginated()`, `created()` for future v2 envelope pattern

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2026-07-17 - version 2.4.2
+
+- `src/shared/openapi/`: OpenAPI 3.1 spec generation with `@asteasolutions/zod-to-openapi`, all endpoints registered with schemas
+- `src/modules/docs/routes.ts`: Swagger UI at `/api/docs` and raw spec at `/api/docs/openapi.json`
+
 ## 2026-07-17 - version 2.4.1
 
 - Per-module Zod schemas for all POST/PUT endpoints across 11 modules (calendar, posts, profiles, follows, feedback, chat, vitals, medical-journal, forum, nba, gallery)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2026-07-17 - version 2.4.0
+
+- `src/shared/utils/response.ts`: typed response helpers — `success()`, `paginated()`, `created()` for future v2 envelope pattern
+- Standardize error handling across all 17 controllers to use AppError subclasses and `next(err)` instead of manual `res.status().json()` responses
+
 ## 2026-07-17 - version 2.3.2
 
 - `src/shared/utils/shutdown.ts`: graceful shutdown with SIGTERM/SIGINT handling, 30s drain timeout, pg and Knex pool cleanup

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,14 @@
 {
   "name": "portfolio_api",
-  "version": "2.2.0",
+  "version": "2.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "portfolio_api",
-      "version": "2.2.0",
+      "version": "2.4.1",
       "dependencies": {
+        "@asteasolutions/zod-to-openapi": "^9.0.0",
         "@aws-sdk/client-s3": "^3.995.0",
         "@aws-sdk/lib-storage": "^3.995.0",
         "apicache": "^1.6.3",
@@ -33,6 +34,7 @@
         "pino": "^10.3.1",
         "pino-http": "^11.0.0",
         "sharp": "^0.34.1",
+        "swagger-ui-express": "^5.0.1",
         "uuid": "^9.0.0",
         "xml2js": "^0.6.2",
         "zod": "^3.25.76"
@@ -46,6 +48,7 @@
         "@types/node": "^26.1.1",
         "@types/pg": "^8.20.0",
         "@types/pino-http": "^5.8.4",
+        "@types/swagger-ui-express": "^4.1.8",
         "@types/uuid": "^10.0.0",
         "@types/xml2js": "^0.4.14",
         "drizzle-kit": "^0.31.10",
@@ -57,6 +60,18 @@
       },
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@asteasolutions/zod-to-openapi": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@asteasolutions/zod-to-openapi/-/zod-to-openapi-9.0.0.tgz",
+      "integrity": "sha512-/bI1+jCvTlkWzlBFH2wd9uADreYm9yQ34r7+iNV+ISLHMjtT1BFC/mxgv9UxTxRBNBZvpZ31Wr5qlzYyHA/YsA==",
+      "license": "MIT",
+      "dependencies": {
+        "openapi3-ts": "^4.6.0"
+      },
+      "peerDependencies": {
+        "zod": "^4.0.0"
       }
     },
     "node_modules/@aws-crypto/crc32": {
@@ -3449,6 +3464,13 @@
         "url": "https://opencollective.com/pkgr"
       }
     },
+    "node_modules/@scarf/scarf": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@scarf/scarf/-/scarf-1.4.0.tgz",
+      "integrity": "sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0"
+    },
     "node_modules/@sinclair/typebox": {
       "version": "0.34.48",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.48.tgz",
@@ -4461,7 +4483,7 @@
       "version": "8.20.0",
       "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.20.0.tgz",
       "integrity": "sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*",
@@ -4562,6 +4584,17 @@
       "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/swagger-ui-express": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@types/swagger-ui-express/-/swagger-ui-express-4.1.8.tgz",
+      "integrity": "sha512-AhZV8/EIreHFmBV5wAs0gzJUNq9JbbSXgJLQubCC0jtIo6prnI9MIRRxnU4MZX9RB9yXxF1V4R7jtLl/Wcj31g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/express": "*",
+        "@types/serve-static": "*"
+      }
     },
     "node_modules/@types/uuid": {
       "version": "10.0.0",
@@ -9312,6 +9345,15 @@
       "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
       "license": "MIT"
     },
+    "node_modules/openapi3-ts": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/openapi3-ts/-/openapi3-ts-4.6.0.tgz",
+      "integrity": "sha512-a4sfn6L2sIShhtzJqmjGrARvxAW/3F2BJDdyRVvNF9VhAsZSh5hSyI3a9TNvmzBxXmq66nY5LNT5bQcBxYAZZg==",
+      "license": "MIT",
+      "dependencies": {
+        "yaml": "^2.9.0"
+      }
+    },
     "node_modules/p-limit": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
@@ -10762,6 +10804,30 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/swagger-ui-dist": {
+      "version": "5.32.9",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.32.9.tgz",
+      "integrity": "sha512-8i2tzJQi+7bgxESMD2hg/UBumbTsf6vLbtu4cW5ETPz/B070UuS0rTP1hu6WSH81HcsHqYalJE+rP21Vg96rUQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@scarf/scarf": "=1.4.0"
+      }
+    },
+    "node_modules/swagger-ui-express": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/swagger-ui-express/-/swagger-ui-express-5.0.1.tgz",
+      "integrity": "sha512-SrNU3RiBGTLLmFU8GIJdOdanJTl4TOmT27tt3bWWHppqYmAZ6IDuEuBvMU6nZq0zLEe6b/1rACXCgLZqO6ZfrA==",
+      "license": "MIT",
+      "dependencies": {
+        "swagger-ui-dist": ">=5.0.0"
+      },
+      "engines": {
+        "node": ">= v0.10.32"
+      },
+      "peerDependencies": {
+        "express": ">=4.0.0 || >=5.0.0-beta"
+      }
+    },
     "node_modules/synckit": {
       "version": "0.11.12",
       "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.11.12.tgz",
@@ -11909,6 +11975,21 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "license": "ISC"
+    },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
     },
     "node_modules/yargs": {
       "version": "17.7.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portfolio_api",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "description": "Portfolio API with Node.js and Python",
   "main": "server.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portfolio_api",
-  "version": "2.3.2",
+  "version": "2.4.0",
   "description": "Portfolio API with Node.js and Python",
   "main": "server.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portfolio_api",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "description": "Portfolio API with Node.js and Python",
   "main": "server.js",
   "scripts": {
@@ -11,6 +11,7 @@
     "test": "jest"
   },
   "dependencies": {
+    "@asteasolutions/zod-to-openapi": "^9.0.0",
     "@aws-sdk/client-s3": "^3.995.0",
     "@aws-sdk/lib-storage": "^3.995.0",
     "apicache": "^1.6.3",
@@ -36,6 +37,7 @@
     "pino": "^10.3.1",
     "pino-http": "^11.0.0",
     "sharp": "^0.34.1",
+    "swagger-ui-express": "^5.0.1",
     "uuid": "^9.0.0",
     "xml2js": "^0.6.2",
     "zod": "^3.25.76"
@@ -49,6 +51,7 @@
     "@types/node": "^26.1.1",
     "@types/pg": "^8.20.0",
     "@types/pino-http": "^5.8.4",
+    "@types/swagger-ui-express": "^4.1.8",
     "@types/uuid": "^10.0.0",
     "@types/xml2js": "^0.4.14",
     "drizzle-kit": "^0.31.10",

--- a/src/modules/calendar/routes.ts
+++ b/src/modules/calendar/routes.ts
@@ -5,6 +5,19 @@
 import { Router } from 'express';
 import { CalendarController } from './controller.js';
 import { checkJwt } from '../../config/auth.js';
+import { validateBody } from '../../middleware/validate.js';
+import {
+  createEventSchema,
+  updateEventSchema,
+  createCalendarSchema,
+  updateCalendarSchema,
+  createCountdownSchema,
+  updateCountdownSchema,
+  addMemberSchema,
+  updateMemberSchema,
+  addEventCardSchema,
+  updateEventCardSchema,
+} from './schemas.js';
 
 const router = Router();
 const ctrl = new CalendarController();
@@ -21,8 +34,8 @@ router.use(checkJwt);
 
 router.get('/events', (req, res, next) => ctrl.getEvents(req, res, next));
 router.get('/events/:id', (req, res, next) => ctrl.getEventById(req, res, next));
-router.post('/events', (req, res, next) => ctrl.createEvent(req, res, next));
-router.put('/events/:id', (req, res, next) => ctrl.updateEvent(req, res, next));
+router.post('/events', validateBody(createEventSchema), (req, res, next) => ctrl.createEvent(req, res, next));
+router.put('/events/:id', validateBody(updateEventSchema), (req, res, next) => ctrl.updateEvent(req, res, next));
 router.delete('/events/:id', (req, res, next) => ctrl.deleteEvent(req, res, next));
 
 // ---------------------------------------------------------------------------
@@ -30,8 +43,8 @@ router.delete('/events/:id', (req, res, next) => ctrl.deleteEvent(req, res, next
 // ---------------------------------------------------------------------------
 
 router.get('/calendars', (req, res, next) => ctrl.getCalendars(req, res, next));
-router.post('/calendars', (req, res, next) => ctrl.createCalendar(req, res, next));
-router.put('/calendars/:id', (req, res, next) => ctrl.updateCalendar(req, res, next));
+router.post('/calendars', validateBody(createCalendarSchema), (req, res, next) => ctrl.createCalendar(req, res, next));
+router.put('/calendars/:id', validateBody(updateCalendarSchema), (req, res, next) => ctrl.updateCalendar(req, res, next));
 router.delete('/calendars/:id', (req, res, next) => ctrl.deleteCalendar(req, res, next));
 
 // Google Calendar connection
@@ -49,10 +62,10 @@ router.delete('/calendars/:id/google', (req, res, next) =>
 router.get('/calendars/:id/members', (req, res, next) =>
   ctrl.getMembers(req, res, next),
 );
-router.post('/calendars/:id/members', (req, res, next) =>
+router.post('/calendars/:id/members', validateBody(addMemberSchema), (req, res, next) =>
   ctrl.inviteMember(req, res, next),
 );
-router.put('/calendars/:id/members/:memberSub', (req, res, next) =>
+router.put('/calendars/:id/members/:memberSub', validateBody(updateMemberSchema), (req, res, next) =>
   ctrl.updateMemberRole(req, res, next),
 );
 router.delete('/calendars/:id/members/:memberSub', (req, res, next) =>
@@ -66,10 +79,10 @@ router.delete('/calendars/:id/members/:memberSub', (req, res, next) =>
 router.get('/events/:id/cards', (req, res, next) =>
   ctrl.getEventCards(req, res, next),
 );
-router.post('/events/:id/cards', (req, res, next) =>
+router.post('/events/:id/cards', validateBody(addEventCardSchema), (req, res, next) =>
   ctrl.addEventCard(req, res, next),
 );
-router.put('/events/:id/cards/:entryId', (req, res, next) =>
+router.put('/events/:id/cards/:entryId', validateBody(updateEventCardSchema), (req, res, next) =>
   ctrl.updateEventCard(req, res, next),
 );
 router.delete('/events/:id/cards/:entryId', (req, res, next) =>
@@ -84,10 +97,10 @@ router.get('/countdowns', (req, res, next) => ctrl.getCountdowns(req, res, next)
 router.get('/countdowns/:id', (req, res, next) =>
   ctrl.getCountdownById(req, res, next),
 );
-router.post('/countdowns', (req, res, next) =>
+router.post('/countdowns', validateBody(createCountdownSchema), (req, res, next) =>
   ctrl.createCountdown(req, res, next),
 );
-router.put('/countdowns/:id', (req, res, next) =>
+router.put('/countdowns/:id', validateBody(updateCountdownSchema), (req, res, next) =>
   ctrl.updateCountdown(req, res, next),
 );
 router.delete('/countdowns/:id', (req, res, next) =>

--- a/src/modules/calendar/schemas.ts
+++ b/src/modules/calendar/schemas.ts
@@ -1,0 +1,107 @@
+import { z } from 'zod';
+
+// ---------------------------------------------------------------------------
+// Calendar Events
+// ---------------------------------------------------------------------------
+
+export const createEventSchema = z.object({
+  title: z.string().trim().min(1, 'title is required'),
+  description: z.string().trim().optional(),
+  startDate: z.string().min(1, 'startDate is required'),
+  endDate: z.string().min(1, 'endDate is required'),
+  allDay: z.boolean().optional(),
+  color: z.string().optional(),
+  calendarId: z.string().uuid().optional(),
+});
+
+export const updateEventSchema = z.object({
+  title: z.string().trim().min(1).optional(),
+  description: z.string().trim().optional(),
+  startDate: z.string().optional(),
+  endDate: z.string().optional(),
+  allDay: z.boolean().optional(),
+  color: z.string().optional(),
+});
+
+// ---------------------------------------------------------------------------
+// Calendars
+// ---------------------------------------------------------------------------
+
+export const createCalendarSchema = z.object({
+  name: z.string().trim().min(1, 'name is required'),
+  color: z.string().optional(),
+  syncMode: z.string().optional(),
+});
+
+export const updateCalendarSchema = z.object({
+  name: z.string().trim().min(1).optional(),
+  color: z.string().optional(),
+  syncMode: z.string().optional(),
+  googleCalId: z.string().optional().nullable(),
+  googleCalName: z.string().optional().nullable(),
+});
+
+// ---------------------------------------------------------------------------
+// Countdowns
+// ---------------------------------------------------------------------------
+
+export const createCountdownSchema = z.object({
+  title: z.string().trim().min(1, 'title is required'),
+  description: z.string().trim().optional(),
+  targetDate: z.string().min(1, 'targetDate is required'),
+  color: z.string().optional(),
+});
+
+export const updateCountdownSchema = z.object({
+  title: z.string().trim().min(1).optional(),
+  description: z.string().trim().optional(),
+  targetDate: z.string().optional(),
+  color: z.string().optional(),
+});
+
+// ---------------------------------------------------------------------------
+// Calendar Members
+// ---------------------------------------------------------------------------
+
+export const addMemberSchema = z.object({
+  email: z.string().email('email must be a valid email address'),
+  role: z.enum(['editor', 'viewer']).optional(),
+});
+
+export const updateMemberSchema = z.object({
+  role: z.enum(['editor', 'viewer']),
+});
+
+// ---------------------------------------------------------------------------
+// Event Cards
+// ---------------------------------------------------------------------------
+
+export const addEventCardSchema = z.object({
+  cardId: z.string().min(1, 'cardId is required'),
+  cardName: z.string().min(1, 'cardName is required'),
+  cardSetId: z.string().optional(),
+  cardSetName: z.string().optional(),
+  cardImageUrl: z.string().url().optional(),
+  quantity: z.number().int().min(1).optional(),
+  notes: z.string().optional(),
+});
+
+export const updateEventCardSchema = z.object({
+  quantity: z.number().int().min(1).optional(),
+  notes: z.string().optional(),
+});
+
+// ---------------------------------------------------------------------------
+// Inferred types
+// ---------------------------------------------------------------------------
+
+export type CreateEventInput = z.infer<typeof createEventSchema>;
+export type UpdateEventInput = z.infer<typeof updateEventSchema>;
+export type CreateCalendarInput = z.infer<typeof createCalendarSchema>;
+export type UpdateCalendarInput = z.infer<typeof updateCalendarSchema>;
+export type CreateCountdownInput = z.infer<typeof createCountdownSchema>;
+export type UpdateCountdownInput = z.infer<typeof updateCountdownSchema>;
+export type AddMemberInput = z.infer<typeof addMemberSchema>;
+export type UpdateMemberInput = z.infer<typeof updateMemberSchema>;
+export type AddEventCardInput = z.infer<typeof addEventCardSchema>;
+export type UpdateEventCardInput = z.infer<typeof updateEventCardSchema>;

--- a/src/modules/chat/controller.ts
+++ b/src/modules/chat/controller.ts
@@ -1,53 +1,48 @@
 import type { Request, Response, NextFunction } from 'express';
 import { ChatService } from './service.js';
 import { createModuleLogger } from '../../shared/utils/logger.js';
+import { ValidationError } from '../../shared/errors/AppError.js';
 
 const log = createModuleLogger('chat');
 
 const service = new ChatService();
 
 export class ChatController {
-  async chat(req: Request, res: Response, _next: NextFunction): Promise<void> {
-    const { prompt } = req.body;
-
-    if (!prompt) {
-      res.status(400).json({ error: 'Prompt is required' });
-      return;
-    }
-
-    if (prompt.length > 4000) {
-      res.status(400).json({ error: 'Prompt too long' });
-      return;
-    }
-
+  async chat(req: Request, res: Response, next: NextFunction): Promise<void> {
     try {
+      const { prompt } = req.body;
+
+      if (!prompt) {
+        throw new ValidationError('Prompt is required');
+      }
+
+      if (prompt.length > 4000) {
+        throw new ValidationError('Prompt too long');
+      }
+
       const reply = await service.chat(prompt);
       res.json({ reply });
     } catch (error) {
-      log.error({ err: error }, 'ChatGPT request failed');
-      res.status(500).json({ error: 'ChatGPT request failed' });
+      next(error);
     }
   }
 
-  async summarize(req: Request, res: Response, _next: NextFunction): Promise<void> {
-    const { text } = req.body;
-
-    if (text.length > 4000) {
-      res.status(400).json({ error: 'Text too long' });
-      return;
-    }
-
-    if (!text) {
-      res.status(400).json({ error: 'Text for summarization is required' });
-      return;
-    }
-
+  async summarize(req: Request, res: Response, next: NextFunction): Promise<void> {
     try {
+      const { text } = req.body;
+
+      if (text.length > 4000) {
+        throw new ValidationError('Text too long');
+      }
+
+      if (!text) {
+        throw new ValidationError('Text for summarization is required');
+      }
+
       const reply = await service.summarize(text);
       res.json({ reply });
     } catch (error) {
-      log.error({ err: error }, 'ChatGPT request failed');
-      res.status(500).json({ error: 'ChatGPT request failed' });
+      next(error);
     }
   }
 }

--- a/src/modules/chat/routes.ts
+++ b/src/modules/chat/routes.ts
@@ -1,6 +1,8 @@
 import { Router } from 'express';
 import { ChatController } from './controller.js';
 import { checkJwt } from '../../config/auth.js';
+import { validateBody } from '../../middleware/validate.js';
+import { chatSchema, summarizeSchema } from './schemas.js';
 
 const router = Router();
 const ctrl = new ChatController();
@@ -8,7 +10,7 @@ const ctrl = new ChatController();
 // All routes require authentication
 router.use(checkJwt);
 
-router.post('/', (req, res, next) => ctrl.chat(req, res, next));
-router.post('/summarize', (req, res, next) => ctrl.summarize(req, res, next));
+router.post('/', validateBody(chatSchema), (req, res, next) => ctrl.chat(req, res, next));
+router.post('/summarize', validateBody(summarizeSchema), (req, res, next) => ctrl.summarize(req, res, next));
 
 export default router;

--- a/src/modules/chat/schemas.ts
+++ b/src/modules/chat/schemas.ts
@@ -1,0 +1,19 @@
+import { z } from 'zod';
+
+export const chatSchema = z.object({
+  prompt: z
+    .string({ required_error: 'Prompt is required' })
+    .min(1, 'Prompt must not be empty')
+    .max(4000, 'Prompt too long'),
+});
+
+export type ChatInput = z.infer<typeof chatSchema>;
+
+export const summarizeSchema = z.object({
+  text: z
+    .string({ required_error: 'Text for summarization is required' })
+    .min(1, 'Text must not be empty')
+    .max(4000, 'Text too long'),
+});
+
+export type SummarizeInput = z.infer<typeof summarizeSchema>;

--- a/src/modules/docs/routes.ts
+++ b/src/modules/docs/routes.ts
@@ -1,0 +1,30 @@
+import { Router } from 'express';
+import swaggerUi from 'swagger-ui-express';
+
+// Import route registrations (side-effect: populates the registry)
+import '../../shared/openapi/registerRoutes.js';
+import { generateOpenAPIDocument } from '../../shared/openapi/generator.js';
+
+const router = Router();
+
+// Cache the generated spec so it's not rebuilt on every request
+let cachedSpec: ReturnType<typeof generateOpenAPIDocument> | null = null;
+
+function getSpec() {
+  if (!cachedSpec) {
+    cachedSpec = generateOpenAPIDocument();
+  }
+  return cachedSpec;
+}
+
+// GET /api/docs/openapi.json — raw OpenAPI spec
+router.get('/openapi.json', (_req, res) => {
+  res.json(getSpec());
+});
+
+// GET /api/docs — Swagger UI
+router.use('/', swaggerUi.serve, swaggerUi.setup(undefined, {
+  swaggerOptions: { url: '/api/docs/openapi.json' },
+}));
+
+export default router;

--- a/src/modules/f1/controller.ts
+++ b/src/modules/f1/controller.ts
@@ -1,5 +1,6 @@
 import type { Request, Response, NextFunction } from 'express';
 import { F1Service, MEMORY_ERROR_MESSAGES, requestQueue } from './service.js';
+import { AppError } from '../../shared/errors/AppError.js';
 
 /** Extract a single string param (Express 5 params can be string | string[]). */
 function param(val: string | string[]): string {
@@ -19,12 +20,7 @@ async function handleQueuedRoute(
     res.json(data);
   } catch (error: any) {
     if (error.message === MEMORY_ERROR_MESSAGES.QUEUE_TIMEOUT) {
-      res.status(503).json({
-        error: 'Request timeout',
-        details: 'The request took too long due to high server load.',
-        suggestion: 'Please try again later',
-      });
-      return;
+      return next(new AppError('Request timeout', 503));
     }
     next(error);
   }
@@ -115,7 +111,7 @@ export class F1Controller {
       await service.clearCache();
       res.json({ message: 'Cache cleared successfully' });
     } catch (error: any) {
-      res.status(500).json({ error: `Failed to clear cache: ${error.message}` });
+      next(error);
     }
   }
 

--- a/src/modules/fantasy/controller.ts
+++ b/src/modules/fantasy/controller.ts
@@ -1,5 +1,6 @@
 import type { Request, Response, NextFunction } from 'express';
 import { FantasyService, MEMORY_ERROR_MESSAGES } from './service.js';
+import { AppError } from '../../shared/errors/AppError.js';
 
 /** Extract a single string param (Express 5 params can be string | string[]). */
 function param(val: string | string[]): string {
@@ -18,17 +19,7 @@ export class FantasyController {
       res.json(result);
     } catch (error: any) {
       if (error.message === MEMORY_ERROR_MESSAGES.QUEUE_TIMEOUT) {
-        res.status(503).json({
-          error: 'Request timeout',
-          details: 'The request took too long due to high server load.',
-          suggestion: 'Please try again later',
-        });
-        return;
-      }
-      // If the error came from results.error in the python script
-      if (!error.statusCode) {
-        res.status(500).json({ error: error.message });
-        return;
+        return next(new AppError('Request timeout', 503));
       }
       next(error);
     }

--- a/src/modules/feedback/controller.ts
+++ b/src/modules/feedback/controller.ts
@@ -1,6 +1,7 @@
 import type { Request, Response, NextFunction } from 'express';
 import { FeedbackRepository } from './repository.js';
 import { createModuleLogger } from '../../shared/utils/logger.js';
+import { NotFoundError, UnauthorizedError, ValidationError } from '../../shared/errors/AppError.js';
 
 const log = createModuleLogger('feedback');
 
@@ -12,13 +13,12 @@ function param(val: string | string[]): string {
 const repo = new FeedbackRepository();
 
 export class FeedbackController {
-  async list(req: Request, res: Response, _next: NextFunction): Promise<void> {
+  async list(req: Request, res: Response, next: NextFunction): Promise<void> {
     try {
       const { page = '1', limit = '10', rotation, searchTerm } = req.query as Record<string, string>;
       const userSub = (req as any).auth.payload.sub as string;
       if (!userSub) {
-        res.status(401).json({ error: 'Unauthorized: No user sub found' });
-        return;
+        throw new UnauthorizedError('Unauthorized: No user sub found');
       }
       const { feedback, totalCount } = await repo.findWithPagination(
         Number(page),
@@ -29,56 +29,49 @@ export class FeedbackController {
       );
       res.status(200).json({ success: true, feedback, totalCount });
     } catch (error) {
-      log.error({ err: error }, 'failed to fetch feedback');
-      res.status(500).json({ error: 'Failed to fetch feedback' });
+      next(error);
     }
   }
 
-  async create(req: Request, res: Response, _next: NextFunction): Promise<void> {
+  async create(req: Request, res: Response, next: NextFunction): Promise<void> {
     try {
       const { text, rotation, journal_entry_id } = req.body;
       const userSub = (req as any).auth.payload.sub as string;
       if (!text || !rotation) {
-        res.status(400).json({ error: 'Missing required fields: text, rotation' });
-        return;
+        throw new ValidationError('Missing required fields: text, rotation');
       }
       const feedback = await repo.add({ text, rotation, journal_entry_id, user_sub: userSub });
       res.status(201).json({ success: true, feedback });
     } catch (error) {
-      log.error({ err: error }, 'failed to add feedback');
-      res.status(500).json({ error: 'Failed to add feedback' });
+      next(error);
     }
   }
 
-  async update(req: Request, res: Response, _next: NextFunction): Promise<void> {
+  async update(req: Request, res: Response, next: NextFunction): Promise<void> {
     try {
       const id = param(req.params.id);
       const { text, rotation, journal_entry_id } = req.body;
       const userSub = (req as any).auth.payload.sub as string;
       if (!text || !rotation) {
-        res.status(400).json({ error: 'Missing required fields: text, rotation' });
-        return;
+        throw new ValidationError('Missing required fields: text, rotation');
       }
       const feedback = await repo.update(id, { text, rotation, journal_entry_id, user_sub: userSub });
       res.status(200).json({ success: true, feedback });
     } catch (error: any) {
-      log.error({ err: error }, 'failed to update feedback');
       if (error.message === 'Feedback not found or unauthorized') {
-        res.status(404).json({ error: 'Feedback not found or unauthorized' });
-      } else {
-        res.status(500).json({ error: 'Failed to update feedback' });
+        return next(new NotFoundError('Feedback not found or unauthorized'));
       }
+      next(error);
     }
   }
 
-  async remove(req: Request, res: Response, _next: NextFunction): Promise<void> {
+  async remove(req: Request, res: Response, next: NextFunction): Promise<void> {
     try {
       const id = param(req.params.id);
       await repo.delete(id);
       res.status(200).json({ success: true });
     } catch (error) {
-      log.error({ err: error }, 'failed to delete feedback');
-      res.status(500).json({ error: 'Failed to delete feedback' });
+      next(error);
     }
   }
 }

--- a/src/modules/feedback/routes.ts
+++ b/src/modules/feedback/routes.ts
@@ -1,6 +1,8 @@
 import { Router } from 'express';
 import { FeedbackController } from './controller.js';
 import { checkJwt } from '../../config/auth.js';
+import { validateBody } from '../../middleware/validate.js';
+import { createFeedbackSchema, updateFeedbackSchema } from './schemas.js';
 
 const router = Router();
 const ctrl = new FeedbackController();
@@ -9,8 +11,8 @@ const ctrl = new FeedbackController();
 router.use(checkJwt);
 
 router.get('/', (req, res, next) => ctrl.list(req, res, next));
-router.post('/', (req, res, next) => ctrl.create(req, res, next));
-router.put('/:id', (req, res, next) => ctrl.update(req, res, next));
+router.post('/', validateBody(createFeedbackSchema), (req, res, next) => ctrl.create(req, res, next));
+router.put('/:id', validateBody(updateFeedbackSchema), (req, res, next) => ctrl.update(req, res, next));
 router.delete('/:id', (req, res, next) => ctrl.remove(req, res, next));
 
 export default router;

--- a/src/modules/feedback/schemas.ts
+++ b/src/modules/feedback/schemas.ts
@@ -1,0 +1,17 @@
+import { z } from 'zod';
+
+export const createFeedbackSchema = z.object({
+  text: z.string({ required_error: 'text is required' }).min(1, 'text must not be empty'),
+  rotation: z.string({ required_error: 'rotation is required' }).min(1, 'rotation must not be empty'),
+  journal_entry_id: z.string().optional(),
+});
+
+export type CreateFeedbackInput = z.infer<typeof createFeedbackSchema>;
+
+export const updateFeedbackSchema = z.object({
+  text: z.string({ required_error: 'text is required' }).min(1, 'text must not be empty'),
+  rotation: z.string({ required_error: 'rotation is required' }).min(1, 'rotation must not be empty'),
+  journal_entry_id: z.string().optional(),
+});
+
+export type UpdateFeedbackInput = z.infer<typeof updateFeedbackSchema>;

--- a/src/modules/follows/controller.ts
+++ b/src/modules/follows/controller.ts
@@ -6,6 +6,7 @@ import type { Request, Response, NextFunction } from 'express';
 import { z } from 'zod';
 import * as repo from './repository.js';
 import { createModuleLogger } from '../../shared/utils/logger.js';
+import { NotFoundError, ValidationError, ConflictError } from '../../shared/errors/AppError.js';
 
 const log = createModuleLogger('follows');
 
@@ -28,7 +29,7 @@ const usernameParamSchema = z.object({
 
 export class FollowsController {
   /** POST /api/follows/:username — send follow request */
-  async follow(req: Request, res: Response, _next: NextFunction) {
+  async follow(req: Request, res: Response, next: NextFunction) {
     const parseResult = usernameParamSchema.safeParse({
       username: param(req.params.username),
     });
@@ -37,7 +38,7 @@ export class FollowsController {
         field: e.path.join('.'),
         message: e.message,
       }));
-      return res.status(400).json({ error: 'Validation failed', details });
+      throw new ValidationError('Validation failed', details);
     }
 
     const followerSub = (req as any).auth.payload.sub as string;
@@ -46,12 +47,12 @@ export class FollowsController {
     try {
       const target = await repo.getTargetByUsername(username);
       if (!target) {
-        return res.status(404).json({ error: 'User not found' });
+        throw new NotFoundError('User not found');
       }
       const { user_sub: followingSub, is_public } = target;
 
       if (followerSub === followingSub) {
-        return res.status(400).json({ error: 'Cannot follow yourself' });
+        throw new ValidationError('Cannot follow yourself');
       }
 
       const status = is_public ? 'accepted' : 'pending';
@@ -59,61 +60,46 @@ export class FollowsController {
       return res.status(201).json(row);
     } catch (err: any) {
       if (err.code === '23505') {
-        return res
-          .status(409)
-          .json({ error: 'Follow request already exists' });
+        throw new ConflictError('Follow request already exists');
       }
-      log.error({ err }, 'POST /:username failed');
-      return res
-        .status(500)
-        .json({ error: 'Failed to send follow request' });
+      next(err);
     }
   }
 
   /** PUT /api/follows/:id/accept */
-  async accept(req: Request, res: Response, _next: NextFunction) {
+  async accept(req: Request, res: Response, next: NextFunction) {
     const followingSub = (req as any).auth.payload.sub as string;
     const id = param(req.params.id);
 
     try {
       const row = await repo.acceptFollow(id, followingSub);
       if (!row) {
-        return res
-          .status(404)
-          .json({ error: 'Follow request not found' });
+        throw new NotFoundError('Follow request not found');
       }
       return res.json(row);
     } catch (err: any) {
-      log.error({ err }, 'PUT /:id/accept failed');
-      return res
-        .status(500)
-        .json({ error: 'Failed to accept follow request' });
+      next(err);
     }
   }
 
   /** PUT /api/follows/:id/reject */
-  async reject(req: Request, res: Response, _next: NextFunction) {
+  async reject(req: Request, res: Response, next: NextFunction) {
     const followingSub = (req as any).auth.payload.sub as string;
     const id = param(req.params.id);
 
     try {
       const row = await repo.rejectFollow(id, followingSub);
       if (!row) {
-        return res
-          .status(404)
-          .json({ error: 'Follow request not found' });
+        throw new NotFoundError('Follow request not found');
       }
       return res.json(row);
     } catch (err: any) {
-      log.error({ err }, 'PUT /:id/reject failed');
-      return res
-        .status(500)
-        .json({ error: 'Failed to reject follow request' });
+      next(err);
     }
   }
 
   /** DELETE /api/follows/:username */
-  async unfollow(req: Request, res: Response, _next: NextFunction) {
+  async unfollow(req: Request, res: Response, next: NextFunction) {
     const parseResult = usernameParamSchema.safeParse({
       username: param(req.params.username),
     });
@@ -122,7 +108,7 @@ export class FollowsController {
         field: e.path.join('.'),
         message: e.message,
       }));
-      return res.status(400).json({ error: 'Validation failed', details });
+      throw new ValidationError('Validation failed', details);
     }
 
     const followerSub = (req as any).auth.payload.sub as string;
@@ -131,24 +117,21 @@ export class FollowsController {
     try {
       const followingSub = await repo.getTargetSubByUsername(username);
       if (!followingSub) {
-        return res.status(404).json({ error: 'User not found' });
+        throw new NotFoundError('User not found');
       }
 
       const rowCount = await repo.deleteFollow(followerSub, followingSub);
       if (rowCount === 0) {
-        return res
-          .status(404)
-          .json({ error: 'Follow relationship not found' });
+        throw new NotFoundError('Follow relationship not found');
       }
       return res.status(204).end();
     } catch (err: any) {
-      log.error({ err }, 'DELETE /:username failed');
-      return res.status(500).json({ error: 'Failed to unfollow user' });
+      next(err);
     }
   }
 
   /** GET /api/follows/requests */
-  async getRequests(req: Request, res: Response, _next: NextFunction) {
+  async getRequests(req: Request, res: Response, next: NextFunction) {
     const followingSub = (req as any).auth.payload.sub as string;
 
     try {
@@ -156,14 +139,12 @@ export class FollowsController {
       return res.json({ requests: rows });
     } catch (err: any) {
       log.error({ err }, 'GET /requests failed');
-      return res
-        .status(500)
-        .json({ error: 'Failed to fetch follow requests' });
+      next(err);
     }
   }
 
   /** GET /api/follows/following */
-  async getFollowing(req: Request, res: Response, _next: NextFunction) {
+  async getFollowing(req: Request, res: Response, next: NextFunction) {
     const followerSub = (req as any).auth.payload.sub as string;
 
     try {
@@ -171,14 +152,12 @@ export class FollowsController {
       return res.json({ following: rows });
     } catch (err: any) {
       log.error({ err }, 'GET /following failed');
-      return res
-        .status(500)
-        .json({ error: 'Failed to fetch following list' });
+      next(err);
     }
   }
 
   /** GET /api/follows/followers */
-  async getFollowers(req: Request, res: Response, _next: NextFunction) {
+  async getFollowers(req: Request, res: Response, next: NextFunction) {
     const followingSub = (req as any).auth.payload.sub as string;
 
     try {
@@ -186,9 +165,7 @@ export class FollowsController {
       return res.json({ followers: rows });
     } catch (err: any) {
       log.error({ err }, 'GET /followers failed');
-      return res
-        .status(500)
-        .json({ error: 'Failed to fetch followers list' });
+      next(err);
     }
   }
 }

--- a/src/modules/follows/routes.ts
+++ b/src/modules/follows/routes.ts
@@ -5,6 +5,8 @@
 import { Router } from 'express';
 import { FollowsController } from './controller.js';
 import { checkJwt } from '../../config/auth.js';
+import { validateParams } from '../../middleware/validate.js';
+import { followParamSchema } from './schemas.js';
 
 const router = Router();
 const ctrl = new FollowsController();
@@ -18,7 +20,7 @@ router.get('/following', (req, res, next) => ctrl.getFollowing(req, res, next));
 router.get('/followers', (req, res, next) => ctrl.getFollowers(req, res, next));
 
 // POST /api/follows/:username — send follow request
-router.post('/:username', (req, res, next) => ctrl.follow(req, res, next));
+router.post('/:username', validateParams(followParamSchema), (req, res, next) => ctrl.follow(req, res, next));
 
 // PUT /api/follows/:id/accept
 router.put('/:id/accept', (req, res, next) => ctrl.accept(req, res, next));

--- a/src/modules/follows/schemas.ts
+++ b/src/modules/follows/schemas.ts
@@ -1,0 +1,9 @@
+import { z } from 'zod';
+
+const USERNAME_REGEX = /^[a-z0-9_]{3,30}$/;
+
+export const followParamSchema = z.object({
+  username: z.string().regex(USERNAME_REGEX),
+});
+
+export type FollowParam = z.infer<typeof followParamSchema>;

--- a/src/modules/forum/controller.ts
+++ b/src/modules/forum/controller.ts
@@ -1,5 +1,6 @@
 import type { Request, Response, NextFunction } from 'express';
 import { ForumRepository } from './repository.js';
+import { NotFoundError, ValidationError } from '../../shared/errors/AppError.js';
 import { createModuleLogger } from '../../shared/utils/logger.js';
 
 const log = createModuleLogger('forum');
@@ -32,15 +33,14 @@ export class ForumController {
   }
 
   async getForumPosts(req: Request, res: Response, next: NextFunction): Promise<void> {
-    const page = parseInt(req.query.page as string, 10) || 1;
-    const limit = parseInt(req.query.limit as string, 10) || 20;
-
-    if (page < 1 || limit < 1) {
-      res.status(400).json({ error: 'page and limit must be positive integers' });
-      return;
-    }
-
     try {
+      const page = parseInt(req.query.page as string, 10) || 1;
+      const limit = parseInt(req.query.limit as string, 10) || 20;
+
+      if (page < 1 || limit < 1) {
+        throw new ValidationError('page and limit must be positive integers');
+      }
+
       const { data, totalCount } = await repo.getForumPosts(page, limit);
       res.status(200).json({
         data,
@@ -61,11 +61,7 @@ export class ForumController {
       const username = (req as any).auth.payload.sub as string;
 
       if (!title || !text) {
-        res.status(400).json({
-          error: 'Missing required fields',
-          required: ['title', 'text'],
-        });
-        return;
+        throw new ValidationError('Missing required fields: title, text');
       }
 
       const post = await repo.createForumPost(title, text, username);
@@ -80,11 +76,7 @@ export class ForumController {
       const { latitude, longitude, text } = req.body;
 
       if (!latitude || !longitude || !text) {
-        res.status(400).json({
-          error: 'Missing required fields',
-          required: ['latitude', 'longitude', 'text'],
-        });
-        return;
+        throw new ValidationError('Missing required fields: latitude, longitude, text');
       }
 
       const marker = await repo.createMarker(latitude, longitude, text);
@@ -111,8 +103,7 @@ export class ForumController {
       const deleted = await repo.deleteMarker(id);
 
       if (!deleted) {
-        res.status(404).json({ error: 'Marker not found' });
-        return;
+        throw new NotFoundError('Marker not found');
       }
 
       res.status(200).json({ message: 'Marker deleted successfully', deleted });

--- a/src/modules/forum/routes.ts
+++ b/src/modules/forum/routes.ts
@@ -1,6 +1,8 @@
 import { Router } from 'express';
 import { ForumController } from './controller.js';
 import { checkJwt } from '../../config/auth.js';
+import { validateBody } from '../../middleware/validate.js';
+import { createForumPostSchema, createMarkerSchema } from './schemas.js';
 
 const router = Router();
 const ctrl = new ForumController();
@@ -13,10 +15,10 @@ router.get('/table/:tableName', checkJwt, (req, res, next) =>
 
 // Forum posts
 router.get('/postforum', (req, res, next) => ctrl.getForumPosts(req, res, next));
-router.post('/postforum', checkJwt, (req, res, next) => ctrl.createForumPost(req, res, next));
+router.post('/postforum', checkJwt, validateBody(createForumPostSchema), (req, res, next) => ctrl.createForumPost(req, res, next));
 
 // Markers
-router.post('/markers', (req, res, next) => ctrl.createMarker(req, res, next));
+router.post('/markers', validateBody(createMarkerSchema), (req, res, next) => ctrl.createMarker(req, res, next));
 router.get('/markers', (req, res, next) => ctrl.getMarkers(req, res, next));
 router.delete('/markers/:id', checkJwt, (req, res, next) => ctrl.deleteMarker(req, res, next));
 

--- a/src/modules/forum/schemas.ts
+++ b/src/modules/forum/schemas.ts
@@ -1,0 +1,16 @@
+import { z } from 'zod';
+
+export const createForumPostSchema = z.object({
+  title: z.string({ required_error: 'title is required' }).min(1, 'title must not be empty'),
+  text: z.string({ required_error: 'text is required' }).min(1, 'text must not be empty'),
+});
+
+export type CreateForumPostInput = z.infer<typeof createForumPostSchema>;
+
+export const createMarkerSchema = z.object({
+  latitude: z.number({ required_error: 'latitude is required', invalid_type_error: 'latitude must be a number' }),
+  longitude: z.number({ required_error: 'longitude is required', invalid_type_error: 'longitude must be a number' }),
+  text: z.string({ required_error: 'text is required' }).min(1, 'text must not be empty'),
+});
+
+export type CreateMarkerInput = z.infer<typeof createMarkerSchema>;

--- a/src/modules/gallery/controller.ts
+++ b/src/modules/gallery/controller.ts
@@ -1,6 +1,7 @@
 import type { Request, Response, NextFunction } from 'express';
 import sharp from 'sharp';
 import { createModuleLogger } from '../../shared/utils/logger.js';
+import { NotFoundError, ValidationError, ForbiddenError } from '../../shared/errors/AppError.js';
 
 const log = createModuleLogger('gallery');
 import { Upload } from '@aws-sdk/lib-storage';
@@ -17,24 +18,21 @@ function param(val: string | string[]): string {
 const repo = new GalleryRepository();
 
 export class GalleryController {
-  async create(req: Request, res: Response, _next: NextFunction): Promise<void> {
+  async create(req: Request, res: Response, next: NextFunction): Promise<void> {
     if (!req.is('multipart/form-data')) {
-      res.status(400).json({ error: 'Content-Type must be multipart/form-data.' });
-      return;
+      throw new ValidationError('Content-Type must be multipart/form-data.');
     }
 
     const { text, description, date } = req.body as Record<string, string>;
     const file = req.file;
 
     if (!file || !text || !description || !date) {
-      res.status(400).json({ error: 'All fields are required.' });
-      return;
+      throw new ValidationError('All fields are required.');
     }
 
     const parsedDate = new Date(date);
     if (isNaN(parsedDate.getTime())) {
-      res.status(400).json({ error: 'Invalid date format.' });
-      return;
+      throw new ValidationError('Invalid date format.');
     }
 
     try {
@@ -63,8 +61,7 @@ export class GalleryController {
         outputFormat = 'webp';
         contentType = 'image/webp';
       } else {
-        res.status(400).json({ error: 'Unsupported image format.' });
-        return;
+        throw new ValidationError('Unsupported image format.');
       }
 
       const key = `gallery/${Date.now()}_${sanitizedFilename.replace(/\.[^/.]+$/, '')}.${outputFormat}`;
@@ -90,20 +87,18 @@ export class GalleryController {
 
       res.status(201).json(savedData);
     } catch (error) {
-      log.error({ err: error }, 'failed to upload image or save data');
-      res.status(500).json({ error: 'Failed to upload image or save data.' });
+      next(error);
     }
   }
 
-  async list(req: Request, res: Response, _next: NextFunction): Promise<void> {
+  async list(req: Request, res: Response, next: NextFunction): Promise<void> {
     const { page = '1', limit = '10' } = req.query as Record<string, string>;
 
     const pageNumber = parseInt(page, 10);
     const limitNumber = parseInt(limit, 10);
 
     if (isNaN(pageNumber) || isNaN(limitNumber) || pageNumber <= 0 || limitNumber <= 0) {
-      res.status(400).json({ error: 'Invalid page or limit parameters.' });
-      return;
+      throw new ValidationError('Invalid page or limit parameters.');
     }
 
     try {
@@ -121,11 +116,11 @@ export class GalleryController {
       res.status(200).json(images);
     } catch (error) {
       log.error({ err: error }, 'failed to fetch gallery items');
-      res.status(500).json({ error: 'Failed to fetch gallery items from database.' });
+      next(error);
     }
   }
 
-  async remove(req: Request, res: Response, _next: NextFunction): Promise<void> {
+  async remove(req: Request, res: Response, next: NextFunction): Promise<void> {
     const id = param(req.params.id);
     const userSub = (req as any).auth?.payload?.sub as string | undefined;
 
@@ -133,13 +128,11 @@ export class GalleryController {
       const record = await repo.findById(id);
 
       if (!record) {
-        res.status(404).json({ error: 'Record not found.' });
-        return;
+        throw new NotFoundError('Record not found.');
       }
 
       if (!userSub || record.user_sub !== userSub) {
-        res.status(403).json({ error: 'Unauthorized to delete this record.' });
-        return;
+        throw new ForbiddenError('Unauthorized to delete this record.');
       }
 
       await repo.deleteById(id);
@@ -149,8 +142,7 @@ export class GalleryController {
 
       res.status(200).json({ message: 'Record and image deleted successfully.' });
     } catch (error) {
-      log.error({ err: error }, 'failed to delete gallery item');
-      res.status(500).json({ error: 'Failed to delete record.' });
+      next(error);
     }
   }
 }

--- a/src/modules/gallery/routes.ts
+++ b/src/modules/gallery/routes.ts
@@ -2,12 +2,14 @@ import { Router } from 'express';
 import multer from 'multer';
 import { GalleryController } from './controller.js';
 import { checkJwt } from '../../config/auth.js';
+import { validateBody } from '../../middleware/validate.js';
+import { createGalleryItemSchema } from './schemas.js';
 
 const router = Router();
 const ctrl = new GalleryController();
 const upload = multer({ storage: multer.memoryStorage() });
 
-router.post('/', checkJwt, upload.single('file'), (req, res, next) =>
+router.post('/', checkJwt, upload.single('file'), validateBody(createGalleryItemSchema), (req, res, next) =>
   ctrl.create(req, res, next),
 );
 router.get('/', (req, res, next) => ctrl.list(req, res, next));

--- a/src/modules/gallery/schemas.ts
+++ b/src/modules/gallery/schemas.ts
@@ -1,0 +1,16 @@
+import { z } from 'zod';
+
+/**
+ * Validates the body fields of the gallery create endpoint.
+ * Note: the file itself is handled by multer (multipart), not by this schema.
+ */
+export const createGalleryItemSchema = z.object({
+  text: z.string({ required_error: 'text is required' }).min(1, 'text must not be empty'),
+  description: z.string({ required_error: 'description is required' }).min(1, 'description must not be empty'),
+  date: z.string({ required_error: 'date is required' }).refine(
+    (val) => !isNaN(new Date(val).getTime()),
+    { message: 'Invalid date format' },
+  ),
+});
+
+export type CreateGalleryItemInput = z.infer<typeof createGalleryItemSchema>;

--- a/src/modules/google-auth/controller.ts
+++ b/src/modules/google-auth/controller.ts
@@ -1,6 +1,7 @@
 import type { Request, Response, NextFunction } from 'express';
 import { env } from '../../config/env.js';
 import { createModuleLogger } from '../../shared/utils/logger.js';
+import { ValidationError } from '../../shared/errors/AppError.js';
 
 const log = createModuleLogger('google-auth');
 import {
@@ -33,7 +34,7 @@ function enqueueForUser(userId: string, fn: () => Promise<void>): Promise<void> 
 }
 
 export class GoogleAuthController {
-  async getStatus(req: Request, res: Response, _next: NextFunction): Promise<void> {
+  async getStatus(req: Request, res: Response, next: NextFunction): Promise<void> {
     const userId = (req as any).auth.payload.sub as string;
     try {
       const auth = await db.getGoogleAuth(userId);
@@ -43,21 +44,19 @@ export class GoogleAuthController {
         res.json({ connected: false });
       }
     } catch (err: any) {
-      log.error({ err }, 'GET /auth/status failed');
-      res.status(500).json({ error: 'Failed to check connection status' });
+      next(err);
     }
   }
 
-  async getAuthUrl(req: Request, res: Response, _next: NextFunction): Promise<void> {
-    const userId = (req as any).auth.payload.sub as string;
-    const origin = req.query.origin as string | undefined;
-
-    if (!origin || !ALLOWED_ORIGINS.has(origin)) {
-      res.status(400).json({ error: 'Missing or invalid origin' });
-      return;
-    }
-
+  async getAuthUrl(req: Request, res: Response, next: NextFunction): Promise<void> {
     try {
+      const userId = (req as any).auth.payload.sub as string;
+      const origin = req.query.origin as string | undefined;
+
+      if (!origin || !ALLOWED_ORIGINS.has(origin)) {
+        throw new ValidationError('Missing or invalid origin');
+      }
+
       const state = buildState(userId, origin);
       const params = new URLSearchParams({
         client_id: env.GOOGLE_CLIENT_ID!,
@@ -70,12 +69,11 @@ export class GoogleAuthController {
       });
       res.json({ url: `https://accounts.google.com/o/oauth2/v2/auth?${params}` });
     } catch (err: any) {
-      log.error({ err }, 'GET /auth/url failed');
-      res.status(500).json({ error: 'Failed to generate authorization URL' });
+      next(err);
     }
   }
 
-  async handleCallback(req: Request, res: Response, _next: NextFunction): Promise<void> {
+  async handleCallback(req: Request, res: Response, next: NextFunction): Promise<void> {
     const { code, state, error } = req.query as Record<string, string>;
 
     const parsed = verifyState(state);
@@ -89,8 +87,7 @@ export class GoogleAuthController {
 
     if (!parsed) {
       log.warn('invalid state param in callback');
-      res.status(400).json({ error: 'Invalid state parameter' });
-      return;
+      return next(new ValidationError('Invalid state parameter'));
     }
 
     const { userId } = parsed;
@@ -137,7 +134,7 @@ export class GoogleAuthController {
     }
   }
 
-  async disconnect(req: Request, res: Response, _next: NextFunction): Promise<void> {
+  async disconnect(req: Request, res: Response, next: NextFunction): Promise<void> {
     const userId = (req as any).auth.payload.sub as string;
     try {
       try {
@@ -148,8 +145,7 @@ export class GoogleAuthController {
       await db.deleteGoogleAuth(userId);
       res.sendStatus(204);
     } catch (err: any) {
-      log.error({ err }, 'DELETE /auth/disconnect failed');
-      res.status(500).json({ error: 'Failed to disconnect Google Calendar' });
+      next(err);
     }
   }
 

--- a/src/modules/medical-journal/controller.ts
+++ b/src/modules/medical-journal/controller.ts
@@ -1,6 +1,7 @@
 import type { Request, Response, NextFunction } from 'express';
 import { MedJournalRepository } from './repository.js';
 import { createModuleLogger } from '../../shared/utils/logger.js';
+import { NotFoundError } from '../../shared/errors/AppError.js';
 
 const log = createModuleLogger('medical-journal');
 
@@ -12,7 +13,7 @@ function param(val: string | string[]): string {
 const repo = new MedJournalRepository();
 
 export class MedJournalController {
-  async saveEntry(req: Request, res: Response, _next: NextFunction): Promise<void> {
+  async saveEntry(req: Request, res: Response, next: NextFunction): Promise<void> {
     const entry = req.body;
     const userSub = (req as any).auth.payload.sub as string;
 
@@ -24,11 +25,11 @@ export class MedJournalController {
       res.status(200).json({ success: true, entry: savedEntry });
     } catch (error) {
       log.error({ err: error }, 'failed to save entry');
-      res.status(500).json({ error: 'Failed to save entry' });
+      next(error);
     }
   }
 
-  async deleteEntry(req: Request, res: Response, _next: NextFunction): Promise<void> {
+  async deleteEntry(req: Request, res: Response, next: NextFunction): Promise<void> {
     const id = param(req.params.id);
     const userSub = (req as any).auth.payload.sub as string;
 
@@ -37,28 +38,26 @@ export class MedJournalController {
       res.status(200).json({ success: true });
     } catch (error) {
       log.error({ err: error }, 'failed to delete entry');
-      res.status(500).json({ error: 'Failed to delete entry' });
+      next(error);
     }
   }
 
-  async getEntry(req: Request, res: Response, _next: NextFunction): Promise<void> {
+  async getEntry(req: Request, res: Response, next: NextFunction): Promise<void> {
     const id = param(req.params.id);
     const userSub = (req as any).auth.payload.sub as string;
 
     try {
       const entry = await repo.findById(id, userSub);
       if (!entry) {
-        res.status(404).json({ error: 'Entry not found' });
-        return;
+        throw new NotFoundError('Entry not found');
       }
       res.status(200).json({ success: true, entry });
     } catch (error) {
-      log.error({ err: error }, 'failed to fetch entry');
-      res.status(500).json({ error: 'Failed to fetch entry' });
+      next(error);
     }
   }
 
-  async listEntries(req: Request, res: Response, _next: NextFunction): Promise<void> {
+  async listEntries(req: Request, res: Response, next: NextFunction): Promise<void> {
     const { page = '1', limit = '10', searchTerm, rotation } = req.query as Record<string, string>;
     const userSub = (req as any).auth.payload.sub as string;
 
@@ -73,11 +72,11 @@ export class MedJournalController {
       res.status(200).json({ success: true, entries });
     } catch (error) {
       log.error({ err: error }, 'failed to fetch entries');
-      res.status(500).json({ error: 'Failed to fetch entries' });
+      next(error);
     }
   }
 
-  async index(req: Request, res: Response, _next: NextFunction): Promise<void> {
+  async index(req: Request, res: Response, next: NextFunction): Promise<void> {
     try {
       const userId = (req as any).auth.sub as string;
       res.json({
@@ -85,7 +84,7 @@ export class MedJournalController {
         userId,
       });
     } catch (error: any) {
-      res.status(500).json({ error: error.message });
+      next(error);
     }
   }
 }

--- a/src/modules/medical-journal/routes.ts
+++ b/src/modules/medical-journal/routes.ts
@@ -1,6 +1,8 @@
 import { Router } from 'express';
 import { MedJournalController } from './controller.js';
 import { checkJwt } from '../../config/auth.js';
+import { validateBody } from '../../middleware/validate.js';
+import { saveEntrySchema } from './schemas.js';
 
 const router = Router();
 const ctrl = new MedJournalController();
@@ -8,7 +10,7 @@ const ctrl = new MedJournalController();
 // All routes require authentication
 router.use(checkJwt);
 
-router.post('/save-entry', (req, res, next) => ctrl.saveEntry(req, res, next));
+router.post('/save-entry', validateBody(saveEntrySchema), (req, res, next) => ctrl.saveEntry(req, res, next));
 router.delete('/delete-entry/:id', (req, res, next) => ctrl.deleteEntry(req, res, next));
 router.get('/edit-entry/:id', (req, res, next) => ctrl.getEntry(req, res, next));
 router.get('/entries', (req, res, next) => ctrl.listEntries(req, res, next));

--- a/src/modules/medical-journal/schemas.ts
+++ b/src/modules/medical-journal/schemas.ts
@@ -1,0 +1,19 @@
+import { z } from 'zod';
+
+export const saveEntrySchema = z.object({
+  id: z.string().optional(),
+  patientSetting: z.string({ required_error: 'patientSetting is required' }),
+  interaction: z.string({ required_error: 'interaction is required' }),
+  canmedsRoles: z.array(z.string()).optional(),
+  learningObjectives: z.array(z.string()).optional(),
+  rotation: z.string({ required_error: 'rotation is required' }),
+  date: z.string({ required_error: 'date is required' }),
+  location: z.string().optional(),
+  hospital: z.string().optional(),
+  doctor: z.string().optional(),
+  whatIDidWell: z.string().optional(),
+  whatICouldImprove: z.string().optional(),
+  feedbackText: z.string().optional(),
+});
+
+export type SaveEntryInput = z.infer<typeof saveEntrySchema>;

--- a/src/modules/nba/controller.ts
+++ b/src/modules/nba/controller.ts
@@ -1,6 +1,6 @@
 import type { Request, Response, NextFunction } from 'express';
 import { NbaService } from './service.js';
-import { ValidationError } from '../../shared/errors/index.js';
+import { ValidationError, UnauthorizedError } from '../../shared/errors/index.js';
 import { env } from '../../config/env.js';
 
 const service = new NbaService();
@@ -122,7 +122,7 @@ export class NbaController {
       const season = parseSeason(req.params.season);
       const secret = env.PLAYOFFS_ADMIN_SECRET;
       if (!secret || req.headers.authorization !== `Bearer ${secret}`) {
-        return res.status(401).json({ error: 'Unauthorized' });
+        throw new UnauthorizedError();
       }
       const { picks } = req.body;
       if (!isPlainObject(picks)) {

--- a/src/modules/nba/routes.ts
+++ b/src/modules/nba/routes.ts
@@ -1,6 +1,8 @@
 import { Router } from 'express';
 import { NbaController } from './controller.js';
 import { checkJwt } from '../../config/auth.js';
+import { validateBody } from '../../middleware/validate.js';
+import { savePicksSchema, saveResultsSchema } from './schemas.js';
 
 const router = Router();
 const ctrl = new NbaController();
@@ -18,7 +20,7 @@ router.get('/playoffs/picks/:season', checkJwt, (req, res, next) =>
 router.get('/playoffs/picks/:season/public', (req, res, next) =>
   ctrl.getPublicPicks(req, res, next),
 );
-router.put('/playoffs/picks/:season', checkJwt, (req, res, next) =>
+router.put('/playoffs/picks/:season', checkJwt, validateBody(savePicksSchema), (req, res, next) =>
   ctrl.savePicks(req, res, next),
 );
 
@@ -26,7 +28,7 @@ router.put('/playoffs/picks/:season', checkJwt, (req, res, next) =>
 router.get('/playoffs/leaderboard/:season', (req, res, next) =>
   ctrl.getLeaderboard(req, res, next),
 );
-router.put('/playoffs/results/:season', (req, res, next) =>
+router.put('/playoffs/results/:season', validateBody(saveResultsSchema), (req, res, next) =>
   ctrl.saveResults(req, res, next),
 );
 

--- a/src/modules/nba/schemas.ts
+++ b/src/modules/nba/schemas.ts
@@ -1,0 +1,20 @@
+import { z } from 'zod';
+
+export const savePicksSchema = z.object({
+  picks: z.record(z.string(), z.unknown()).refine(
+    (val) => val !== null && typeof val === 'object' && !Array.isArray(val),
+    { message: 'picks must be a plain object' },
+  ),
+  displayName: z.string().optional(),
+});
+
+export type SavePicksInput = z.infer<typeof savePicksSchema>;
+
+export const saveResultsSchema = z.object({
+  picks: z.record(z.string(), z.unknown()).refine(
+    (val) => val !== null && typeof val === 'object' && !Array.isArray(val),
+    { message: 'picks must be a plain object' },
+  ),
+});
+
+export type SaveResultsInput = z.infer<typeof saveResultsSchema>;

--- a/src/modules/posts/controller.ts
+++ b/src/modules/posts/controller.ts
@@ -5,6 +5,7 @@
 import type { Request, Response, NextFunction } from 'express';
 import multer from 'multer';
 import { createModuleLogger } from '../../shared/utils/logger.js';
+import { NotFoundError, ValidationError } from '../../shared/errors/AppError.js';
 
 const log = createModuleLogger('posts');
 import path from 'path';
@@ -96,20 +97,18 @@ const createPostSchema = z.discriminatedUnion('type', [
 
 export class PostsController {
   /** POST /api/posts */
-  async createPost(req: Request, res: Response, _next: NextFunction) {
+  async createPost(req: Request, res: Response, next: NextFunction) {
     // Run multer first so req.body and req.files are populated
     try {
       await runMulter(req, res);
     } catch (err: any) {
       if (err.code === 'LIMIT_FILE_SIZE') {
-        return res.status(400).json({ error: 'File too large' });
+        throw new ValidationError('File too large');
       }
       if (err.code === 'LIMIT_FILE_COUNT') {
-        return res
-          .status(400)
-          .json({ error: `Maximum ${MAX_FILES} files allowed` });
+        throw new ValidationError(`Maximum ${MAX_FILES} files allowed`);
       }
-      return res.status(400).json({ error: err.message });
+      throw new ValidationError(err.message);
     }
 
     // Zod validation (after multer so req.body is populated)
@@ -119,7 +118,7 @@ export class PostsController {
         field: e.path.join('.'),
         message: e.message,
       }));
-      return res.status(400).json({ error: 'Validation failed', details });
+      throw new ValidationError('Validation failed', details);
     }
     const validated = parseResult.data;
 
@@ -134,7 +133,8 @@ export class PostsController {
         return res.status(201).json({ ...row, media: [] });
       } catch (err: any) {
         log.error({ err }, 'POST / text failed');
-        return res.status(500).json({ error: 'Failed to create post' });
+        next(err);
+        return;
       }
     }
 
@@ -143,12 +143,10 @@ export class PostsController {
       const caption = validated.caption?.trim() || null;
       const files = (req as any).files as Express.Multer.File[] | undefined;
       if (!files || files.length === 0) {
-        return res
-          .status(400)
-          .json({ error: 'At least one file is required for a media post' });
+        throw new ValidationError('At least one file is required for a media post');
       }
       if (files.length > 10) {
-        return res.status(400).json({ error: 'Maximum 10 files allowed' });
+        throw new ValidationError('Maximum 10 files allowed');
       }
 
       const client = await (await import('../../config/database.js')).pool.connect();
@@ -173,9 +171,7 @@ export class PostsController {
             } catch (vidErr: any) {
               await client.query('ROLLBACK');
               log.error({ err: vidErr }, 'video processing failed');
-              return res
-                .status(400)
-                .json({ error: 'Failed to process video' });
+              throw new ValidationError('Failed to process video');
             }
 
             const { thumbBuffer, width, height, duration } = vidProcessed;
@@ -206,9 +202,7 @@ export class PostsController {
               processed = await processImage(fileBuffer);
             } catch (imgErr: any) {
               await client.query('ROLLBACK');
-              return res
-                .status(imgErr.status || 400)
-                .json({ error: imgErr.message });
+              throw new ValidationError(imgErr.message);
             }
 
             const { fullBuffer, thumbBuffer, blurDataUrl, width, height } =
@@ -239,18 +233,23 @@ export class PostsController {
         return res.status(201).json({ ...post, media: mediaRows });
       } catch (err: any) {
         await client.query('ROLLBACK');
-        log.error({ err }, 'POST / photo failed');
-        return res.status(500).json({ error: 'Failed to create post' });
+        if (err instanceof ValidationError) {
+          next(err);
+        } else {
+          log.error({ err }, 'POST / photo failed');
+          next(err);
+        }
+        return;
       } finally {
         client.release();
       }
     }
 
-    return res.status(400).json({ error: 'type must be "text" or "photo"' });
+    throw new ValidationError('type must be "text" or "photo"');
   }
 
   /** GET /api/posts/user/:username */
-  async getPostsByUser(req: Request, res: Response, _next: NextFunction) {
+  async getPostsByUser(req: Request, res: Response, next: NextFunction) {
     const username = param(req.params.username);
     const cursor = req.query.cursor as string | undefined;
     const LIMIT = 20;
@@ -261,7 +260,7 @@ export class PostsController {
     if (cursor) {
       const d = new Date(cursor);
       if (isNaN(d.getTime())) {
-        return res.status(400).json({ error: 'Invalid cursor' });
+        throw new ValidationError('Invalid cursor');
       }
       cursorDate = d.toISOString();
     }
@@ -270,7 +269,7 @@ export class PostsController {
       // Check visibility
       const profile = await repo.getProfileVisibility(username);
       if (!profile) {
-        return res.status(404).json({ error: 'User not found' });
+        throw new NotFoundError('User not found');
       }
 
       if (!profile.is_public && viewerSub !== profile.user_sub) {
@@ -309,13 +308,12 @@ export class PostsController {
 
       res.json({ posts: formattedPosts, nextCursor });
     } catch (err: any) {
-      log.error({ err }, 'GET /user/:username failed');
-      res.status(500).json({ error: 'Failed to fetch posts' });
+      next(err);
     }
   }
 
   /** GET /api/posts/discover */
-  async discover(req: Request, res: Response, _next: NextFunction) {
+  async discover(req: Request, res: Response, next: NextFunction) {
     const LIMIT = 30;
     try {
       const rows = await repo.getDiscoverPosts(LIMIT);
@@ -328,17 +326,17 @@ export class PostsController {
       res.json({ posts: formattedPosts });
     } catch (err: any) {
       log.error({ err }, 'GET /discover failed');
-      res.status(500).json({ error: 'Failed to fetch discover posts' });
+      next(err);
     }
   }
 
   /** GET /api/posts/:id */
-  async getById(req: Request, res: Response, _next: NextFunction) {
+  async getById(req: Request, res: Response, next: NextFunction) {
     const id = param(req.params.id);
     try {
       const postRow = await repo.getPostById(id);
       if (!postRow) {
-        return res.status(404).json({ error: 'Post not found' });
+        throw new NotFoundError('Post not found');
       }
 
       const mediaRows = await repo.getPostMediaByPostId(id);
@@ -350,13 +348,12 @@ export class PostsController {
         media: mediaRows,
       });
     } catch (err: any) {
-      log.error({ err }, 'GET /:id failed');
-      res.status(500).json({ error: 'Failed to fetch post' });
+      next(err);
     }
   }
 
   /** DELETE /api/posts/:id */
-  async deleteById(req: Request, res: Response, _next: NextFunction) {
+  async deleteById(req: Request, res: Response, next: NextFunction) {
     const sub = (req as any).auth.payload.sub as string;
     const id = param(req.params.id);
 
@@ -366,7 +363,7 @@ export class PostsController {
 
       const rowCount = await repo.deletePost(id, sub);
       if (rowCount === 0) {
-        return res.status(404).json({ error: 'Post not found' });
+        throw new NotFoundError('Post not found');
       }
 
       // Best-effort S3 cleanup
@@ -388,8 +385,7 @@ export class PostsController {
 
       res.status(204).end();
     } catch (err: any) {
-      log.error({ err }, 'DELETE /:id failed');
-      res.status(500).json({ error: 'Failed to delete post' });
+      next(err);
     }
   }
 }

--- a/src/modules/posts/routes.ts
+++ b/src/modules/posts/routes.ts
@@ -5,12 +5,14 @@
 import { Router } from 'express';
 import { PostsController } from './controller.js';
 import { checkJwt, optionalCheckJwt } from '../../config/auth.js';
+import { validateBody } from '../../middleware/validate.js';
+import { createPostSchema } from './schemas.js';
 
 const router = Router();
 const ctrl = new PostsController();
 
 // POST /api/posts — create a post (checkJwt + upsertUser applied at app level)
-router.post('/', checkJwt, (req, res, next) =>
+router.post('/', checkJwt, validateBody(createPostSchema), (req, res, next) =>
   ctrl.createPost(req, res, next),
 );
 

--- a/src/modules/posts/schemas.ts
+++ b/src/modules/posts/schemas.ts
@@ -1,0 +1,27 @@
+import { z } from 'zod';
+
+export const createPostSchema = z.discriminatedUnion('type', [
+  z.object({
+    type: z.literal('text'),
+    content: z
+      .string({ required_error: 'content is required' })
+      .trim()
+      .min(1, 'content must be at least 1 character')
+      .max(500, 'content must be 500 characters or fewer'),
+    caption: z
+      .string()
+      .trim()
+      .max(2200, 'caption must be 2200 characters or fewer')
+      .optional(),
+  }),
+  z.object({
+    type: z.literal('photo'),
+    caption: z
+      .string()
+      .trim()
+      .max(2200, 'caption must be 2200 characters or fewer')
+      .optional(),
+  }),
+]);
+
+export type CreatePostInput = z.infer<typeof createPostSchema>;

--- a/src/modules/profiles/controller.ts
+++ b/src/modules/profiles/controller.ts
@@ -6,6 +6,7 @@ import type { Request, Response, NextFunction } from 'express';
 import multer from 'multer';
 import sharp from 'sharp';
 import { createModuleLogger } from '../../shared/utils/logger.js';
+import { NotFoundError, ValidationError, ConflictError } from '../../shared/errors/AppError.js';
 
 const log = createModuleLogger('profiles');
 import { fromBuffer as fileTypeFromBuffer } from 'file-type';
@@ -99,35 +100,28 @@ const setupProfileSchema = z.object({
 
 export class ProfilesController {
   /** POST /api/profiles/me/avatar */
-  async uploadAvatar(req: Request, res: Response, _next: NextFunction) {
+  async uploadAvatar(req: Request, res: Response, next: NextFunction) {
     // Run multer
     await new Promise<void>((resolve, reject) => {
       avatarUpload(req as any, res as any, (err: any) => {
         if (err?.code === 'LIMIT_FILE_SIZE') {
-          res
-            .status(400)
-            .json({ error: 'Avatar must be 10 MB or smaller' });
-          return resolve();
+          return reject(new ValidationError('Avatar must be 10 MB or smaller'));
         }
         if (err) {
-          res.status(400).json({ error: err.message });
-          return resolve();
+          return reject(new ValidationError(err.message));
         }
         resolve();
       });
     });
 
-    // If response already sent by multer error handler
-    if (res.headersSent) return;
-
     const file = (req as any).file as Express.Multer.File | undefined;
-    if (!file) return res.status(400).json({ error: 'No file provided' });
+    if (!file) throw new ValidationError('No file provided');
 
     const sub = (req as any).auth.payload.sub as string;
 
     const detected = await fileTypeFromBuffer(file.buffer).catch(() => null);
     if (!detected || !ALLOWED_MIME.has(detected.mime)) {
-      return res.status(400).json({ error: 'Unsupported image type' });
+      throw new ValidationError('Unsupported image type');
     }
 
     let avatarBuffer: Buffer;
@@ -139,7 +133,7 @@ export class ProfilesController {
         .toBuffer();
     } catch (err: any) {
       log.error({ err }, 'avatar sharp error');
-      return res.status(400).json({ error: 'Failed to process image' });
+      throw new ValidationError('Failed to process image');
     }
 
     const safeKey = sub.replace(/[^a-zA-Z0-9_\-|]/g, '_');
@@ -150,42 +144,41 @@ export class ProfilesController {
       avatarUrl = await s3Upload(avatarBuffer, key, 'image/webp');
     } catch (err: any) {
       log.error({ err }, 'avatar S3 upload failed');
-      return res.status(500).json({ error: 'Failed to upload avatar' });
+      next(err);
+      return;
     }
 
     try {
       const row = await repo.updateAvatarUrl(sub, avatarUrl);
-      if (!row) return res.status(404).json({ error: 'Profile not set up yet' });
+      if (!row) throw new NotFoundError('Profile not set up yet');
       res.json(row);
     } catch (err: any) {
-      log.error({ err }, 'avatar DB update failed');
-      res.status(500).json({ error: 'Failed to save avatar URL' });
+      next(err);
     }
   }
 
   /** GET /api/profiles/me */
-  async getMe(req: Request, res: Response, _next: NextFunction) {
+  async getMe(req: Request, res: Response, next: NextFunction) {
     const sub = (req as any).auth.payload.sub as string;
     try {
       const profile = await repo.getOwnProfile(sub);
       if (!profile)
-        return res.status(404).json({ error: 'Profile not set up yet' });
+        throw new NotFoundError('Profile not set up yet');
       res.json(profile);
     } catch (err: any) {
-      log.error({ err }, 'GET /me failed');
-      res.status(500).json({ error: 'Failed to fetch profile' });
+      next(err);
     }
   }
 
   /** PUT /api/profiles/me */
-  async updateMe(req: Request, res: Response, _next: NextFunction) {
+  async updateMe(req: Request, res: Response, next: NextFunction) {
     const parseResult = updateProfileSchema.safeParse(req.body);
     if (!parseResult.success) {
       const details = parseResult.error.errors.map((e) => ({
         field: e.path.join('.'),
         message: e.message,
       }));
-      return res.status(400).json({ error: 'Validation failed', details });
+      throw new ValidationError('Validation failed', details);
     }
 
     const sub = (req as any).auth.payload.sub as string;
@@ -194,7 +187,7 @@ export class ProfilesController {
     try {
       const wasPublic = await repo.getIsPublic(sub);
       if (wasPublic === null)
-        return res.status(404).json({ error: 'Profile not set up yet' });
+        throw new NotFoundError('Profile not set up yet');
       const wasPrivate = !wasPublic;
 
       const row = await repo.updateProfile(sub, {
@@ -203,7 +196,7 @@ export class ProfilesController {
         avatar_url,
         is_public,
       });
-      if (!row) return res.status(404).json({ error: 'Profile not set up yet' });
+      if (!row) throw new NotFoundError('Profile not set up yet');
 
       // auto-accept follows if switching to public
       if (wasPrivate && row.is_public) {
@@ -212,20 +205,19 @@ export class ProfilesController {
 
       res.json(row);
     } catch (err: any) {
-      log.error({ err }, 'PUT /me failed');
-      res.status(500).json({ error: 'Failed to update profile' });
+      next(err);
     }
   }
 
   /** POST /api/profiles/setup */
-  async setup(req: Request, res: Response, _next: NextFunction) {
+  async setup(req: Request, res: Response, next: NextFunction) {
     const parseResult = setupProfileSchema.safeParse(req.body);
     if (!parseResult.success) {
       const details = parseResult.error.errors.map((e) => ({
         field: e.path.join('.'),
         message: e.message,
       }));
-      return res.status(400).json({ error: 'Validation failed', details });
+      throw new ValidationError('Validation failed', details);
     }
 
     const sub = (req as any).auth.payload.sub as string;
@@ -243,17 +235,17 @@ export class ProfilesController {
       if (err.code === '23505') {
         const detail: string = err.detail ?? '';
         if (detail.includes('user_sub')) {
-          return res.status(409).json({ error: 'Profile already set up' });
+          throw new ConflictError('Profile already set up');
         }
-        return res.status(409).json({ error: 'Username already taken' });
+        throw new ConflictError('Username already taken');
       }
       log.error({ err }, 'POST /setup failed');
-      res.status(500).json({ error: 'Failed to create profile' });
+      next(err);
     }
   }
 
   /** GET /api/profiles/discover */
-  async discover(req: Request, res: Response, _next: NextFunction) {
+  async discover(req: Request, res: Response, next: NextFunction) {
     const limit = 20;
     const offset = parseInt(req.query.offset as string, 10) || 0;
     try {
@@ -266,15 +258,15 @@ export class ProfilesController {
       });
     } catch (err: any) {
       log.error({ err }, 'GET /discover failed');
-      res.status(500).json({ error: 'Failed to fetch discover list' });
+      next(err);
     }
   }
 
   /** GET /api/profiles/:username */
-  async getByUsername(req: Request, res: Response, _next: NextFunction) {
+  async getByUsername(req: Request, res: Response, next: NextFunction) {
     const username = param(req.params.username);
     if (!USERNAME_RE.test(username)) {
-      return res.status(400).json({ error: 'Invalid username format' });
+      throw new ValidationError('Invalid username format');
     }
 
     const viewerSub =
@@ -283,7 +275,7 @@ export class ProfilesController {
     try {
       const profile = await repo.getPublicProfile(username, viewerSub);
       if (!profile)
-        return res.status(404).json({ error: 'Profile not found' });
+        throw new NotFoundError('Profile not found');
 
       const isOwn = viewerSub && viewerSub === profile.user_sub;
 
@@ -293,8 +285,7 @@ export class ProfilesController {
           isOwn || !viewerSub ? null : (profile.follow_status ?? 'none'),
       });
     } catch (err: any) {
-      log.error({ err }, 'GET /:username failed');
-      res.status(500).json({ error: 'Failed to fetch profile' });
+      next(err);
     }
   }
 }

--- a/src/modules/profiles/routes.ts
+++ b/src/modules/profiles/routes.ts
@@ -5,6 +5,8 @@
 import { Router } from 'express';
 import { ProfilesController } from './controller.js';
 import { checkJwt, optionalCheckJwt } from '../../config/auth.js';
+import { validateBody } from '../../middleware/validate.js';
+import { setupProfileSchema, updateProfileSchema } from './schemas.js';
 
 const router = Router();
 const ctrl = new ProfilesController();
@@ -20,12 +22,12 @@ router.get('/me', checkJwt, (req, res, next) =>
 );
 
 // PUT /api/profiles/me
-router.put('/me', checkJwt, (req, res, next) =>
+router.put('/me', checkJwt, validateBody(updateProfileSchema), (req, res, next) =>
   ctrl.updateMe(req, res, next),
 );
 
 // POST /api/profiles/setup
-router.post('/setup', checkJwt, (req, res, next) =>
+router.post('/setup', checkJwt, validateBody(setupProfileSchema), (req, res, next) =>
   ctrl.setup(req, res, next),
 );
 

--- a/src/modules/profiles/schemas.ts
+++ b/src/modules/profiles/schemas.ts
@@ -1,0 +1,55 @@
+import { z } from 'zod';
+
+const USERNAME_REGEX = /^[a-z0-9_]{3,30}$/;
+
+export const setupProfileSchema = z.object({
+  username: z
+    .string({ required_error: 'username is required' })
+    .regex(
+      USERNAME_REGEX,
+      'username must be 3-30 characters: lowercase letters, numbers, and underscores only',
+    ),
+  display_name: z
+    .string()
+    .trim()
+    .max(50, 'display_name must be 50 characters or fewer')
+    .optional(),
+  bio: z
+    .string()
+    .trim()
+    .max(160, 'bio must be 160 characters or fewer')
+    .optional(),
+  avatar_url: z
+    .union([z.string().url('avatar_url must be a valid URL'), z.literal('')])
+    .optional(),
+});
+
+export const updateProfileSchema = z.object({
+  display_name: z
+    .string()
+    .trim()
+    .max(50, 'display_name must be 50 characters or fewer')
+    .optional(),
+  bio: z
+    .string()
+    .trim()
+    .max(160, 'bio must be 160 characters or fewer')
+    .optional(),
+  avatar_url: z
+    .union([z.string().url('avatar_url must be a valid URL'), z.literal('')])
+    .optional(),
+  is_public: z.boolean().optional(),
+});
+
+export const usernameParamSchema = z.object({
+  username: z
+    .string()
+    .regex(
+      USERNAME_REGEX,
+      'username must be 3-30 characters: lowercase letters, numbers, and underscores only',
+    ),
+});
+
+export type SetupProfileInput = z.infer<typeof setupProfileSchema>;
+export type UpdateProfileInput = z.infer<typeof updateProfileSchema>;
+export type UsernameParam = z.infer<typeof usernameParamSchema>;

--- a/src/modules/timeline/controller.ts
+++ b/src/modules/timeline/controller.ts
@@ -5,6 +5,7 @@
 import type { Request, Response, NextFunction } from 'express';
 import * as repo from './repository.js';
 import { createModuleLogger } from '../../shared/utils/logger.js';
+import { ValidationError } from '../../shared/errors/AppError.js';
 
 const log = createModuleLogger('timeline');
 
@@ -12,7 +13,7 @@ const LIMIT = 20;
 
 export class TimelineController {
   /** GET /api/timeline */
-  async getTimeline(req: Request, res: Response, _next: NextFunction) {
+  async getTimeline(req: Request, res: Response, next: NextFunction) {
     const sub = (req as any).auth.payload.sub as string;
     const cursor = req.query.cursor as string | undefined;
 
@@ -20,7 +21,7 @@ export class TimelineController {
     if (cursor) {
       const d = new Date(cursor);
       if (isNaN(d.getTime())) {
-        return res.status(400).json({ error: 'Invalid cursor' });
+        throw new ValidationError('Invalid cursor');
       }
       cursorDate = d.toISOString();
     } else {
@@ -51,7 +52,7 @@ export class TimelineController {
       return res.json({ posts, nextCursor });
     } catch (err: any) {
       log.error({ err }, 'GET / failed');
-      return res.status(500).json({ error: 'Failed to fetch timeline' });
+      next(err);
     }
   }
 }

--- a/src/modules/vitals/controller.ts
+++ b/src/modules/vitals/controller.ts
@@ -1,47 +1,40 @@
 import type { Request, Response, NextFunction } from 'express';
 import { VitalsRepository, VALID_METRICS, VALID_RATINGS } from './repository.js';
 import { createModuleLogger } from '../../shared/utils/logger.js';
+import { ValidationError } from '../../shared/errors/AppError.js';
 
 const log = createModuleLogger('vitals');
 
 const repo = new VitalsRepository();
 
 export class VitalsController {
-  async ingest(req: Request, res: Response, _next: NextFunction): Promise<void> {
-    const {
-      metric,
-      value,
-      rating,
-      page,
-      nav_type,
-      app_version = 'unknown',
-    } = req.body;
-
-    if (!metric || value === undefined || value === null || !rating || !page) {
-      res.status(400).json({ error: 'metric, value, rating, and page are required' });
-      return;
-    }
-
-    if (!VALID_METRICS.has(metric)) {
-      res.status(400).json({
-        error: `metric must be one of: ${[...VALID_METRICS].join(', ')}`,
-      });
-      return;
-    }
-
-    if (!VALID_RATINGS.has(rating)) {
-      res.status(400).json({
-        error: `rating must be one of: ${[...VALID_RATINGS].join(', ')}`,
-      });
-      return;
-    }
-
-    if (typeof value !== 'number') {
-      res.status(400).json({ error: 'value must be a number' });
-      return;
-    }
-
+  async ingest(req: Request, res: Response, next: NextFunction): Promise<void> {
     try {
+      const {
+        metric,
+        value,
+        rating,
+        page,
+        nav_type,
+        app_version = 'unknown',
+      } = req.body;
+
+      if (!metric || value === undefined || value === null || !rating || !page) {
+        throw new ValidationError('metric, value, rating, and page are required');
+      }
+
+      if (!VALID_METRICS.has(metric)) {
+        throw new ValidationError(`metric must be one of: ${[...VALID_METRICS].join(', ')}`);
+      }
+
+      if (!VALID_RATINGS.has(rating)) {
+        throw new ValidationError(`rating must be one of: ${[...VALID_RATINGS].join(', ')}`);
+      }
+
+      if (typeof value !== 'number') {
+        throw new ValidationError('value must be a number');
+      }
+
       const row = await repo.insert({
         metric,
         value,
@@ -52,51 +45,46 @@ export class VitalsController {
       });
       res.status(201).json(row);
     } catch (err: any) {
-      log.error({ err }, 'POST /vitals failed');
-      res.status(500).json({ error: 'Failed to store vital' });
+      next(err);
     }
   }
 
-  async getSummary(req: Request, res: Response, _next: NextFunction): Promise<void> {
+  async getSummary(req: Request, res: Response, next: NextFunction): Promise<void> {
     const { v, mode } = req.query as Record<string, string>;
     try {
       const summary = await repo.getSummary(v, mode);
       res.json({ summary });
     } catch (err: any) {
-      log.error({ err }, 'GET /vitals/summary failed');
-      res.status(500).json({ error: 'Failed to fetch vitals summary' });
+      next(err);
     }
   }
 
-  async getByPage(req: Request, res: Response, _next: NextFunction): Promise<void> {
+  async getByPage(req: Request, res: Response, next: NextFunction): Promise<void> {
     const { v, mode } = req.query as Record<string, string>;
     try {
       const byPage = await repo.getByPage(v, mode);
       res.json({ byPage });
     } catch (err: any) {
-      log.error({ err }, 'GET /vitals/by-page failed');
-      res.status(500).json({ error: 'Failed to fetch vitals by page' });
+      next(err);
     }
   }
 
-  async getByVersion(req: Request, res: Response, _next: NextFunction): Promise<void> {
+  async getByVersion(req: Request, res: Response, next: NextFunction): Promise<void> {
     const { v, mode } = req.query as Record<string, string>;
     try {
       const byVersion = await repo.getByVersion(v, mode);
       res.json({ byVersion });
     } catch (err: any) {
-      log.error({ err }, 'GET /vitals/by-version failed');
-      res.status(500).json({ error: 'Failed to fetch vitals by version' });
+      next(err);
     }
   }
 
-  async getVersions(_req: Request, res: Response, _next: NextFunction): Promise<void> {
+  async getVersions(_req: Request, res: Response, next: NextFunction): Promise<void> {
     try {
       const versions = await repo.getVersions();
       res.json({ versions });
     } catch (err: any) {
-      log.error({ err }, 'GET /vitals/versions failed');
-      res.status(500).json({ error: 'Failed to fetch versions' });
+      next(err);
     }
   }
 }

--- a/src/modules/vitals/routes.ts
+++ b/src/modules/vitals/routes.ts
@@ -1,12 +1,14 @@
 import { Router } from 'express';
 import { VitalsController } from './controller.js';
 import { checkJwt } from '../../config/auth.js';
+import { validateBody } from '../../middleware/validate.js';
+import { ingestVitalSchema } from './schemas.js';
 
 const router = Router();
 const ctrl = new VitalsController();
 
 // Open ingestion — no auth
-router.post('/', (req, res, next) => ctrl.ingest(req, res, next));
+router.post('/', validateBody(ingestVitalSchema), (req, res, next) => ctrl.ingest(req, res, next));
 
 // Auth required for read endpoints
 router.get('/summary', checkJwt, (req, res, next) => ctrl.getSummary(req, res, next));

--- a/src/modules/vitals/schemas.ts
+++ b/src/modules/vitals/schemas.ts
@@ -1,0 +1,21 @@
+import { z } from 'zod';
+
+const validMetrics = ['LCP', 'CLS', 'FCP', 'INP', 'TTFB'] as const;
+const validRatings = ['good', 'needs-improvement', 'poor'] as const;
+
+export const ingestVitalSchema = z.object({
+  metric: z.enum(validMetrics, {
+    required_error: 'metric is required',
+    invalid_type_error: `metric must be one of: ${validMetrics.join(', ')}`,
+  }),
+  value: z.number({ required_error: 'value is required', invalid_type_error: 'value must be a number' }),
+  rating: z.enum(validRatings, {
+    required_error: 'rating is required',
+    invalid_type_error: `rating must be one of: ${validRatings.join(', ')}`,
+  }),
+  page: z.string({ required_error: 'page is required' }).min(1, 'page must not be empty'),
+  nav_type: z.string().nullish(),
+  app_version: z.string().default('unknown'),
+});
+
+export type IngestVitalInput = z.infer<typeof ingestVitalSchema>;

--- a/src/modules/youtube/controller.ts
+++ b/src/modules/youtube/controller.ts
@@ -1,5 +1,6 @@
 import type { Request, Response, NextFunction } from 'express';
 import { YouTubeService } from './service.js';
+import { ValidationError } from '../../shared/errors/AppError.js';
 import { createModuleLogger } from '../../shared/utils/logger.js';
 
 const log = createModuleLogger('youtube');
@@ -11,8 +12,7 @@ export class YouTubeController {
     try {
       const channelId = req.query.channel_id as string | undefined;
       if (!channelId) {
-        res.status(400).json({ error: 'channel_id query parameter is required' });
-        return;
+        throw new ValidationError('channel_id query parameter is required');
       }
 
       const videos = await service.getRecentVideos(channelId);

--- a/src/shared/openapi/generator.ts
+++ b/src/shared/openapi/generator.ts
@@ -1,0 +1,25 @@
+import {
+  OpenApiGeneratorV31,
+  extendZodWithOpenApi,
+} from '@asteasolutions/zod-to-openapi';
+import { z } from 'zod';
+import { registry } from './registry.js';
+
+// Extend Zod globally so .openapi() is available on all schemas
+extendZodWithOpenApi(z);
+
+export function generateOpenAPIDocument() {
+  const generator = new OpenApiGeneratorV31(registry.definitions);
+
+  return generator.generateDocument({
+    openapi: '3.1.0',
+    info: {
+      title: 'Portfolio API',
+      version: '2.4.2',
+      description:
+        'Backend API for the Portfolio platform. Provides endpoints for NBA stats, calendar management, social features, media galleries, and more.',
+    },
+    servers: [{ url: '/api', description: 'API base path' }],
+    security: [{ bearerAuth: [] }],
+  });
+}

--- a/src/shared/openapi/registerRoutes.ts
+++ b/src/shared/openapi/registerRoutes.ts
@@ -1,0 +1,462 @@
+// ---------------------------------------------------------------------------
+// OpenAPI route registrations — register endpoint metadata with the registry
+// ---------------------------------------------------------------------------
+
+import { z } from 'zod';
+import { registry } from './registry.js';
+
+// ── Security scheme ───────────────────────────────────────────────────────
+
+registry.registerComponent('securitySchemes', 'bearerAuth', {
+  type: 'http',
+  scheme: 'bearer',
+  bearerFormat: 'JWT',
+  description: 'Auth0 JWT token',
+});
+
+// ── Import module schemas ─────────────────────────────────────────────────
+
+import {
+  createEventSchema,
+  updateEventSchema,
+  createCalendarSchema,
+  updateCalendarSchema,
+  createCountdownSchema,
+  updateCountdownSchema,
+  addMemberSchema,
+  updateMemberSchema,
+  addEventCardSchema,
+  updateEventCardSchema,
+} from '../../modules/calendar/schemas.js';
+
+import { createPostSchema } from '../../modules/posts/schemas.js';
+import { setupProfileSchema, updateProfileSchema } from '../../modules/profiles/schemas.js';
+import { followParamSchema } from '../../modules/follows/schemas.js';
+import { createFeedbackSchema, updateFeedbackSchema } from '../../modules/feedback/schemas.js';
+import { chatSchema, summarizeSchema } from '../../modules/chat/schemas.js';
+import { ingestVitalSchema } from '../../modules/vitals/schemas.js';
+import { saveEntrySchema } from '../../modules/medical-journal/schemas.js';
+import { createForumPostSchema, createMarkerSchema } from '../../modules/forum/schemas.js';
+import { savePicksSchema, saveResultsSchema } from '../../modules/nba/schemas.js';
+import { createGalleryItemSchema } from '../../modules/gallery/schemas.js';
+
+// ── Helper ────────────────────────────────────────────────────────────────
+
+const errorResponse = z.object({
+  error: z.string(),
+  message: z.string(),
+  details: z.any().optional(),
+});
+
+// ── Health ─────────────────────────────────────────────────────────────────
+
+registry.registerPath({
+  method: 'get',
+  path: '/health',
+  summary: 'Health check',
+  tags: ['Health'],
+  responses: {
+    200: { description: 'Service health', content: { 'application/json': { schema: z.object({ status: z.string(), uptime: z.number(), dbConnected: z.boolean(), version: z.string() }) } } },
+  },
+});
+
+registry.registerPath({
+  method: 'get',
+  path: '/ready',
+  summary: 'Readiness probe',
+  tags: ['Health'],
+  responses: {
+    200: { description: 'Ready', content: { 'application/json': { schema: z.object({ status: z.literal('ready') }) } } },
+    503: { description: 'Shutting down' },
+  },
+});
+
+// ── NBA ────────────────────────────────────────────────────────────────────
+
+registry.registerPath({
+  method: 'get',
+  path: '/nba/teams',
+  summary: 'List NBA teams',
+  tags: ['NBA'],
+  responses: { 200: { description: 'Team list' } },
+});
+
+registry.registerPath({
+  method: 'get',
+  path: '/nba/teams/{teamId}/players',
+  summary: 'Players on a team',
+  tags: ['NBA'],
+  request: { params: z.object({ teamId: z.string() }) },
+  responses: { 200: { description: 'Player list' } },
+});
+
+registry.registerPath({
+  method: 'put',
+  path: '/nba/playoffs/picks/{season}',
+  summary: 'Save bracket picks',
+  tags: ['NBA'],
+  security: [{ bearerAuth: [] }],
+  request: { params: z.object({ season: z.string() }), body: { content: { 'application/json': { schema: savePicksSchema } } } },
+  responses: { 200: { description: 'Saved' }, 401: { description: 'Unauthorized' } },
+});
+
+registry.registerPath({
+  method: 'put',
+  path: '/nba/playoffs/results/{season}',
+  summary: 'Save official results (admin)',
+  tags: ['NBA'],
+  request: { params: z.object({ season: z.string() }), body: { content: { 'application/json': { schema: saveResultsSchema } } } },
+  responses: { 200: { description: 'Saved' }, 401: { description: 'Unauthorized' } },
+});
+
+// ── Calendar ──────────────────────────────────────────────────────────────
+
+registry.registerPath({
+  method: 'get',
+  path: '/calendar/events',
+  summary: 'List calendar events',
+  tags: ['Calendar'],
+  security: [{ bearerAuth: [] }],
+  responses: { 200: { description: 'Event list' } },
+});
+
+registry.registerPath({
+  method: 'post',
+  path: '/calendar/events',
+  summary: 'Create a calendar event',
+  tags: ['Calendar'],
+  security: [{ bearerAuth: [] }],
+  request: { body: { content: { 'application/json': { schema: createEventSchema } } } },
+  responses: { 201: { description: 'Created' }, 400: { description: 'Validation error' } },
+});
+
+registry.registerPath({
+  method: 'put',
+  path: '/calendar/events/{id}',
+  summary: 'Update a calendar event',
+  tags: ['Calendar'],
+  security: [{ bearerAuth: [] }],
+  request: { params: z.object({ id: z.string().uuid() }), body: { content: { 'application/json': { schema: updateEventSchema } } } },
+  responses: { 200: { description: 'Updated' } },
+});
+
+registry.registerPath({
+  method: 'post',
+  path: '/calendar/calendars',
+  summary: 'Create a calendar',
+  tags: ['Calendar'],
+  security: [{ bearerAuth: [] }],
+  request: { body: { content: { 'application/json': { schema: createCalendarSchema } } } },
+  responses: { 201: { description: 'Created' } },
+});
+
+registry.registerPath({
+  method: 'put',
+  path: '/calendar/calendars/{id}',
+  summary: 'Update a calendar',
+  tags: ['Calendar'],
+  security: [{ bearerAuth: [] }],
+  request: { params: z.object({ id: z.string().uuid() }), body: { content: { 'application/json': { schema: updateCalendarSchema } } } },
+  responses: { 200: { description: 'Updated' } },
+});
+
+registry.registerPath({
+  method: 'post',
+  path: '/calendar/countdowns',
+  summary: 'Create a countdown',
+  tags: ['Calendar'],
+  security: [{ bearerAuth: [] }],
+  request: { body: { content: { 'application/json': { schema: createCountdownSchema } } } },
+  responses: { 201: { description: 'Created' } },
+});
+
+registry.registerPath({
+  method: 'put',
+  path: '/calendar/countdowns/{id}',
+  summary: 'Update a countdown',
+  tags: ['Calendar'],
+  security: [{ bearerAuth: [] }],
+  request: { params: z.object({ id: z.string().uuid() }), body: { content: { 'application/json': { schema: updateCountdownSchema } } } },
+  responses: { 200: { description: 'Updated' } },
+});
+
+registry.registerPath({
+  method: 'post',
+  path: '/calendar/calendars/{id}/members',
+  summary: 'Add a calendar member',
+  tags: ['Calendar'],
+  security: [{ bearerAuth: [] }],
+  request: { params: z.object({ id: z.string().uuid() }), body: { content: { 'application/json': { schema: addMemberSchema } } } },
+  responses: { 201: { description: 'Added' } },
+});
+
+registry.registerPath({
+  method: 'put',
+  path: '/calendar/calendars/{id}/members/{memberSub}',
+  summary: 'Update member role',
+  tags: ['Calendar'],
+  security: [{ bearerAuth: [] }],
+  request: { params: z.object({ id: z.string().uuid(), memberSub: z.string() }), body: { content: { 'application/json': { schema: updateMemberSchema } } } },
+  responses: { 200: { description: 'Updated' } },
+});
+
+registry.registerPath({
+  method: 'post',
+  path: '/calendar/events/{id}/cards',
+  summary: 'Add an event card',
+  tags: ['Calendar'],
+  security: [{ bearerAuth: [] }],
+  request: { params: z.object({ id: z.string().uuid() }), body: { content: { 'application/json': { schema: addEventCardSchema } } } },
+  responses: { 201: { description: 'Added' } },
+});
+
+registry.registerPath({
+  method: 'put',
+  path: '/calendar/events/{id}/cards/{entryId}',
+  summary: 'Update an event card',
+  tags: ['Calendar'],
+  security: [{ bearerAuth: [] }],
+  request: { params: z.object({ id: z.string().uuid(), entryId: z.string().uuid() }), body: { content: { 'application/json': { schema: updateEventCardSchema } } } },
+  responses: { 200: { description: 'Updated' } },
+});
+
+// ── Posts ──────────────────────────────────────────────────────────────────
+
+registry.registerPath({
+  method: 'post',
+  path: '/posts',
+  summary: 'Create a post (text or photo)',
+  tags: ['Posts'],
+  security: [{ bearerAuth: [] }],
+  request: { body: { content: { 'application/json': { schema: createPostSchema } } } },
+  responses: { 201: { description: 'Created' } },
+});
+
+registry.registerPath({
+  method: 'get',
+  path: '/posts/user/{username}',
+  summary: 'Get posts by username',
+  tags: ['Posts'],
+  request: { params: z.object({ username: z.string() }) },
+  responses: { 200: { description: 'Post list' } },
+});
+
+registry.registerPath({
+  method: 'get',
+  path: '/posts/discover',
+  summary: 'Public discover feed',
+  tags: ['Posts'],
+  responses: { 200: { description: 'Post list' } },
+});
+
+registry.registerPath({
+  method: 'delete',
+  path: '/posts/{id}',
+  summary: 'Delete a post',
+  tags: ['Posts'],
+  security: [{ bearerAuth: [] }],
+  request: { params: z.object({ id: z.string().uuid() }) },
+  responses: { 204: { description: 'Deleted' } },
+});
+
+// ── Profiles ──────────────────────────────────────────────────────────────
+
+registry.registerPath({
+  method: 'post',
+  path: '/profiles/setup',
+  summary: 'Set up a new profile',
+  tags: ['Profiles'],
+  security: [{ bearerAuth: [] }],
+  request: { body: { content: { 'application/json': { schema: setupProfileSchema } } } },
+  responses: { 201: { description: 'Profile created' }, 409: { description: 'Username taken' } },
+});
+
+registry.registerPath({
+  method: 'put',
+  path: '/profiles/me',
+  summary: 'Update own profile',
+  tags: ['Profiles'],
+  security: [{ bearerAuth: [] }],
+  request: { body: { content: { 'application/json': { schema: updateProfileSchema } } } },
+  responses: { 200: { description: 'Updated' } },
+});
+
+registry.registerPath({
+  method: 'get',
+  path: '/profiles/me',
+  summary: 'Get own profile',
+  tags: ['Profiles'],
+  security: [{ bearerAuth: [] }],
+  responses: { 200: { description: 'Profile' } },
+});
+
+// ── Follows ───────────────────────────────────────────────────────────────
+
+registry.registerPath({
+  method: 'post',
+  path: '/follows/{username}',
+  summary: 'Follow a user',
+  tags: ['Follows'],
+  security: [{ bearerAuth: [] }],
+  request: { params: followParamSchema },
+  responses: { 200: { description: 'Follow request sent' }, 409: { description: 'Already following' } },
+});
+
+// ── Timeline ──────────────────────────────────────────────────────────────
+
+registry.registerPath({
+  method: 'get',
+  path: '/timeline',
+  summary: 'Get timeline feed',
+  tags: ['Timeline'],
+  security: [{ bearerAuth: [] }],
+  responses: { 200: { description: 'Timeline items' } },
+});
+
+// ── Feedback ──────────────────────────────────────────────────────────────
+
+registry.registerPath({
+  method: 'post',
+  path: '/feedback',
+  summary: 'Create feedback entry',
+  tags: ['Feedback'],
+  security: [{ bearerAuth: [] }],
+  request: { body: { content: { 'application/json': { schema: createFeedbackSchema } } } },
+  responses: { 201: { description: 'Created' } },
+});
+
+registry.registerPath({
+  method: 'put',
+  path: '/feedback/{id}',
+  summary: 'Update feedback entry',
+  tags: ['Feedback'],
+  security: [{ bearerAuth: [] }],
+  request: { params: z.object({ id: z.string() }), body: { content: { 'application/json': { schema: updateFeedbackSchema } } } },
+  responses: { 200: { description: 'Updated' } },
+});
+
+// ── Chat ──────────────────────────────────────────────────────────────────
+
+registry.registerPath({
+  method: 'post',
+  path: '/chatgpt',
+  summary: 'Send a chat message',
+  tags: ['Chat'],
+  security: [{ bearerAuth: [] }],
+  request: { body: { content: { 'application/json': { schema: chatSchema } } } },
+  responses: { 200: { description: 'Chat response' } },
+});
+
+registry.registerPath({
+  method: 'post',
+  path: '/chatgpt/summarize',
+  summary: 'Summarize text',
+  tags: ['Chat'],
+  security: [{ bearerAuth: [] }],
+  request: { body: { content: { 'application/json': { schema: summarizeSchema } } } },
+  responses: { 200: { description: 'Summary' } },
+});
+
+// ── Vitals ─────────────────────────────────────────────────────────────────
+
+registry.registerPath({
+  method: 'post',
+  path: '/vitals',
+  summary: 'Ingest a web vital metric',
+  tags: ['Vitals'],
+  request: { body: { content: { 'application/json': { schema: ingestVitalSchema } } } },
+  responses: { 204: { description: 'Accepted' } },
+});
+
+registry.registerPath({
+  method: 'get',
+  path: '/vitals/summary',
+  summary: 'Get vitals summary',
+  tags: ['Vitals'],
+  responses: { 200: { description: 'Summary data' } },
+});
+
+// ── Medical Journal ───────────────────────────────────────────────────────
+
+registry.registerPath({
+  method: 'post',
+  path: '/med-journal/save-entry',
+  summary: 'Save a journal entry',
+  tags: ['Medical Journal'],
+  security: [{ bearerAuth: [] }],
+  request: { body: { content: { 'application/json': { schema: saveEntrySchema } } } },
+  responses: { 200: { description: 'Saved' } },
+});
+
+// ── Gallery ───────────────────────────────────────────────────────────────
+
+registry.registerPath({
+  method: 'post',
+  path: '/gallery',
+  summary: 'Upload a gallery item',
+  tags: ['Gallery'],
+  security: [{ bearerAuth: [] }],
+  request: { body: { content: { 'multipart/form-data': { schema: z.object({ file: z.any(), text: z.string(), description: z.string(), date: z.string().optional() }) } } } },
+  responses: { 201: { description: 'Created' } },
+});
+
+registry.registerPath({
+  method: 'get',
+  path: '/gallery',
+  summary: 'List gallery items',
+  tags: ['Gallery'],
+  responses: { 200: { description: 'Gallery items' } },
+});
+
+// ── Forum ─────────────────────────────────────────────────────────────────
+
+registry.registerPath({
+  method: 'post',
+  path: '/postforum',
+  summary: 'Create a forum post',
+  tags: ['Forum'],
+  security: [{ bearerAuth: [] }],
+  request: { body: { content: { 'application/json': { schema: createForumPostSchema } } } },
+  responses: { 201: { description: 'Created' } },
+});
+
+registry.registerPath({
+  method: 'post',
+  path: '/markers',
+  summary: 'Create a map marker',
+  tags: ['Forum'],
+  request: { body: { content: { 'application/json': { schema: createMarkerSchema } } } },
+  responses: { 201: { description: 'Created' } },
+});
+
+// ── YouTube ───────────────────────────────────────────────────────────────
+
+registry.registerPath({
+  method: 'get',
+  path: '/youtube',
+  summary: 'Get recent YouTube videos',
+  tags: ['YouTube'],
+  request: { query: z.object({ channel_id: z.string() }) },
+  responses: { 200: { description: 'Video list' } },
+});
+
+// ── F1 ────────────────────────────────────────────────────────────────────
+
+registry.registerPath({
+  method: 'get',
+  path: '/f1/qualifying/{year}/{round}',
+  summary: 'Get F1 qualifying data',
+  tags: ['F1'],
+  request: { params: z.object({ year: z.string(), round: z.string() }) },
+  responses: { 200: { description: 'Qualifying data' } },
+});
+
+// ── Geo ───────────────────────────────────────────────────────────────────
+
+registry.registerPath({
+  method: 'get',
+  path: '/geo',
+  summary: 'Get geolocation from IP',
+  tags: ['Geo'],
+  responses: { 200: { description: 'Location data' } },
+});

--- a/src/shared/openapi/registry.ts
+++ b/src/shared/openapi/registry.ts
@@ -1,0 +1,3 @@
+import { OpenAPIRegistry } from '@asteasolutions/zod-to-openapi';
+
+export const registry = new OpenAPIRegistry();

--- a/src/shared/utils/index.ts
+++ b/src/shared/utils/index.ts
@@ -13,4 +13,6 @@ export {
 } from './mediaProcessor.js';
 export type { ProcessedImage, ProcessedVideo } from './mediaProcessor.js';
 export { logger, createModuleLogger } from './logger.js';
+export { success, paginated, created } from './response.js';
+export type { PaginationMeta } from './response.js';
 export { setupGracefulShutdown, isShutdown } from './shutdown.js';

--- a/src/shared/utils/response.ts
+++ b/src/shared/utils/response.ts
@@ -1,0 +1,29 @@
+/**
+ * Typed response helpers for consistent API responses.
+ *
+ * NOTE: paul-explore currently expects raw response bodies (not wrapped).
+ * Existing endpoints keep their "v1" shape. New endpoints should use these
+ * helpers and set the X-API-Version: 2 header.
+ */
+
+export interface PaginationMeta {
+  page: number;
+  pageSize: number;
+  total: number;
+  hasMore: boolean;
+}
+
+export function success<T>(data: T): { data: T } {
+  return { data };
+}
+
+export function paginated<T>(
+  data: T[],
+  pagination: PaginationMeta,
+): { data: T[]; pagination: PaginationMeta } {
+  return { data, pagination };
+}
+
+export function created<T>(data: T): { data: T } {
+  return { data };
+}


### PR DESCRIPTION
## Summary
- Add typed response helpers (`success`, `paginated`, `created`) for future v2 envelope pattern
- Standardize error handling across all 17 controllers to use AppError subclasses and `next(err)`
- Add comprehensive Zod validation schemas for all POST/PUT endpoints across 11 modules, wired into routes
- Generate OpenAPI 3.1 spec with zod-to-openapi, serve Swagger UI at `/api/docs`

## Test plan
- [x] Verify `tsc --noEmit` passes
- [x] Confirm existing JS routes still work via server.js
- [x] POST with invalid body returns 400 with Zod error details
- [x] Check `/api/docs` serves Swagger UI
- [x] Check `/api/docs/openapi.json` returns valid OpenAPI spec