### PR TITLE
add referrals module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2026-07-20 - version 2.9.1
+
+- Add a `referrals` module backing the work-portfolio referral-links demo: create a shareable slug (custom or generated, uniqueness enforced), resolve it, record clicks (UA stored hashed), and read click stats. Public endpoints with basic IP rate limits
+- New `referrals` and `referral_clicks` tables (migration `001_referrals`) plus Drizzle schema definitions
+
 ## 2026-07-17 - version 2.9.0
 
 - Extract post creation transaction logic (BEGIN/COMMIT/ROLLBACK) from controller to `posts/service.ts`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portfolio_api",
-  "version": "2.9.0",
+  "version": "2.9.1",
   "description": "Portfolio API with Node.js and Python",
   "main": "dist/index.js",
   "scripts": {

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,31 +1,30 @@
-import express from 'express';
-import cors from 'cors';
 import compression from 'compression';
+import cors from 'cors';
+import express from 'express';
 import helmet from 'helmet';
-
-import { requestLogger } from './middleware/requestLogger.js';
 import { errorHandler } from './middleware/errorHandler.js';
-
-// Module routers
-import nbaRoutes from './modules/nba/routes.js';
+import { requestLogger } from './middleware/requestLogger.js';
 import calendarRoutes from './modules/calendar/routes.js';
+import chatRoutes from './modules/chat/routes.js';
+import docsRoutes from './modules/docs/routes.js';
 import f1Routes from './modules/f1/routes.js';
 import fantasyRoutes from './modules/fantasy/routes.js';
-import galleryRoutes from './modules/gallery/routes.js';
-import medJournalRoutes from './modules/medical-journal/routes.js';
 import feedbackRoutes from './modules/feedback/routes.js';
-import chatRoutes from './modules/chat/routes.js';
-import youtubeRoutes from './modules/youtube/routes.js';
-import postsRoutes from './modules/posts/routes.js';
-import profilesRoutes from './modules/profiles/routes.js';
 import followsRoutes from './modules/follows/routes.js';
-import timelineRoutes from './modules/timeline/routes.js';
-import vitalsRoutes from './modules/vitals/routes.js';
+import forumRoutes from './modules/forum/routes.js';
+import galleryRoutes from './modules/gallery/routes.js';
 import geoRoutes from './modules/geo/routes.js';
 import googleAuthRoutes from './modules/google-auth/routes.js';
-import forumRoutes from './modules/forum/routes.js';
 import healthRoutes from './modules/health/routes.js';
-import docsRoutes from './modules/docs/routes.js';
+import medJournalRoutes from './modules/medical-journal/routes.js';
+// Module routers
+import nbaRoutes from './modules/nba/routes.js';
+import postsRoutes from './modules/posts/routes.js';
+import profilesRoutes from './modules/profiles/routes.js';
+import referralsRoutes from './modules/referrals/routes.js';
+import timelineRoutes from './modules/timeline/routes.js';
+import vitalsRoutes from './modules/vitals/routes.js';
+import youtubeRoutes from './modules/youtube/routes.js';
 
 export const app = express();
 
@@ -34,11 +33,7 @@ export const app = express();
 app.use(helmet());
 app.use(
   cors({
-    origin: [
-      'https://paulsumido.com',
-      'https://develop.paulsumido.com',
-      'http://localhost:3000',
-    ],
+    origin: ['https://paulsumido.com', 'https://develop.paulsumido.com', 'http://localhost:3000'],
   }),
 );
 app.use(compression());
@@ -58,6 +53,7 @@ app.use('/api/f1', f1Routes);
 app.use('/api/fantasy', fantasyRoutes);
 app.use('/api/vitals', vitalsRoutes);
 app.use('/api/geo', geoRoutes);
+app.use('/api/referrals', referralsRoutes);
 
 // Auth-aware routes (each module applies checkJwt internally per-route)
 app.use('/api/calendar', calendarRoutes);

--- a/src/config/drizzle/schema.ts
+++ b/src/config/drizzle/schema.ts
@@ -2,25 +2,23 @@
 // Drizzle ORM schema definitions — social modules
 // ---------------------------------------------------------------------------
 
+import type { InferInsertModel, InferSelectModel } from 'drizzle-orm';
 import {
+  boolean,
+  doublePrecision,
+  integer,
   pgTable,
   text,
   timestamp,
   uuid,
-  integer,
-  boolean,
-  doublePrecision,
 } from 'drizzle-orm/pg-core';
-import type { InferSelectModel, InferInsertModel } from 'drizzle-orm';
 
 // ── users ──────────────────────────────────────────────────────────────────
 export const users = pgTable('users', {
   sub: text('sub').primaryKey(),
   email: text('email').notNull(),
   name: text('name'),
-  updatedAt: timestamp('updated_at', { withTimezone: true })
-    .defaultNow()
-    .notNull(),
+  updatedAt: timestamp('updated_at', { withTimezone: true }).defaultNow().notNull(),
 });
 
 export type User = InferSelectModel<typeof users>;
@@ -36,12 +34,8 @@ export const userProfiles = pgTable('user_profiles', {
   bio: text('bio'),
   avatarUrl: text('avatar_url'),
   isPublic: boolean('is_public').default(true).notNull(),
-  createdAt: timestamp('created_at', { withTimezone: true })
-    .defaultNow()
-    .notNull(),
-  updatedAt: timestamp('updated_at', { withTimezone: true })
-    .defaultNow()
-    .notNull(),
+  createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
+  updatedAt: timestamp('updated_at', { withTimezone: true }).defaultNow().notNull(),
 });
 
 export type UserProfile = InferSelectModel<typeof userProfiles>;
@@ -56,12 +50,8 @@ export const posts = pgTable('posts', {
   type: text('type').notNull(),
   caption: text('caption'),
   content: text('content'),
-  createdAt: timestamp('created_at', { withTimezone: true })
-    .defaultNow()
-    .notNull(),
-  updatedAt: timestamp('updated_at', { withTimezone: true })
-    .defaultNow()
-    .notNull(),
+  createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
+  updatedAt: timestamp('updated_at', { withTimezone: true }).defaultNow().notNull(),
 });
 
 export type Post = InferSelectModel<typeof posts>;
@@ -82,9 +72,7 @@ export const postMedia = pgTable('post_media', {
   mediaType: text('media_type').notNull(),
   thumbnailUrl: text('thumbnail_url'),
   duration: doublePrecision('duration'),
-  createdAt: timestamp('created_at', { withTimezone: true })
-    .defaultNow()
-    .notNull(),
+  createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
 });
 
 export type PostMedia = InferSelectModel<typeof postMedia>;
@@ -100,13 +88,34 @@ export const follows = pgTable('follows', {
     .notNull()
     .references(() => users.sub),
   status: text('status').notNull().default('pending'),
-  createdAt: timestamp('created_at', { withTimezone: true })
-    .defaultNow()
-    .notNull(),
-  updatedAt: timestamp('updated_at', { withTimezone: true })
-    .defaultNow()
-    .notNull(),
+  createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
+  updatedAt: timestamp('updated_at', { withTimezone: true }).defaultNow().notNull(),
 });
 
 export type Follow = InferSelectModel<typeof follows>;
 export type NewFollow = InferInsertModel<typeof follows>;
+
+// ── referrals ────────────────────────────────────────────────────────────────
+export const referrals = pgTable('referrals', {
+  id: uuid('id').primaryKey().defaultRandom(),
+  slug: text('slug').notNull().unique(),
+  targetPath: text('target_path').notNull().default('/'),
+  label: text('label'),
+  createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
+});
+
+export type Referral = InferSelectModel<typeof referrals>;
+export type NewReferral = InferInsertModel<typeof referrals>;
+
+// ── referral_clicks ──────────────────────────────────────────────────────────
+export const referralClicks = pgTable('referral_clicks', {
+  id: uuid('id').primaryKey().defaultRandom(),
+  referralId: uuid('referral_id')
+    .notNull()
+    .references(() => referrals.id, { onDelete: 'cascade' }),
+  uaHash: text('ua_hash'),
+  createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
+});
+
+export type ReferralClick = InferSelectModel<typeof referralClicks>;
+export type NewReferralClick = InferInsertModel<typeof referralClicks>;

--- a/src/migrations/001_referrals.ts
+++ b/src/migrations/001_referrals.ts
@@ -1,0 +1,34 @@
+/**
+ * Migration: referrals
+ *
+ * Backs the work-portfolio referral-links demo: shareable slugs that point at
+ * a path on the site, plus a click log so the demo can show real counts.
+ */
+
+import type { Knex } from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.schema.createTable('referrals', (t) => {
+    t.uuid('id').primary().defaultTo(knex.raw('gen_random_uuid()'));
+    t.string('slug', 64).notNullable().unique();
+    t.text('target_path').notNullable().defaultTo('/');
+    t.text('label');
+    t.timestamp('created_at', { useTz: true }).defaultTo(knex.fn.now());
+  });
+
+  await knex.schema.createTable('referral_clicks', (t) => {
+    t.uuid('id').primary().defaultTo(knex.raw('gen_random_uuid()'));
+    t.uuid('referral_id').notNullable().references('id').inTable('referrals').onDelete('CASCADE');
+    t.string('ua_hash', 64);
+    t.timestamp('created_at', { useTz: true }).defaultTo(knex.fn.now());
+  });
+
+  await knex.schema.raw(
+    'CREATE INDEX IF NOT EXISTS idx_referral_clicks_referral_id ON referral_clicks(referral_id)',
+  );
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.dropTableIfExists('referral_clicks');
+  await knex.schema.dropTableIfExists('referrals');
+}

