### PR TITLE
Fix architecture audit findings (phase 12)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 2026-07-17 - version 2.9.0
+
+- Extract post creation transaction logic (BEGIN/COMMIT/ROLLBACK) from controller to `posts/service.ts`
+- Add named service methods for Google auth DB access — controller no longer touches `db` directly
+- Move NBA date calculations (`getCurrentSeason`, `getCurrentSeasonYear`) from repository to service layer
+- Addresses layer boundary violations identified in the Phase 10 architecture audit
+
 ## 2026-07-17 - version 2.8.0
 
 - Switch package manager from npm to pnpm for strict dependency resolution and faster installs

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portfolio_api",
-  "version": "2.8.0",
+  "version": "2.8.1",
   "description": "Portfolio API with Node.js and Python",
   "main": "dist/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portfolio_api",
-  "version": "2.8.1",
+  "version": "2.8.2",
   "description": "Portfolio API with Node.js and Python",
   "main": "dist/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portfolio_api",
-  "version": "2.8.2",
+  "version": "2.9.0",
   "description": "Portfolio API with Node.js and Python",
   "main": "dist/index.js",
   "scripts": {

--- a/src/modules/google-auth/controller.ts
+++ b/src/modules/google-auth/controller.ts
@@ -5,7 +5,6 @@ import { ValidationError } from '../../shared/errors/AppError.js';
 
 const log = createModuleLogger('google-auth');
 import {
-  db,
   registerWatch,
   stopWatch,
   fetchIncrementalEvents,
@@ -14,6 +13,14 @@ import {
   verifyState,
   fromGoogleEvent,
   processExistingItem,
+  getGoogleAuth,
+  upsertGoogleAuth,
+  deleteGoogleAuth,
+  getCalendarByGoogleCalId,
+  updateCalendar,
+  getEventByGoogleId,
+  createCalendarEventFromWebhook,
+  updateSyncToken,
 } from './service.js';
 
 // Per-user webhook queue
@@ -37,7 +44,7 @@ export class GoogleAuthController {
   async getStatus(req: Request, res: Response, next: NextFunction): Promise<void> {
     const userId = (req as any).auth.payload.sub as string;
     try {
-      const auth = await db.getGoogleAuth(userId);
+      const auth = await getGoogleAuth(userId);
       if (auth) {
         res.json({ connected: true, googleCalId: auth.google_cal_id });
       } else {
@@ -115,7 +122,7 @@ export class GoogleAuthController {
       const { access_token, refresh_token, expires_in } = await tokenRes.json();
       const tokenExpiry = new Date(Date.now() + expires_in * 1000);
 
-      await db.upsertGoogleAuth(userId, {
+      await upsertGoogleAuth(userId, {
         accessToken: access_token,
         refreshToken: refresh_token,
         tokenExpiry,
@@ -142,7 +149,7 @@ export class GoogleAuthController {
       } catch (watchErr: any) {
         log.warn({ err: watchErr }, 'stopWatch failed on disconnect');
       }
-      await db.deleteGoogleAuth(userId);
+      await deleteGoogleAuth(userId);
       res.sendStatus(204);
     } catch (err: any) {
       next(err);
@@ -165,7 +172,7 @@ export class GoogleAuthController {
 
     enqueueForUser(userId, async () => {
       if (googleCalId) {
-        const calendar = await db.getCalendarByGoogleCalId(googleCalId, userId);
+        const calendar = await getCalendarByGoogleCalId(googleCalId, userId);
         if (!calendar) {
           log.info({ googleCalId, userId }, 'orphaned channel');
           return;
@@ -178,10 +185,10 @@ export class GoogleAuthController {
         );
         log.info({ count: items.length, userId, googleCalId }, 'webhook items received');
 
-        await db.updateCalendar(calendar.id, { syncToken: nextSyncToken }, userId);
+        await updateCalendar(calendar.id, { syncToken: nextSyncToken }, userId);
 
         for (const item of items) {
-          const existing = await db.getEventByGoogleId(item.id, userId);
+          const existing = await getEventByGoogleId(item.id, userId);
 
           if (!existing) {
             if (calendar.syncMode !== 'two_way') {
@@ -191,23 +198,23 @@ export class GoogleAuthController {
             if (item.status === 'cancelled') continue;
             const fields = fromGoogleEvent(item);
             log.info({ itemId: item.id, calendarId: calendar.id }, 'importing new event');
-            await db.createCalendarEventFromWebhook(fields, item.id, calendar.id, userId);
+            await createCalendarEventFromWebhook(fields, item.id, calendar.id, userId);
             continue;
           }
 
           await processExistingItem(item, userId, existing);
         }
       } else {
-        const auth = await db.getGoogleAuth(userId);
+        const auth = await getGoogleAuth(userId);
         if (!auth) return;
 
         const { items, nextSyncToken } = await fetchIncrementalEvents(userId, auth.sync_token);
         log.info({ count: items.length, userId }, 'incremental fetch items received');
 
-        await db.updateSyncToken(userId, nextSyncToken);
+        await updateSyncToken(userId, nextSyncToken);
 
         for (const item of items) {
-          const existing = await db.getEventByGoogleId(item.id, userId);
+          const existing = await getEventByGoogleId(item.id, userId);
           if (!existing) {
             log.info({ itemId: item.id, status: item.status }, 'skipping item: not in our DB');
             continue;

--- a/src/modules/google-auth/service.ts
+++ b/src/modules/google-auth/service.ts
@@ -19,7 +19,53 @@ const { registerWatch, stopWatch, fetchIncrementalEvents } = require('../../../u
   ) => Promise<{ items: GoogleCalendarItem[]; nextSyncToken: string }>;
 };
 
-export { db, registerWatch, stopWatch, fetchIncrementalEvents };
+export { registerWatch, stopWatch, fetchIncrementalEvents };
+
+// ── Service methods wrapping DB access ────────────────────────────────────
+
+export async function getGoogleAuth(userId: string) {
+  return db.getGoogleAuth(userId);
+}
+
+export async function upsertGoogleAuth(
+  userId: string,
+  tokens: { accessToken: string; refreshToken: string; tokenExpiry: Date },
+) {
+  return db.upsertGoogleAuth(userId, tokens);
+}
+
+export async function deleteGoogleAuth(userId: string) {
+  return db.deleteGoogleAuth(userId);
+}
+
+export async function getCalendarByGoogleCalId(googleCalId: string, userId: string) {
+  return db.getCalendarByGoogleCalId(googleCalId, userId);
+}
+
+export async function updateCalendar(calendarId: string, data: { syncToken: string }, userId: string) {
+  return db.updateCalendar(calendarId, data, userId);
+}
+
+export async function getEventByGoogleId(googleEventId: string, userId: string) {
+  return db.getEventByGoogleId(googleEventId, userId);
+}
+
+export async function createCalendarEventFromWebhook(
+  fields: WebhookEventFields,
+  googleEventId: string,
+  calendarId: string,
+  userId: string,
+) {
+  return db.createCalendarEventFromWebhook(fields, googleEventId, calendarId, userId);
+}
+
+export async function getGoogleAuthForSync(userId: string) {
+  return db.getGoogleAuth(userId);
+}
+
+export async function updateSyncToken(userId: string, syncToken: string) {
+  return db.updateSyncToken(userId, syncToken);
+}
 
 const ALLOWED_ORIGINS = new Set([
   'https://paulsumido.com',

--- a/src/modules/nba/repository.ts
+++ b/src/modules/nba/repository.ts
@@ -34,23 +34,8 @@ async function throttledFetch(
   return fetch(url, options);
 }
 
-function getCurrentSeason(): string {
-  const now = new Date();
-  const year = now.getFullYear();
-  const seasonStartYear = now.getMonth() >= 9 ? year : year - 1;
-  const seasonEndYear = seasonStartYear + 1;
-  return `${seasonStartYear}-${seasonEndYear.toString().slice(-2)}`;
-}
-
-function getCurrentSeasonYear(): number {
-  const now = new Date();
-  const year = now.getFullYear();
-  return now.getMonth() >= 9 ? year : year - 1;
-}
-
 export class NbaRepository {
-  async fetchTeams(): Promise<PaginatedResponse<NbaTeam[]>> {
-    const season = getCurrentSeason();
+  async fetchTeams(season: string): Promise<PaginatedResponse<NbaTeam[]>> {
     const url = `https://stats.nba.com/stats/leaguestandingsv3?LeagueID=00&Season=${season}&SeasonType=Regular+Season`;
     const response = await throttledFetch(url, { headers: NBA_HEADERS });
     const data = await response.json();
@@ -85,10 +70,11 @@ export class NbaRepository {
 
   async fetchPlayersByTeam(
     teamId: number,
+    season: string,
   ): Promise<PaginatedResponse<NbaPlayer[]>> {
     const url = new URL(`${NBA_BASE_URL}/commonteamroster`);
     url.searchParams.append('LeagueID', '00');
-    url.searchParams.append('Season', getCurrentSeason());
+    url.searchParams.append('Season', season);
     url.searchParams.append('TeamID', teamId.toString());
 
     const response = await throttledFetch(url.toString(), {
@@ -156,6 +142,8 @@ export class NbaRepository {
 
   async fetchPlayerStats(
     playerId: number,
+    season: string,
+    seasonYear: number,
   ): Promise<PaginatedResponse<PlayerStats[]>> {
     const url = new URL(`${NBA_BASE_URL}/playerdashboardbygeneralsplits`);
     const params: Record<string, string> = {
@@ -176,7 +164,7 @@ export class NbaRepository {
       PlayerID: playerId.toString(),
       PlusMinus: 'N',
       Rank: 'N',
-      Season: getCurrentSeason(),
+      Season: season,
       SeasonSegment: '',
       SeasonType: 'Regular Season',
       ShotClockRange: '',
@@ -216,7 +204,7 @@ export class NbaRepository {
     const stats: PlayerStats = {
       games_played: parseInt(get('GP')) || 0,
       player_id: playerId,
-      season: getCurrentSeasonYear(),
+      season: seasonYear,
       min: get('MIN') || '0:00',
       fgm: parseFloat(get('FGM')) || 0,
       fga: parseFloat(get('FGA')) || 0,
@@ -251,8 +239,7 @@ export class NbaRepository {
     };
   }
 
-  async fetchShotChart(playerId: number): Promise<{ data: ShotChartData }> {
-    const season = getCurrentSeason();
+  async fetchShotChart(playerId: number, season: string): Promise<{ data: ShotChartData }> {
 
     // Deterministic mock data per player (NBA blocks shotchartdetail from some envs)
     const seed = (n: number) => {

--- a/src/modules/nba/service.ts
+++ b/src/modules/nba/service.ts
@@ -11,6 +11,22 @@ import type {
 import { getCachedData } from '../../shared/utils/cache.js';
 import { NotFoundError, ValidationError } from '../../shared/errors/index.js';
 
+// ── Date calculations (not data access — belong in service, not repository) ──
+
+export function getCurrentSeason(): string {
+  const now = new Date();
+  const year = now.getFullYear();
+  const seasonStartYear = now.getMonth() >= 9 ? year : year - 1;
+  const seasonEndYear = seasonStartYear + 1;
+  return `${seasonStartYear}-${seasonEndYear.toString().slice(-2)}`;
+}
+
+export function getCurrentSeasonYear(): number {
+  const now = new Date();
+  const year = now.getFullYear();
+  return now.getMonth() >= 9 ? year : year - 1;
+}
+
 // Playoff scoring constants
 const ROUND_POINTS: Record<string, number> = {
   r1: 1,
@@ -105,15 +121,17 @@ export class NbaService {
   constructor(private repo = new NbaRepository()) {}
 
   async getTeams(): Promise<PaginatedResponse<NbaTeam[]>> {
-    return getCachedData('teams', () => this.repo.fetchTeams());
+    const season = getCurrentSeason();
+    return getCachedData('teams', () => this.repo.fetchTeams(season));
   }
 
   async getPlayersByTeam(
     teamId: number,
   ): Promise<PaginatedResponse<NbaPlayer[]>> {
     if (isNaN(teamId)) throw new ValidationError('Invalid team ID');
+    const season = getCurrentSeason();
     return getCachedData(`team-players-${teamId}`, () =>
-      this.repo.fetchPlayersByTeam(teamId),
+      this.repo.fetchPlayersByTeam(teamId, season),
     );
   }
 
@@ -121,16 +139,19 @@ export class NbaService {
     playerId: number,
   ): Promise<PaginatedResponse<PlayerStats[]>> {
     if (isNaN(playerId)) throw new ValidationError('Invalid player ID');
+    const season = getCurrentSeason();
+    const seasonYear = getCurrentSeasonYear();
     return getCachedData(`player-stats-${playerId}`, () =>
-      this.repo.fetchPlayerStats(playerId),
+      this.repo.fetchPlayerStats(playerId, season, seasonYear),
     );
   }
 
   async getShotChart(playerId: number): Promise<{ data: ShotChartData }> {
     if (isNaN(playerId)) throw new ValidationError('Invalid player ID');
+    const season = getCurrentSeason();
     return getCachedData(
       `shots-${playerId}`,
-      () => this.repo.fetchShotChart(playerId),
+      () => this.repo.fetchShotChart(playerId, season),
       86400,
     );
   }

--- a/src/modules/posts/controller.ts
+++ b/src/modules/posts/controller.ts
@@ -8,44 +8,14 @@ import { createModuleLogger } from '../../shared/utils/logger.js';
 import { NotFoundError, ValidationError } from '../../shared/errors/AppError.js';
 
 const log = createModuleLogger('posts');
-import path from 'path';
-import { fromBuffer as fileTypeFromBuffer } from 'file-type';
-import { Upload } from '@aws-sdk/lib-storage';
-import { DeleteObjectCommand } from '@aws-sdk/client-s3';
-import { s3, S3_BUCKET, CDN_BASE } from '../../config/s3.js';
-import {
-  type ProcessedImage,
-  type ProcessedVideo,
-  processImage,
-  processVideo,
-  ALLOWED_VIDEO_MIME,
-} from '../../shared/utils/mediaProcessor.js';
 import * as repo from './repository.js';
-import type { MediaRow } from './types.js';
+import * as service from './service.js';
 
 // ── Helpers ────────────────────────────────────────────────────────────────
 
 /** Express 5 params can be string | string[] */
 function param(val: string | string[]): string {
   return Array.isArray(val) ? val[0] : val;
-}
-
-async function s3Upload(
-  buffer: Buffer,
-  key: string,
-  contentType: string,
-): Promise<string> {
-  const up = new Upload({
-    client: s3,
-    params: {
-      Bucket: S3_BUCKET!,
-      Key: key,
-      Body: buffer,
-      ContentType: contentType,
-    },
-  });
-  await up.done();
-  return `${CDN_BASE}/${key}`;
 }
 
 // ── Multer ─────────────────────────────────────────────────────────────────
@@ -67,8 +37,7 @@ function runMulter(req: Request, res: Response): Promise<void> {
 }
 
 // ── Zod schema for createPost ──────────────────────────────────────────────
-// We inline-import the JS schema to avoid duplicating the definition.
-// eslint-disable-next-line @typescript-eslint/no-var-requires
+
 import { z } from 'zod';
 
 const createPostSchema = z.discriminatedUnion('type', [
@@ -151,90 +120,10 @@ export class PostsController {
         throw new ValidationError('Maximum 10 files allowed');
       }
 
-      const client = await (await import('../../config/database.js')).pool.connect();
       try {
-        await client.query('BEGIN');
-
-        const post = await repo.insertPhotoPost(sub, caption);
-        const postId = post.id;
-
-        const mediaRows: MediaRow[] = [];
-        for (let i = 0; i < files.length; i++) {
-          const fileBuffer = files[i].buffer;
-          const detected = await fileTypeFromBuffer(
-            fileBuffer.slice(0, 4100),
-          );
-
-          if (detected && ALLOWED_VIDEO_MIME.has(detected.mime)) {
-            // ── video file ─────────────────────────────────────────────────
-            let vidProcessed: ProcessedVideo;
-            try {
-              vidProcessed = await processVideo(fileBuffer);
-            } catch (vidErr: any) {
-              await client.query('ROLLBACK');
-              log.error({ err: vidErr }, 'video processing failed');
-              throw new ValidationError('Failed to process video');
-            }
-
-            const { thumbBuffer, width, height, duration } = vidProcessed;
-            const videoKey = `posts/${postId}/${i}_video${path.extname(files[i].originalname) || '.mp4'}`;
-            const thumbKey = `posts/${postId}/${i}_thumb.webp`;
-
-            const [videoUrl, thumbUrl] = await Promise.all([
-              s3Upload(fileBuffer, videoKey, detected.mime),
-              s3Upload(thumbBuffer, thumbKey, 'image/webp'),
-            ]);
-
-            const mediaRow = await repo.insertMediaRow(postId, {
-              s3Key: videoKey,
-              url: videoUrl,
-              width,
-              height,
-              position: i,
-              blurDataUrl: '',
-              mediaType: 'video',
-              thumbnailUrl: thumbUrl,
-              duration,
-            });
-            mediaRows.push(mediaRow);
-          } else {
-            // ── image file ─────────────────────────────────────────────────
-            let processed: ProcessedImage;
-            try {
-              processed = await processImage(fileBuffer);
-            } catch (imgErr: any) {
-              await client.query('ROLLBACK');
-              throw new ValidationError(imgErr.message);
-            }
-
-            const { fullBuffer, thumbBuffer, blurDataUrl, width, height } =
-              processed;
-            const fullKey = `posts/${postId}/${i}_full.webp`;
-            const thumbKey = `posts/${postId}/${i}_thumb.webp`;
-
-            const [fullUrl, thumbUrl] = await Promise.all([
-              s3Upload(fullBuffer, fullKey, 'image/webp'),
-              s3Upload(thumbBuffer, thumbKey, 'image/webp'),
-            ]);
-
-            const mediaRow = await repo.insertMediaRow(postId, {
-              s3Key: fullKey,
-              url: fullUrl,
-              width: width ?? 0,
-              height: height ?? 0,
-              position: i,
-              blurDataUrl,
-              mediaType: 'image',
-              thumbnailUrl: thumbUrl,
-            });
-            mediaRows.push(mediaRow);
-          }
-        }
-
-        await client.query('COMMIT');
-        return res.status(201).json({ ...post, media: mediaRows });
+        const result = await service.createPhotoPost(sub, caption, files);
+        return res.status(201).json(result);
       } catch (err: any) {
-        await client.query('ROLLBACK');
         if (err instanceof ValidationError) {
           next(err);
         } else {
@@ -242,8 +131,6 @@ export class PostsController {
           next(err);
         }
         return;
-      } finally {
-        client.release();
       }
     }
 
@@ -360,31 +247,7 @@ export class PostsController {
     const id = param(req.params.id);
 
     try {
-      // Grab S3 keys before delete
-      const mediaKeys = await repo.getMediaS3Keys(id);
-
-      const rowCount = await repo.deletePost(id, sub);
-      if (rowCount === 0) {
-        throw new NotFoundError('Post not found');
-      }
-
-      // Best-effort S3 cleanup
-      if (mediaKeys.length > 0) {
-        await Promise.allSettled(
-          mediaKeys.flatMap(({ s3_key }) => [
-            s3.send(
-              new DeleteObjectCommand({ Bucket: S3_BUCKET!, Key: s3_key }),
-            ),
-            s3.send(
-              new DeleteObjectCommand({
-                Bucket: S3_BUCKET!,
-                Key: s3_key.replace('_full.webp', '_thumb.webp'),
-              }),
-            ),
-          ]),
-        );
-      }
-
+      await service.deletePostWithMedia(id, sub);
       res.status(204).end();
     } catch (err: any) {
       next(err);

--- a/src/modules/posts/service.ts
+++ b/src/modules/posts/service.ts
@@ -1,0 +1,169 @@
+// ---------------------------------------------------------------------------
+// Posts module — service layer (owns transaction lifecycle)
+// ---------------------------------------------------------------------------
+
+import path from 'path';
+import { fromBuffer as fileTypeFromBuffer } from 'file-type';
+import { Upload } from '@aws-sdk/lib-storage';
+import { DeleteObjectCommand } from '@aws-sdk/client-s3';
+import { s3, S3_BUCKET, CDN_BASE } from '../../config/s3.js';
+import {
+  type ProcessedImage,
+  type ProcessedVideo,
+  processImage,
+  processVideo,
+  ALLOWED_VIDEO_MIME,
+} from '../../shared/utils/mediaProcessor.js';
+import { createModuleLogger } from '../../shared/utils/logger.js';
+import { ValidationError } from '../../shared/errors/AppError.js';
+import * as repo from './repository.js';
+import type { PostRow, MediaRow } from './types.js';
+
+const log = createModuleLogger('posts');
+
+async function s3Upload(
+  buffer: Buffer,
+  key: string,
+  contentType: string,
+): Promise<string> {
+  const up = new Upload({
+    client: s3,
+    params: {
+      Bucket: S3_BUCKET!,
+      Key: key,
+      Body: buffer,
+      ContentType: contentType,
+    },
+  });
+  await up.done();
+  return `${CDN_BASE}/${key}`;
+}
+
+/**
+ * Create a photo post with media files, wrapped in a database transaction.
+ * Handles image/video processing, S3 uploads, and media row insertion.
+ */
+export async function createPhotoPost(
+  userSub: string,
+  caption: string | null,
+  files: Express.Multer.File[],
+): Promise<PostRow & { media: MediaRow[] }> {
+  const { pool } = await import('../../config/database.js');
+  const client = await pool.connect();
+
+  try {
+    await client.query('BEGIN');
+
+    const post = await repo.insertPhotoPost(userSub, caption);
+    const postId = post.id;
+
+    const mediaRows: MediaRow[] = [];
+    for (let i = 0; i < files.length; i++) {
+      const fileBuffer = files[i].buffer;
+      const detected = await fileTypeFromBuffer(fileBuffer.slice(0, 4100));
+
+      if (detected && ALLOWED_VIDEO_MIME.has(detected.mime)) {
+        let vidProcessed: ProcessedVideo;
+        try {
+          vidProcessed = await processVideo(fileBuffer);
+        } catch (vidErr: any) {
+          await client.query('ROLLBACK');
+          log.error({ err: vidErr }, 'video processing failed');
+          throw new ValidationError('Failed to process video');
+        }
+
+        const { thumbBuffer, width, height, duration } = vidProcessed;
+        const videoKey = `posts/${postId}/${i}_video${path.extname(files[i].originalname) || '.mp4'}`;
+        const thumbKey = `posts/${postId}/${i}_thumb.webp`;
+
+        const [videoUrl, thumbUrl] = await Promise.all([
+          s3Upload(fileBuffer, videoKey, detected.mime),
+          s3Upload(thumbBuffer, thumbKey, 'image/webp'),
+        ]);
+
+        const mediaRow = await repo.insertMediaRow(postId, {
+          s3Key: videoKey,
+          url: videoUrl,
+          width,
+          height,
+          position: i,
+          blurDataUrl: '',
+          mediaType: 'video',
+          thumbnailUrl: thumbUrl,
+          duration,
+        });
+        mediaRows.push(mediaRow);
+      } else {
+        let processed: ProcessedImage;
+        try {
+          processed = await processImage(fileBuffer);
+        } catch (imgErr: any) {
+          await client.query('ROLLBACK');
+          throw new ValidationError(imgErr.message);
+        }
+
+        const { fullBuffer, thumbBuffer, blurDataUrl, width, height } =
+          processed;
+        const fullKey = `posts/${postId}/${i}_full.webp`;
+        const thumbKey = `posts/${postId}/${i}_thumb.webp`;
+
+        const [fullUrl, thumbUrl] = await Promise.all([
+          s3Upload(fullBuffer, fullKey, 'image/webp'),
+          s3Upload(thumbBuffer, thumbKey, 'image/webp'),
+        ]);
+
+        const mediaRow = await repo.insertMediaRow(postId, {
+          s3Key: fullKey,
+          url: fullUrl,
+          width: width ?? 0,
+          height: height ?? 0,
+          position: i,
+          blurDataUrl,
+          mediaType: 'image',
+          thumbnailUrl: thumbUrl,
+        });
+        mediaRows.push(mediaRow);
+      }
+    }
+
+    await client.query('COMMIT');
+    return { ...post, media: mediaRows };
+  } catch (err) {
+    await client.query('ROLLBACK');
+    throw err;
+  } finally {
+    client.release();
+  }
+}
+
+/**
+ * Delete a post and clean up its S3 media (best-effort).
+ */
+export async function deletePostWithMedia(
+  postId: string,
+  userSub: string,
+): Promise<void> {
+  const mediaKeys = await repo.getMediaS3Keys(postId);
+  const rowCount = await repo.deletePost(postId, userSub);
+
+  if (rowCount === 0) {
+    const { NotFoundError } = await import('../../shared/errors/AppError.js');
+    throw new NotFoundError('Post not found');
+  }
+
+  if (mediaKeys.length > 0) {
+    await Promise.allSettled(
+      mediaKeys.flatMap(({ s3_key }) => [
+        s3.send(
+          new DeleteObjectCommand({ Bucket: S3_BUCKET!, Key: s3_key }),
+        ),
+        s3.send(
+          new DeleteObjectCommand({
+            Bucket: S3_BUCKET!,
+            Key: s3_key.replace('_full.webp', '_thumb.webp'),
+          }),
+        ),
+      ]),
+    );
+  }
+}


### PR DESCRIPTION
## Summary

- Extract post creation transaction logic (BEGIN/COMMIT/ROLLBACK) from controller into `posts/service.ts`
- Add named service methods for Google auth module — controller no longer imports the raw `db` object
- Move `getCurrentSeason()` / `getCurrentSeasonYear()` from NBA repository to service (date calc, not data access)

Addresses the three layer boundary violations flagged in the Phase 10 architecture audit.

## Test plan

- [x] All 45 tests pass
- [x] Type check passes
- [x] Post creation (text + photo) still works end-to-end
- [x] Google Calendar auth flow unchanged
- [x] NBA stats/teams/players endpoints return correct season data