### PR TITLE
Phase 10: architecture audit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2026-07-17 - version 2.9.0
+
+- Architecture audit: documented layer boundary findings, inconsistent layering patterns, and recommendations
+- Remove unused `morgan` and `@types/morgan` dependencies (replaced by pino-http)
+
 ## 2026-07-17 - version 2.7.2
 
 - Remove unused dependencies left over from the overhaul: `apicache` (replaced by the custom typed cache manager), `jest` (replaced by Vitest), and `ts-node` (replaced by `tsx` for the dev server)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portfolio_api",
-  "version": "2.7.2",
+  "version": "2.9.0",
   "description": "Portfolio API with Node.js and Python",
   "main": "dist/index.js",
   "scripts": {
@@ -42,7 +42,6 @@
     "helmet": "^7.0.0",
     "jwks-rsa": "^3.2.0",
     "knex": "^3.3.0",
-    "morgan": "^1.10.0",
     "multer": "^1.4.5-lts.2",
     "openai": "^4.98.0",
     "p-throttle": "^4.1.1",
@@ -60,7 +59,6 @@
     "@types/compression": "^1.8.1",
     "@types/cors": "^2.8.19",
     "@types/express": "^5.0.6",
-    "@types/morgan": "^1.9.10",
     "@types/multer": "^2.2.0",
     "@types/node": "^26.1.1",
     "@types/pg": "^8.20.0",


### PR DESCRIPTION
## Summary
- Audited all 17 modules for layer boundary violations, dead code, and consistency
- Removed unused `morgan` and `@types/morgan` (replaced by pino-http in phase 3, never cleaned up)
- Documented findings in plan/ARCHITECTURE_AUDIT.md (gitignored): posts controller manages raw transactions, google-auth controller bypasses service layer, inconsistent layering across modules
- No forced refactoring — the 2-layer pattern works for CRUD modules, 3-layer earns its keep only where business logic demands it

## Test plan
- [x] Dependency removal only — no logic changes