--- a/src/modules/referrals/controller.ts
+++ b/src/modules/referrals/controller.ts
@@ -1,0 +1,144 @@
+// ---------------------------------------------------------------------------
+// Referrals module — Express controller
+// ---------------------------------------------------------------------------
+
+import { createHash, randomUUID } from 'node:crypto';
+import type { NextFunction, Request, Response } from 'express';
+import type { Referral } from '../../config/drizzle/schema.js';
+import { ConflictError, NotFoundError } from '../../shared/errors/AppError.js';
+import { createModuleLogger } from '../../shared/utils/logger.js';
+import * as repo from './repository.js';
+import type { CreateReferralInput } from './schemas.js';
+import type { ReferralDto, ReferralStats } from './types.js';
+
+const log = createModuleLogger('referrals');
+
+/** Base of the shareable link; the site resolves /r/:slug and records a click. */
+const SITE_URL = (process.env.SITE_URL ?? 'https://paulsumido.com').replace(/\/$/, '');
+
+/** Postgres unique_violation. */
+const UNIQUE_VIOLATION = '23505';
+
+function isUniqueViolation(err: unknown): boolean {
+  return (
+    typeof err === 'object' && err !== null && (err as { code?: string }).code === UNIQUE_VIOLATION
+  );
+}
+
+function param(val: string | string[]): string {
+  return Array.isArray(val) ? val[0] : val;
+}
+
+function buildUrl(slug: string): string {
+  return `${SITE_URL}/r/${slug}`;
+}
+
+function hashUserAgent(ua: string | undefined): string | null {
+  if (!ua) return null;
+  // store a hash, not the raw UA, so the click log stays privacy-preserving
+  return createHash('sha256').update(ua).digest('hex').slice(0, 64);
+}
+
+function toDto(row: Referral, clicks: number): ReferralDto {
+  return {
+    slug: row.slug,
+    targetPath: row.targetPath,
+    label: row.label,
+    url: buildUrl(row.slug),
+    clicks,
+    createdAt: row.createdAt.toISOString(),
+  };
+}
+
+export class ReferralsController {
+  /** POST /api/referrals — create a shareable referral link. */
+  async create(req: Request, res: Response, next: NextFunction) {
+    try {
+      const { slug: custom, targetPath = '/', label } = req.body as CreateReferralInput;
+
+      if (custom) {
+        const existing = await repo.findBySlug(custom);
+        if (existing) throw new ConflictError('slug already taken');
+      }
+      const slug = custom ?? (await this.generateUniqueSlug());
+
+      let row: Referral;
+      try {
+        row = await repo.insertReferral({
+          slug,
+          targetPath,
+          label: label ?? null,
+        });
+      } catch (err) {
+        // lost a race on a taken slug, surface it as a conflict
+        if (isUniqueViolation(err)) throw new ConflictError('slug already taken');
+        throw err;
+      }
+
+      log.info({ slug: row.slug }, 'referral created');
+      res.status(201).json(toDto(row, 0));
+    } catch (err) {
+      next(err);
+    }
+  }
+
+  /** GET /api/referrals/:slug — resolve a link and its current count. */
+  async get(req: Request, res: Response, next: NextFunction) {
+    try {
+      const slug = param(req.params.slug);
+      const row = await repo.findBySlug(slug);
+      if (!row) throw new NotFoundError('referral not found');
+      const clicks = await repo.countClicks(row.id);
+      res.json(toDto(row, clicks));
+    } catch (err) {
+      next(err);
+    }
+  }
+
+  /** POST /api/referrals/:slug/clicks — record a click, return the new count. */
+  async click(req: Request, res: Response, next: NextFunction) {
+    try {
+      const slug = param(req.params.slug);
+      const row = await repo.findBySlug(slug);
+      if (!row) throw new NotFoundError('referral not found');
+      await repo.recordClick(row.id, hashUserAgent(req.get('user-agent')));
+      const clicks = await repo.countClicks(row.id);
+      res.json({ slug: row.slug, targetPath: row.targetPath, clicks });
+    } catch (err) {
+      next(err);
+    }
+  }
+
+  /** GET /api/referrals/:slug/stats — count plus a recent-click sample. */
+  async stats(req: Request, res: Response, next: NextFunction) {
+    try {
+      const slug = param(req.params.slug);
+      const row = await repo.findBySlug(slug);
+      if (!row) throw new NotFoundError('referral not found');
+      const [clicks, recent] = await Promise.all([
+        repo.countClicks(row.id),
+        repo.recentClicks(row.id),
+      ]);
+      const body: ReferralStats = {
+        slug: row.slug,
+        targetPath: row.targetPath,
+        clicks,
+        recent: recent.map((c) => ({ at: c.createdAt.toISOString() })),
+      };
+      res.json(body);
+    } catch (err) {
+      next(err);
+    }
+  }
+
+  /** Generate a slug that is not already taken, retrying a few times. */
+  private async generateUniqueSlug(): Promise<string> {
+    for (let attempt = 0; attempt < 5; attempt++) {
+      const slug = randomUUID().replace(/-/g, '').slice(0, 8);
+      const existing = await repo.findBySlug(slug);
+      if (!existing) return slug;
+    }
+    // extremely unlikely; fall back to a longer slug
+    return randomUUID().replace(/-/g, '').slice(0, 16);
+  }
+}

