### PR TITLE
Add notifications module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2026-07-23 - version 2.14.0
+
+- Add a `notifications` module for Ketsup: `GET /api/notifications` returns the recipient's activity feed (likes, replies, and reposts on their posts by others, plus follows of them), newest first, with an unread count; `PUT /api/notifications/seen` marks all as read
+- Pull-based: notifications are derived by joining the existing likes/replies/reposts/follows tables, so there is no notifications table and no writes were added to those modules. Read state is a single `notifications_seen_at` column
+- New migration `011_notifications_seen` (adds the column to user_profiles) plus the Drizzle schema change
+
 ## 2026-07-23 - version 2.13.0
 
 - Add a `search` module for Ketsup: `GET /api/search?q=...` returns matching public accounts (username or display name) and public posts (text or caption), newest first

--- a/migrations/011_notifications_seen.sql
+++ b/migrations/011_notifications_seen.sql
@@ -1,0 +1,7 @@
+-- Migration: 011_notifications_seen
+-- Tracks when a user last viewed their notifications, for the unread badge.
+-- Notifications themselves are derived (pull-based) from likes/replies/reposts/
+-- follows, so there is no notifications table.
+
+ALTER TABLE user_profiles
+  ADD COLUMN IF NOT EXISTS notifications_seen_at TIMESTAMPTZ;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portfolio_api",
-  "version": "2.13.0",
+  "version": "2.14.0",
   "description": "Portfolio API with Node.js and Python",
   "main": "dist/index.js",
   "scripts": {

--- a/src/app.ts
+++ b/src/app.ts
@@ -17,6 +17,7 @@ import geoRoutes from './modules/geo/routes.js';
 import googleAuthRoutes from './modules/google-auth/routes.js';
 import healthRoutes from './modules/health/routes.js';
 import likesRoutes from './modules/likes/routes.js';
+import notificationsRoutes from './modules/notifications/routes.js';
 import medJournalRoutes from './modules/medical-journal/routes.js';
 // Module routers
 import nbaRoutes from './modules/nba/routes.js';
@@ -71,6 +72,7 @@ app.use('/api/likes', likesRoutes);
 app.use('/api/replies', repliesRoutes);
 app.use('/api/reposts', repostsRoutes);
 app.use('/api/search', searchRoutes);
+app.use('/api/notifications', notificationsRoutes);
 app.use('/api/follows', followsRoutes);
 app.use('/api/timeline', timelineRoutes);
 app.use('/api/google', googleAuthRoutes);

--- a/src/config/drizzle/schema.ts
+++ b/src/config/drizzle/schema.ts
@@ -34,6 +34,9 @@ export const userProfiles = pgTable('user_profiles', {
   bio: text('bio'),
   avatarUrl: text('avatar_url'),
   isPublic: boolean('is_public').default(true).notNull(),
+  notificationsSeenAt: timestamp('notifications_seen_at', {
+    withTimezone: true,
+  }),
   createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
   updatedAt: timestamp('updated_at', { withTimezone: true }).defaultNow().notNull(),
 });

--- a/src/modules/notifications/controller.ts
+++ b/src/modules/notifications/controller.ts
@@ -1,0 +1,30 @@
+// ---------------------------------------------------------------------------
+// Notifications module — Express controller
+// ---------------------------------------------------------------------------
+
+import type { Request, Response, NextFunction } from 'express';
+import * as service from './service.js';
+
+export class NotificationsController {
+  /** GET /api/notifications — the recipient's activity feed + unread count */
+  async list(req: Request, res: Response, next: NextFunction) {
+    try {
+      const sub = (req as any).auth.payload.sub as string;
+      const result = await service.list(sub);
+      res.json(result);
+    } catch (err) {
+      next(err);
+    }
+  }
+
+  /** PUT /api/notifications/seen — mark all notifications as read */
+  async markSeen(req: Request, res: Response, next: NextFunction) {
+    try {
+      const sub = (req as any).auth.payload.sub as string;
+      await service.markSeen(sub);
+      res.status(204).end();
+    } catch (err) {
+      next(err);
+    }
+  }
+}

--- a/src/modules/notifications/index.ts
+++ b/src/modules/notifications/index.ts
@@ -1,0 +1,8 @@
+export { default as notificationsRouter } from './routes.js';
+export { NotificationsController } from './controller.js';
+export type {
+  NotificationItem,
+  NotificationActor,
+  NotificationType,
+  NotificationsResponse,
+} from './types.js';

--- a/src/modules/notifications/notifications.test.ts
+++ b/src/modules/notifications/notifications.test.ts
@@ -1,0 +1,71 @@
+import { describe, test, expect, vi, beforeEach } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+
+vi.mock('../../config/auth.js', () => ({
+  checkJwt: (req: any, _res: any, next: any) => {
+    req.auth = { payload: { sub: 'auth0|me' } };
+    next();
+  },
+}));
+vi.mock('../../middleware/upsertUser.js', () => ({
+  upsertUser: (_req: any, _res: any, next: any) => next(),
+}));
+vi.mock('./repository.js', () => ({
+  listEvents: vi.fn(),
+  getSeenAt: vi.fn(),
+  setSeenAt: vi.fn().mockResolvedValue(undefined),
+}));
+
+import notificationsRouter from './routes.js';
+import * as repo from './repository.js';
+import { errorHandler } from '../../middleware/errorHandler.js';
+
+const actor = { username: 'mara', display_name: 'Mara', avatar_url: null };
+const evt = (type: string, created_at: string) => ({
+  type,
+  actor,
+  post_id: null,
+  created_at,
+});
+const events = [
+  evt('like', '2026-01-03T00:00:00.000Z'),
+  evt('reply', '2026-01-01T00:00:00.000Z'),
+];
+
+function makeApp() {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/notifications', notificationsRouter);
+  app.use(errorHandler);
+  return app;
+}
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('notifications routes', () => {
+  test('counts only events newer than last-seen as unread', async () => {
+    vi.mocked(repo.listEvents).mockResolvedValue(events as any);
+    vi.mocked(repo.getSeenAt).mockResolvedValue(new Date('2026-01-02T00:00:00.000Z'));
+
+    const res = await request(makeApp()).get('/api/notifications');
+
+    expect(res.status).toBe(200);
+    expect(res.body.notifications).toHaveLength(2);
+    expect(res.body.unread_count).toBe(1);
+  });
+
+  test('everything is unread when never viewed', async () => {
+    vi.mocked(repo.listEvents).mockResolvedValue(events as any);
+    vi.mocked(repo.getSeenAt).mockResolvedValue(null);
+
+    const res = await request(makeApp()).get('/api/notifications');
+    expect(res.body.unread_count).toBe(2);
+  });
+
+  test('PUT /seen marks notifications read', async () => {
+    const res = await request(makeApp()).put('/api/notifications/seen');
+    expect(res.status).toBe(204);
+    expect(repo.setSeenAt).toHaveBeenCalledWith('auth0|me', expect.any(Date));
+  });
+});

--- a/src/modules/notifications/repository.ts
+++ b/src/modules/notifications/repository.ts
@@ -1,0 +1,120 @@
+// ---------------------------------------------------------------------------
+// Notifications module — Drizzle ORM repository
+//
+// Pull-based: notifications are derived by joining likes/replies/reposts/follows
+// to the recipient's content, then merged and sorted in JS. No notifications
+// table; read state is a single notifications_seen_at column on the profile.
+// ---------------------------------------------------------------------------
+
+import { and, desc, eq, ne } from 'drizzle-orm';
+import { db } from '../../config/drizzle/index.js';
+import {
+  follows,
+  postLikes,
+  postReplies,
+  posts,
+  reposts,
+  userProfiles,
+} from '../../config/drizzle/schema.js';
+import type { NotificationItem, NotificationType } from './types.js';
+
+interface EventRow {
+  username: string;
+  display_name: string | null;
+  avatar_url: string | null;
+  post_id: string | null;
+  created_at: Date;
+}
+
+const actor = {
+  username: userProfiles.username,
+  display_name: userProfiles.displayName,
+  avatar_url: userProfiles.avatarUrl,
+};
+
+function toItem(type: NotificationType) {
+  return (r: EventRow): NotificationItem => ({
+    type,
+    actor: {
+      username: r.username,
+      display_name: r.display_name,
+      avatar_url: r.avatar_url,
+    },
+    post_id: r.post_id,
+    created_at: r.created_at.toISOString(),
+  });
+}
+
+/**
+ * Recent activity aimed at the recipient: likes, replies, and reposts on their
+ * posts (by someone else), plus follows of them. Merged newest-first.
+ */
+export async function listEvents(
+  recipientSub: string,
+  limit = 50,
+): Promise<NotificationItem[]> {
+  const [likeRows, replyRows, repostRows, followRows] = await Promise.all([
+    db
+      .select({ ...actor, post_id: postLikes.postId, created_at: postLikes.createdAt })
+      .from(postLikes)
+      .innerJoin(posts, eq(posts.id, postLikes.postId))
+      .innerJoin(userProfiles, eq(userProfiles.userSub, postLikes.userSub))
+      .where(and(eq(posts.userSub, recipientSub), ne(postLikes.userSub, recipientSub)))
+      .orderBy(desc(postLikes.createdAt))
+      .limit(limit),
+    db
+      .select({ ...actor, post_id: postReplies.postId, created_at: postReplies.createdAt })
+      .from(postReplies)
+      .innerJoin(posts, eq(posts.id, postReplies.postId))
+      .innerJoin(userProfiles, eq(userProfiles.userSub, postReplies.userSub))
+      .where(and(eq(posts.userSub, recipientSub), ne(postReplies.userSub, recipientSub)))
+      .orderBy(desc(postReplies.createdAt))
+      .limit(limit),
+    db
+      .select({ ...actor, post_id: reposts.postId, created_at: reposts.createdAt })
+      .from(reposts)
+      .innerJoin(posts, eq(posts.id, reposts.postId))
+      .innerJoin(userProfiles, eq(userProfiles.userSub, reposts.userSub))
+      .where(and(eq(posts.userSub, recipientSub), ne(reposts.userSub, recipientSub)))
+      .orderBy(desc(reposts.createdAt))
+      .limit(limit),
+    db
+      .select({ ...actor, created_at: follows.createdAt })
+      .from(follows)
+      .innerJoin(userProfiles, eq(userProfiles.userSub, follows.followerSub))
+      .where(eq(follows.followingSub, recipientSub))
+      .orderBy(desc(follows.createdAt))
+      .limit(limit),
+  ]);
+
+  const merged: NotificationItem[] = [
+    ...(likeRows as EventRow[]).map(toItem('like')),
+    ...(replyRows as EventRow[]).map(toItem('reply')),
+    ...(repostRows as EventRow[]).map(toItem('repost')),
+    ...(followRows as EventRow[]).map((r) => toItem('follow')({ ...r, post_id: null })),
+  ];
+
+  merged.sort((a, b) => b.created_at.localeCompare(a.created_at));
+  return merged.slice(0, limit);
+}
+
+/** When the user last viewed notifications, or null if never. */
+export async function getSeenAt(recipientSub: string): Promise<Date | null> {
+  const rows = await db
+    .select({ seenAt: userProfiles.notificationsSeenAt })
+    .from(userProfiles)
+    .where(eq(userProfiles.userSub, recipientSub))
+    .limit(1);
+  return rows[0]?.seenAt ?? null;
+}
+
+/** Mark notifications as seen at the given time. */
+export async function setSeenAt(
+  recipientSub: string,
+  at: Date,
+): Promise<void> {
+  await db
+    .update(userProfiles)
+    .set({ notificationsSeenAt: at })
+    .where(eq(userProfiles.userSub, recipientSub));
+}

--- a/src/modules/notifications/routes.ts
+++ b/src/modules/notifications/routes.ts
@@ -1,0 +1,23 @@
+// ---------------------------------------------------------------------------
+// Notifications module — Express router
+// ---------------------------------------------------------------------------
+
+import { Router } from 'express';
+import { NotificationsController } from './controller.js';
+import { checkJwt } from '../../config/auth.js';
+import { upsertUser } from '../../middleware/upsertUser.js';
+
+const router = Router();
+const ctrl = new NotificationsController();
+
+// GET /api/notifications — activity feed + unread count
+router.get('/', checkJwt, upsertUser, (req, res, next) =>
+  ctrl.list(req, res, next),
+);
+
+// PUT /api/notifications/seen — mark all as read
+router.put('/seen', checkJwt, upsertUser, (req, res, next) =>
+  ctrl.markSeen(req, res, next),
+);
+
+export default router;

--- a/src/modules/notifications/service.ts
+++ b/src/modules/notifications/service.ts
@@ -1,0 +1,31 @@
+// ---------------------------------------------------------------------------
+// Notifications module — service
+// ---------------------------------------------------------------------------
+
+import * as repo from './repository.js';
+import type { NotificationsResponse } from './types.js';
+
+/**
+ * The recipient's notifications plus an unread count (events newer than the
+ * last time they viewed the list). If they've never viewed it, everything is
+ * unread.
+ */
+export async function list(
+  recipientSub: string,
+): Promise<NotificationsResponse> {
+  const [notifications, seenAt] = await Promise.all([
+    repo.listEvents(recipientSub),
+    repo.getSeenAt(recipientSub),
+  ]);
+
+  const unread_count = seenAt
+    ? notifications.filter((n) => new Date(n.created_at) > seenAt).length
+    : notifications.length;
+
+  return { notifications, unread_count };
+}
+
+/** Mark all current notifications as seen. */
+export async function markSeen(recipientSub: string): Promise<void> {
+  await repo.setSeenAt(recipientSub, new Date());
+}

--- a/src/modules/notifications/types.ts
+++ b/src/modules/notifications/types.ts
@@ -1,0 +1,24 @@
+// ---------------------------------------------------------------------------
+// Notifications module — types
+// ---------------------------------------------------------------------------
+
+export type NotificationType = 'like' | 'reply' | 'repost' | 'follow';
+
+export interface NotificationActor {
+  username: string;
+  display_name: string | null;
+  avatar_url: string | null;
+}
+
+export interface NotificationItem {
+  type: NotificationType;
+  actor: NotificationActor;
+  /** The post the action was on, or null for follows. */
+  post_id: string | null;
+  created_at: string;
+}
+
+export interface NotificationsResponse {
+  notifications: NotificationItem[];
+  unread_count: number;
+}


### PR DESCRIPTION
Adds real notifications for Ketsup (Phase 5). Pull-based, so it is self-contained and did not touch the likes/replies/reposts/follows modules.

Endpoints:
- GET /api/notifications — the recipient activity feed (likes, replies, reposts on their posts by others, plus follows of them), merged newest-first, with an unread count (events newer than the last time they viewed the list)
- PUT /api/notifications/seen — mark all as read

How it works: the feed is derived by joining the existing likes/replies/reposts/follows tables to the recipient content, merged and sorted in JS. Read state is a single notifications_seen_at column, so the only schema change is migration 011 (adds the column to user_profiles). No notifications table, no event writes anywhere else.

Standard module layout registered at /api/notifications, supertest tests (repo mocked) covering the unread computation (with and without a seen timestamp) and mark-seen. Verified locally: lint, typecheck, test (3 new), build all pass. Ran migration 011 at merge.