### PR TITLE
Add likes module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 2026-07-23 - version 2.10.0
+
+- Add a `likes` module for the Ketsup likes feature: like a post (`POST /api/likes/:postId`), remove a like (`DELETE /api/likes/:postId`, both idempotent), and a batch summary endpoint (`GET /api/likes?ids=a,b,c`) returning like counts and liked-by-me per post, capped at 100 ids and skipping non-uuid ids
+- Self-contained by design: it does not touch the posts read path, so the frontend overlays like state per feed page with one extra request
+- New `post_likes` table (migration `008_post_likes`, unique on post_id + user_sub, FKs cascade) plus a Drizzle schema definition
+- Likes are idempotent via `ON CONFLICT DO NOTHING`
+
 ## 2026-07-20 - version 2.9.1
 
 - Add a `referrals` module backing the work-portfolio referral-links demo: create a shareable slug (custom or generated, uniqueness enforced), resolve it, record clicks (UA stored hashed), and read click stats. Public endpoints with basic IP rate limits

--- a/migrations/008_post_likes.sql
+++ b/migrations/008_post_likes.sql
@@ -1,0 +1,13 @@
+-- Migration: 008_post_likes
+-- Creates post_likes table for the Ketsup likes feature
+
+CREATE TABLE IF NOT EXISTS post_likes (
+  id         UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  post_id    UUID        NOT NULL REFERENCES posts(id) ON DELETE CASCADE,
+  user_sub   TEXT        NOT NULL REFERENCES user_profiles(user_sub) ON DELETE CASCADE,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE (post_id, user_sub)
+);
+
+CREATE INDEX IF NOT EXISTS idx_post_likes_post ON post_likes(post_id);
+CREATE INDEX IF NOT EXISTS idx_post_likes_user ON post_likes(user_sub);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portfolio_api",
-  "version": "2.9.1",
+  "version": "2.10.0",
   "description": "Portfolio API with Node.js and Python",
   "main": "dist/index.js",
   "scripts": {

--- a/src/app.ts
+++ b/src/app.ts
@@ -16,6 +16,7 @@ import galleryRoutes from './modules/gallery/routes.js';
 import geoRoutes from './modules/geo/routes.js';
 import googleAuthRoutes from './modules/google-auth/routes.js';
 import healthRoutes from './modules/health/routes.js';
+import likesRoutes from './modules/likes/routes.js';
 import medJournalRoutes from './modules/medical-journal/routes.js';
 // Module routers
 import nbaRoutes from './modules/nba/routes.js';
@@ -63,6 +64,7 @@ app.use('/api/feedback', feedbackRoutes);
 app.use('/api/chatgpt', chatRoutes);
 app.use('/api/profiles', profilesRoutes);
 app.use('/api/posts', postsRoutes);
+app.use('/api/likes', likesRoutes);
 app.use('/api/follows', followsRoutes);
 app.use('/api/timeline', timelineRoutes);
 app.use('/api/google', googleAuthRoutes);

--- a/src/config/drizzle/schema.ts
+++ b/src/config/drizzle/schema.ts
@@ -78,6 +78,21 @@ export const postMedia = pgTable('post_media', {
 export type PostMedia = InferSelectModel<typeof postMedia>;
 export type NewPostMedia = InferInsertModel<typeof postMedia>;
 
+// ── post_likes ─────────────────────────────────────────────────────────────
+export const postLikes = pgTable('post_likes', {
+  id: uuid('id').primaryKey().defaultRandom(),
+  postId: uuid('post_id')
+    .notNull()
+    .references(() => posts.id, { onDelete: 'cascade' }),
+  userSub: text('user_sub')
+    .notNull()
+    .references(() => users.sub),
+  createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
+});
+
+export type PostLike = InferSelectModel<typeof postLikes>;
+export type NewPostLike = InferInsertModel<typeof postLikes>;
+
 // ── follows ────────────────────────────────────────────────────────────────
 export const follows = pgTable('follows', {
   id: uuid('id').primaryKey().defaultRandom(),

--- a/src/modules/likes/controller.ts
+++ b/src/modules/likes/controller.ts
@@ -1,0 +1,67 @@
+// ---------------------------------------------------------------------------
+// Likes module — Express controller
+// ---------------------------------------------------------------------------
+
+import type { Request, Response, NextFunction } from 'express';
+import { z } from 'zod';
+import * as service from './service.js';
+import { createModuleLogger } from '../../shared/utils/logger.js';
+
+const log = createModuleLogger('likes');
+
+const idSchema = z.string().uuid('post id must be a uuid');
+
+/** Cap batch lookups so a huge id list can't hammer the DB. */
+const MAX_BATCH = 100;
+
+function first(val: string | string[] | undefined): string {
+  return Array.isArray(val) ? val[0] : (val ?? '');
+}
+
+export class LikesController {
+  /** POST /api/likes/:postId — like a post */
+  async like(req: Request, res: Response, next: NextFunction) {
+    try {
+      const postId = idSchema.parse(first(req.params.postId));
+      const userSub = (req as any).auth.payload.sub as string;
+      await service.like(userSub, postId);
+      res.status(204).end();
+    } catch (err) {
+      next(err);
+    }
+  }
+
+  /** DELETE /api/likes/:postId — remove your like */
+  async unlike(req: Request, res: Response, next: NextFunction) {
+    try {
+      const postId = idSchema.parse(first(req.params.postId));
+      const userSub = (req as any).auth.payload.sub as string;
+      await service.unlike(userSub, postId);
+      res.status(204).end();
+    } catch (err) {
+      next(err);
+    }
+  }
+
+  /** GET /api/likes?ids=a,b,c — counts + liked-by-me for a batch of posts */
+  async batch(req: Request, res: Response, next: NextFunction) {
+    try {
+      const raw = first(req.query.ids as string | string[] | undefined);
+      const ids = raw
+        .split(',')
+        .map((s) => s.trim())
+        .filter(Boolean)
+        .slice(0, MAX_BATCH);
+
+      // Ignore anything that isn't a uuid rather than failing the whole batch.
+      const valid = ids.filter((id) => idSchema.safeParse(id).success);
+      const userSub = (req as any).auth?.payload?.sub ?? null;
+
+      const likes = await service.summaries(valid, userSub);
+      res.json({ likes });
+    } catch (err) {
+      log.error({ err }, 'failed to load like summaries');
+      next(err);
+    }
+  }
+}

--- a/src/modules/likes/index.ts
+++ b/src/modules/likes/index.ts
@@ -1,0 +1,3 @@
+export { default as likesRouter } from './routes.js';
+export { LikesController } from './controller.js';
+export type { LikeSummary, LikesResponse } from './types.js';

--- a/src/modules/likes/likes.test.ts
+++ b/src/modules/likes/likes.test.ts
@@ -1,0 +1,88 @@
+import { describe, test, expect, vi, beforeEach } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+
+// Auth: like/unlike require it, batch is optional. Stub a user for all.
+vi.mock('../../config/auth.js', () => ({
+  checkJwt: (req: any, _res: any, next: any) => {
+    req.auth = { payload: { sub: 'auth0|me' } };
+    next();
+  },
+  optionalCheckJwt: (req: any, _res: any, next: any) => {
+    req.auth = { payload: { sub: 'auth0|me' } };
+    next();
+  },
+}));
+vi.mock('../../middleware/upsertUser.js', () => ({
+  upsertUser: (_req: any, _res: any, next: any) => next(),
+}));
+vi.mock('./repository.js', () => ({
+  likePost: vi.fn().mockResolvedValue(undefined),
+  unlikePost: vi.fn().mockResolvedValue(undefined),
+  getLikeCounts: vi.fn(),
+  getLikedByUser: vi.fn(),
+}));
+
+import likesRouter from './routes.js';
+import * as repo from './repository.js';
+import { errorHandler } from '../../middleware/errorHandler.js';
+
+const ID_A = '11111111-1111-1111-1111-111111111111';
+const ID_B = '22222222-2222-2222-2222-222222222222';
+
+function makeApp() {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/likes', likesRouter);
+  app.use(errorHandler);
+  return app;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('likes routes', () => {
+  test('POST /api/likes/:id likes the post', async () => {
+    const res = await request(makeApp()).post(`/api/likes/${ID_A}`);
+    expect(res.status).toBe(204);
+    expect(repo.likePost).toHaveBeenCalledWith('auth0|me', ID_A);
+  });
+
+  test('DELETE /api/likes/:id unlikes the post', async () => {
+    const res = await request(makeApp()).delete(`/api/likes/${ID_A}`);
+    expect(res.status).toBe(204);
+    expect(repo.unlikePost).toHaveBeenCalledWith('auth0|me', ID_A);
+  });
+
+  test('POST with a non-uuid id is rejected', async () => {
+    const res = await request(makeApp()).post('/api/likes/not-a-uuid');
+    expect(res.status).toBe(400);
+    expect(repo.likePost).not.toHaveBeenCalled();
+  });
+
+  test('GET /api/likes returns counts and liked-by-me per post', async () => {
+    vi.mocked(repo.getLikeCounts).mockResolvedValue(new Map([[ID_A, 3]]));
+    vi.mocked(repo.getLikedByUser).mockResolvedValue(new Set([ID_A]));
+
+    const res = await request(makeApp()).get(
+      `/api/likes?ids=${ID_A},${ID_B}`,
+    );
+
+    expect(res.status).toBe(200);
+    expect(res.body.likes).toEqual([
+      { post_id: ID_A, count: 3, liked: true },
+      { post_id: ID_B, count: 0, liked: false },
+    ]);
+  });
+
+  test('GET /api/likes ignores non-uuid ids in the batch', async () => {
+    vi.mocked(repo.getLikeCounts).mockResolvedValue(new Map());
+    vi.mocked(repo.getLikedByUser).mockResolvedValue(new Set());
+
+    const res = await request(makeApp()).get(`/api/likes?ids=garbage,${ID_A}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.likes).toEqual([{ post_id: ID_A, count: 0, liked: false }]);
+  });
+});

--- a/src/modules/likes/repository.ts
+++ b/src/modules/likes/repository.ts
@@ -1,0 +1,53 @@
+// ---------------------------------------------------------------------------
+// Likes module — Drizzle ORM repository
+// ---------------------------------------------------------------------------
+
+import { and, eq, inArray, sql } from 'drizzle-orm';
+import { db } from '../../config/drizzle/index.js';
+import { postLikes } from '../../config/drizzle/schema.js';
+
+/** Add a like. Idempotent: liking an already-liked post is a no-op. */
+export async function likePost(userSub: string, postId: string): Promise<void> {
+  await db
+    .insert(postLikes)
+    .values({ userSub, postId })
+    .onConflictDoNothing();
+}
+
+/** Remove a like. No-op if it wasn't liked. */
+export async function unlikePost(userSub: string, postId: string): Promise<void> {
+  await db
+    .delete(postLikes)
+    .where(and(eq(postLikes.postId, postId), eq(postLikes.userSub, userSub)));
+}
+
+/** Like counts keyed by post id, for the given posts. */
+export async function getLikeCounts(
+  postIds: string[],
+): Promise<Map<string, number>> {
+  if (postIds.length === 0) return new Map();
+  const rows = await db
+    .select({
+      postId: postLikes.postId,
+      count: sql<number>`count(*)::int`,
+    })
+    .from(postLikes)
+    .where(inArray(postLikes.postId, postIds))
+    .groupBy(postLikes.postId);
+  return new Map(rows.map((r) => [r.postId, Number(r.count)]));
+}
+
+/** Set of post ids (from the given list) that the user has liked. */
+export async function getLikedByUser(
+  userSub: string,
+  postIds: string[],
+): Promise<Set<string>> {
+  if (postIds.length === 0) return new Set();
+  const rows = await db
+    .select({ postId: postLikes.postId })
+    .from(postLikes)
+    .where(
+      and(eq(postLikes.userSub, userSub), inArray(postLikes.postId, postIds)),
+    );
+  return new Set(rows.map((r) => r.postId));
+}

--- a/src/modules/likes/routes.ts
+++ b/src/modules/likes/routes.ts
@@ -1,0 +1,26 @@
+// ---------------------------------------------------------------------------
+// Likes module — Express router
+// ---------------------------------------------------------------------------
+
+import { Router } from 'express';
+import { LikesController } from './controller.js';
+import { checkJwt, optionalCheckJwt } from '../../config/auth.js';
+import { upsertUser } from '../../middleware/upsertUser.js';
+
+const router = Router();
+const ctrl = new LikesController();
+
+// GET /api/likes?ids=a,b,c — batch counts + liked-by-me (works for guests)
+router.get('/', optionalCheckJwt, (req, res, next) => ctrl.batch(req, res, next));
+
+// POST /api/likes/:postId — like a post
+router.post('/:postId', checkJwt, upsertUser, (req, res, next) =>
+  ctrl.like(req, res, next),
+);
+
+// DELETE /api/likes/:postId — remove your like
+router.delete('/:postId', checkJwt, (req, res, next) =>
+  ctrl.unlike(req, res, next),
+);
+
+export default router;

--- a/src/modules/likes/service.ts
+++ b/src/modules/likes/service.ts
@@ -1,0 +1,37 @@
+// ---------------------------------------------------------------------------
+// Likes module — service
+// ---------------------------------------------------------------------------
+
+import * as repo from './repository.js';
+import type { LikeSummary } from './types.js';
+
+/** Like a post on behalf of a user. */
+export async function like(userSub: string, postId: string): Promise<void> {
+  await repo.likePost(userSub, postId);
+}
+
+/** Remove a user's like from a post. */
+export async function unlike(userSub: string, postId: string): Promise<void> {
+  await repo.unlikePost(userSub, postId);
+}
+
+/**
+ * Build like summaries for a batch of posts. Counts come for everyone; the
+ * `liked` flag is only meaningful when a user is authenticated (null → all
+ * false). Every requested id gets an entry, defaulting to zero and not liked.
+ */
+export async function summaries(
+  postIds: string[],
+  userSub: string | null,
+): Promise<LikeSummary[]> {
+  const counts = await repo.getLikeCounts(postIds);
+  const liked = userSub
+    ? await repo.getLikedByUser(userSub, postIds)
+    : new Set<string>();
+
+  return postIds.map((id) => ({
+    post_id: id,
+    count: counts.get(id) ?? 0,
+    liked: liked.has(id),
+  }));
+}

--- a/src/modules/likes/types.ts
+++ b/src/modules/likes/types.ts
@@ -1,0 +1,14 @@
+// ---------------------------------------------------------------------------
+// Likes module — types
+// ---------------------------------------------------------------------------
+
+/** Like count and whether the current user liked a single post. */
+export interface LikeSummary {
+  post_id: string;
+  count: number;
+  liked: boolean;
+}
+
+export interface LikesResponse {
+  likes: LikeSummary[];
+}


### PR DESCRIPTION
Adds a self-contained likes module for the Ketsup redesign (Phase 4, feature one). It does not touch the posts read path, so the frontend overlays like state per feed page.

Endpoints:
- POST /api/likes/:postId — like a post (idempotent via ON CONFLICT DO NOTHING)
- DELETE /api/likes/:postId — remove your like (idempotent)
- GET /api/likes?ids=a,b,c — batch counts + liked-by-me per post, capped at 100 ids, skips non-uuid ids

Includes:
- New post_likes table (migration 008_post_likes: unique on post_id+user_sub, FKs cascade, indexes on post_id and user_sub) plus the Drizzle schema definition
- Standard module layout (repository/service/controller/routes/types/index), registered at /api/likes
- Tests (supertest with the repository mocked) covering like, unlike, uuid validation, the batch summary, and non-uuid filtering
- ran 008 migration