--- a/src/modules/referrals/index.ts
+++ b/src/modules/referrals/index.ts
@@ -1,0 +1,3 @@
+export { ReferralsController } from './controller.js';
+export { default as referralsRouter } from './routes.js';
+export type { ReferralDto, ReferralStats } from './types.js';

--- a/src/modules/referrals/referrals.test.ts
+++ b/src/modules/referrals/referrals.test.ts
@@ -1,0 +1,131 @@
+import express from 'express';
+import request from 'supertest';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+// Mock the repository so we exercise routing + controller logic without a DB.
+vi.mock('./repository.js', () => ({
+  findBySlug: vi.fn(),
+  insertReferral: vi.fn(),
+  recordClick: vi.fn(),
+  countClicks: vi.fn(),
+  recentClicks: vi.fn(),
+}));
+
+// Rate limiter is a pass-through in tests to keep them deterministic.
+vi.mock('../../middleware/rateLimiter.js', () => ({
+  createIpLimiter: () => (_req: unknown, _res: unknown, next: () => void) => next(),
+}));
+
+vi.mock('../../shared/utils/logger.js', () => ({
+  logger: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+  createModuleLogger: () => ({
+    info: vi.fn(),
+    error: vi.fn(),
+    warn: vi.fn(),
+    debug: vi.fn(),
+  }),
+}));
+
+import { errorHandler } from '../../middleware/errorHandler.js';
+import * as repo from './repository.js';
+import referralsRoutes from './routes.js';
+
+function makeApp() {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/referrals', referralsRoutes);
+  app.use(errorHandler);
+  return app;
+}
+
+const row = (over: Partial<Record<string, unknown>> = {}) => ({
+  id: 'ref-1',
+  slug: 'abc123',
+  targetPath: '/work-portfolio',
+  label: null,
+  createdAt: new Date('2026-07-20T00:00:00.000Z'),
+  ...over,
+});
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('referrals routes', () => {
+  test('POST / creates a link with a generated slug and zero clicks', async () => {
+    vi.mocked(repo.findBySlug).mockResolvedValue(null);
+    vi.mocked(repo.insertReferral).mockResolvedValue(row() as never);
+
+    const res = await request(makeApp())
+      .post('/api/referrals')
+      .send({ targetPath: '/work-portfolio' });
+
+    expect(res.status).toBe(201);
+    expect(res.body.slug).toBe('abc123');
+    expect(res.body.clicks).toBe(0);
+    expect(res.body.url).toContain('/r/abc123');
+    expect(repo.insertReferral).toHaveBeenCalledOnce();
+  });
+
+  test('POST / rejects a custom slug that already exists with 409', async () => {
+    vi.mocked(repo.findBySlug).mockResolvedValue(row({ slug: 'taken' }) as never);
+
+    const res = await request(makeApp())
+      .post('/api/referrals')
+      .send({ slug: 'taken', targetPath: '/x' });
+
+    expect(res.status).toBe(409);
+    expect(repo.insertReferral).not.toHaveBeenCalled();
+  });
+
+  test('POST / rejects an invalid slug with 400', async () => {
+    const res = await request(makeApp())
+      .post('/api/referrals')
+      .send({ slug: 'NO', targetPath: '/x' });
+
+    expect(res.status).toBe(400);
+  });
+
+  test('GET /:slug returns 404 for an unknown slug', async () => {
+    vi.mocked(repo.findBySlug).mockResolvedValue(null);
+
+    const res = await request(makeApp()).get('/api/referrals/missing');
+
+    expect(res.status).toBe(404);
+  });
+
+  test('GET /:slug returns the link with its click count', async () => {
+    vi.mocked(repo.findBySlug).mockResolvedValue(row() as never);
+    vi.mocked(repo.countClicks).mockResolvedValue(7);
+
+    const res = await request(makeApp()).get('/api/referrals/abc123');
+
+    expect(res.status).toBe(200);
+    expect(res.body.clicks).toBe(7);
+    expect(res.body.targetPath).toBe('/work-portfolio');
+  });
+
+  test('POST /:slug/clicks records a click and returns the new count', async () => {
+    vi.mocked(repo.findBySlug).mockResolvedValue(row() as never);
+    vi.mocked(repo.countClicks).mockResolvedValue(3);
+
+    const res = await request(makeApp()).post('/api/referrals/abc123/clicks');
+
+    expect(res.status).toBe(200);
+    expect(repo.recordClick).toHaveBeenCalledOnce();
+    expect(res.body.clicks).toBe(3);
+  });
+
+  test('GET /:slug/stats returns the count and recent sample', async () => {
+    vi.mocked(repo.findBySlug).mockResolvedValue(row() as never);
+    vi.mocked(repo.countClicks).mockResolvedValue(2);
+    vi.mocked(repo.recentClicks).mockResolvedValue([
+      { createdAt: new Date('2026-07-20T01:00:00.000Z') },
+    ] as never);
+
+    const res = await request(makeApp()).get('/api/referrals/abc123/stats');
+
+    expect(res.status).toBe(200);
+    expect(res.body.clicks).toBe(2);
+    expect(res.body.recent).toHaveLength(1);
+    expect(res.body.recent[0].at).toBe('2026-07-20T01:00:00.000Z');
+  });
+});

