### PR TITLE
Add fly.toml for deploy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2026-07-23 - version 2.14.1
+
+- Add a `fly.toml` so the API can deploy to Fly.io (uses the existing Dockerfile, scale-to-zero, PORT 8080). Secrets (DATABASE_URL, Auth0, R2) are set separately via `fly secrets`. Part of the Ketsup free-stack move
+
 ## 2026-07-23 - version 2.14.0
 
 - Add a `notifications` module for Ketsup: `GET /api/notifications` returns the recipient's activity feed (likes, replies, and reposts on their posts by others, plus follows of them), newest first, with an unread count; `PUT /api/notifications/seen` marks all as read

--- a/fly.toml
+++ b/fly.toml
@@ -1,0 +1,27 @@
+# Fly.io config for portfolio_api.
+# Secrets are set separately (never in this file):
+#   fly secrets set DATABASE_URL=... NEXT_PUBLIC_AUTH0_AUDIENCE=... \
+#     NEXT_PUBLIC_AUTH0_ISSUER_BASE_URL=... \
+#     R2_ACCOUNT_ID=... R2_ACCESS_KEY_ID=... R2_SECRET_ACCESS_KEY=... R2_BUCKET=...
+app = "ketsup-api"
+primary_region = "sea"
+
+[build]
+  dockerfile = "Dockerfile"
+
+[env]
+  PORT = "8080"
+  NODE_ENV = "production"
+
+[http_service]
+  internal_port = 8080
+  force_https = true
+  # Scale to zero when idle (cold starts accepted); wakes on request.
+  auto_stop_machines = "stop"
+  auto_start_machines = true
+  min_machines_running = 0
+
+[[vm]]
+  size = "shared-cpu-1x"
+  # A bit more headroom for Sharp image processing.
+  memory = "512mb"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portfolio_api",
-  "version": "2.14.0",
+  "version": "2.14.1",
   "description": "Portfolio API with Node.js and Python",
   "main": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
Adds a fly.toml so portfolio_api can deploy to Fly.io as part of the Ketsup free-stack move. Uses the existing Dockerfile, PORT 8080, scale-to-zero. Secrets (DATABASE_URL, Auth0, R2) are set via `fly secrets`, not in the file.

Config only, no code change.