--- a/src/modules/referrals/repository.ts
+++ b/src/modules/referrals/repository.ts
@@ -1,0 +1,42 @@
+// ---------------------------------------------------------------------------
+// Referrals module — Drizzle ORM repository
+// ---------------------------------------------------------------------------
+
+import { desc, eq, sql } from 'drizzle-orm';
+import { db } from '../../config/drizzle/index.js';
+import { type Referral, referralClicks, referrals } from '../../config/drizzle/schema.js';
+
+export async function findBySlug(slug: string): Promise<Referral | null> {
+  const rows = await db.select().from(referrals).where(eq(referrals.slug, slug)).limit(1);
+  return rows[0] ?? null;
+}
+
+export async function insertReferral(values: {
+  slug: string;
+  targetPath: string;
+  label: string | null;
+}): Promise<Referral> {
+  const [row] = await db.insert(referrals).values(values).returning();
+  return row;
+}
+
+export async function recordClick(referralId: string, uaHash: string | null): Promise<void> {
+  await db.insert(referralClicks).values({ referralId, uaHash });
+}
+
+export async function countClicks(referralId: string): Promise<number> {
+  const rows = await db
+    .select({ n: sql<number>`count(*)::int` })
+    .from(referralClicks)
+    .where(eq(referralClicks.referralId, referralId));
+  return rows[0]?.n ?? 0;
+}
+
+export async function recentClicks(referralId: string, limit = 20): Promise<{ createdAt: Date }[]> {
+  return db
+    .select({ createdAt: referralClicks.createdAt })
+    .from(referralClicks)
+    .where(eq(referralClicks.referralId, referralId))
+    .orderBy(desc(referralClicks.createdAt))
+    .limit(limit);
+}

--- a/src/modules/referrals/routes.ts
+++ b/src/modules/referrals/routes.ts
@@ -1,0 +1,36 @@
+// ---------------------------------------------------------------------------
+// Referrals module — Express router
+// ---------------------------------------------------------------------------
+
+import { Router } from 'express';
+import { createIpLimiter } from '../../middleware/rateLimiter.js';
+import { validateBody, validateParams } from '../../middleware/validate.js';
+import { ReferralsController } from './controller.js';
+import { createReferralSchema, slugParamSchema } from './schemas.js';
+
+const router = Router();
+const ctrl = new ReferralsController();
+
+// Public demo endpoints, so keep basic IP throttles on the writes.
+const createLimiter = createIpLimiter({ windowMs: 60_000, max: 10 });
+const clickLimiter = createIpLimiter({ windowMs: 60_000, max: 60 });
+
+// POST /api/referrals — create a shareable link
+router.post('/', createLimiter, validateBody(createReferralSchema), (req, res, next) =>
+  ctrl.create(req, res, next),
+);
+
+// GET /api/referrals/:slug — resolve a link
+router.get('/:slug', validateParams(slugParamSchema), (req, res, next) => ctrl.get(req, res, next));
+
+// POST /api/referrals/:slug/clicks — record a click
+router.post('/:slug/clicks', clickLimiter, validateParams(slugParamSchema), (req, res, next) =>
+  ctrl.click(req, res, next),
+);
+
+// GET /api/referrals/:slug/stats — click count plus a recent sample
+router.get('/:slug/stats', validateParams(slugParamSchema), (req, res, next) =>
+  ctrl.stats(req, res, next),
+);
+
+export default router;

--- a/src/modules/referrals/schemas.ts
+++ b/src/modules/referrals/schemas.ts
@@ -1,0 +1,19 @@
+import { z } from 'zod';
+
+/** Slugs are short, url-safe, and used verbatim in the shareable link. */
+export const SLUG_REGEX = /^[a-z0-9-]{3,32}$/;
+
+export const createReferralSchema = z.object({
+  // Optional custom slug; when omitted the server generates a unique one.
+  slug: z.string().regex(SLUG_REGEX).optional(),
+  // Path on the site the link points at, e.g. "/work-portfolio".
+  targetPath: z.string().min(1).max(512).startsWith('/').optional(),
+  label: z.string().max(120).optional(),
+});
+
+export const slugParamSchema = z.object({
+  slug: z.string().regex(SLUG_REGEX),
+});
+
+export type CreateReferralInput = z.infer<typeof createReferralSchema>;
+export type SlugParam = z.infer<typeof slugParamSchema>;

--- a/src/modules/referrals/types.ts
+++ b/src/modules/referrals/types.ts
@@ -1,0 +1,20 @@
+// ---------------------------------------------------------------------------
+// Referrals module — shared TypeScript types
+// ---------------------------------------------------------------------------
+
+/** A referral as returned to clients, with the resolved share URL and count. */
+export interface ReferralDto {
+  slug: string;
+  targetPath: string;
+  label: string | null;
+  url: string;
+  clicks: number;
+  createdAt: string;
+}
+
+export interface ReferralStats {
+  slug: string;
+  targetPath: string;
+  clicks: number;
+  recent: { at: string }[];
+}


### PR DESCRIPTION
Adds a `referrals` module that backs the work-portfolio **referral-links demo** in paul-explore (real shareable links + real click tracking, replacing the simulated version).

## API (public, under `/api/referrals`)
- `POST /` — create a shareable link. Optional custom `slug` (else generated), optional `targetPath` (defaults `/`) and `label`. Slug uniqueness enforced (409 on conflict, plus a DB unique-constraint guard for races). Returns `{ slug, targetPath, label, url, clicks, createdAt }` where `url` = `${SITE_URL}/r/:slug`.
- `GET /:slug` — resolve a link with its current click count.
- `POST /:slug/clicks` — record a click (stores a **hashed** user-agent, not the raw string) and return the new count.
- `GET /:slug/stats` — click count plus a recent-click sample.

Writes are behind basic per-IP rate limits (`createIpLimiter`).

## Data
- Migration `001_referrals`: `referrals` (slug unique, target_path, label, created_at) and `referral_clicks` (referral_id FK cascade, ua_hash, created_at) + an index on `referral_id`.
- Matching Drizzle schema definitions (`referrals`, `referralClicks`).

## Conventions / tests
- Follows the existing module layout (schemas / types / repository / controller / routes / index), Drizzle repository, `AppError` + `errorHandler`, zod validation, module logger.
- 7 route tests (create, custom-slug conflict, invalid slug, unknown-slug 404, resolve, click increment, stats) — all green. Typecheck clean; biome clean on the new files.
- `SITE_URL` env (defaults to `https://paulsumido.com`) controls the link base.

Consumed by a follow-up paul-explore PR (the referral-links demo + a `/r/:slug` route that records the click and redirects). Bumps API `2.9.0 → 2.9.1`.
